### PR TITLE
with_spinner ヘルパー追加 (Result 対応のスピナー制御)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -887,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
@@ -1652,9 +1652,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1681,9 +1681,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1829,19 +1829,28 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=216f25f#216f25fe8821d5eb44401cb87deea62dae556144"
+source = "git+https://github.com/thkt/rurico?rev=350effd#350effdfb351cd54f667ff007a99bded54aa0329"
 dependencies = [
  "bytemuck",
  "hf-hub",
  "log",
  "mlx-rs",
- "mlx-sys",
+ "rurico-ffi",
  "rusqlite",
  "serde",
  "serde_json",
- "sqlite-vec",
  "thiserror",
  "tokenizers",
+]
+
+[[package]]
+name = "rurico-ffi"
+version = "0.1.0"
+source = "git+https://github.com/thkt/rurico?rev=350effd#350effdfb351cd54f667ff007a99bded54aa0329"
+dependencies = [
+ "mlx-sys",
+ "rusqlite",
+ "sqlite-vec",
 ]
 
 [[package]]
@@ -1904,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2308,9 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 repository = "https://github.com/thkt/amici"
 
 [dependencies]
-rurico   = { git = "https://github.com/thkt/rurico", rev = "216f25f" }
+rurico   = { git = "https://github.com/thkt/rurico", rev = "350effd" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 
 [lints.rust]

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,10 @@
 [advisories]
 version = 2
-ignore = []
+ignore = [
+    # paste: unmaintained (RUSTSEC-2024-0436)
+    # rurico の transitive dep (mlx-rs, tokenizers 経由)。safe upgrade なし。
+    { id = "RUSTSEC-2024-0436", reason = "transitive dep via rurico; no safe upgrade available" },
+]
 
 [licenses]
 version = 2

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,4 +2,4 @@ mod shorthand;
 mod spinner;
 
 pub use shorthand::try_expand_shorthand;
-pub use spinner::Spinner;
+pub use spinner::{Spinner, with_spinner};

--- a/src/cli/spinner.rs
+++ b/src/cli/spinner.rs
@@ -26,7 +26,7 @@ impl Spinner {
     }
 
     /// Creates a spinner with an explicit TTY decision — used in tests to exercise both paths.
-    pub(crate) fn new_with_tty(msg: &str, is_tty: bool) -> Self {
+    pub(super) fn new_with_tty(msg: &str, is_tty: bool) -> Self {
         let done = Arc::new(AtomicBool::new(false));
         let message = Arc::new(Mutex::new(msg.to_owned()));
 
@@ -92,6 +92,34 @@ impl Drop for Spinner {
     }
 }
 
+/// Runs `work` under a spinner, finishing or cancelling based on the result.
+///
+/// `work` receives a message-updater closure it can call to show progress.
+/// On success the spinner is finished with the message returned by `finish_msg`.
+/// On error the spinner is cancelled and the error is propagated.
+pub fn with_spinner<T, E>(
+    start: &str,
+    finish_msg: impl FnOnce(&T) -> String,
+    work: impl FnOnce(&dyn Fn(&str)) -> Result<T, E>,
+) -> Result<T, E> {
+    let spinner = Spinner::new(start);
+    let result = {
+        let update = |msg: &str| spinner.set_message(msg);
+        work(&update)
+    };
+    match result {
+        Ok(val) => {
+            let msg = finish_msg(&val);
+            spinner.finish(&msg);
+            Ok(val)
+        }
+        Err(e) => {
+            spinner.cancel();
+            Err(e)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -142,5 +170,44 @@ mod tests {
             "TTY spinner must spawn a background thread"
         );
         spinner.cancel();
+    }
+
+    // T-012: with_spinner success path returns Ok(T)
+    #[test]
+    fn with_spinner_success_returns_ok() {
+        let result = with_spinner(
+            "start",
+            |v: &u32| format!("done {v}"),
+            |_| Ok::<u32, &str>(42),
+        );
+        assert_eq!(result, Ok(42));
+    }
+
+    // T-013: with_spinner error path cancels spinner and returns Err
+    #[test]
+    fn with_spinner_error_propagates() {
+        let result = with_spinner(
+            "start",
+            |_: &()| "done".to_owned(),
+            |_| Err::<(), &str>("boom"),
+        );
+        assert_eq!(result, Err("boom"));
+    }
+
+    // T-014: with_spinner progress updater is callable inside work
+    #[test]
+    fn with_spinner_progress_updater_works() {
+        let messages: std::cell::RefCell<Vec<String>> = std::cell::RefCell::new(Vec::new());
+        let _ = with_spinner(
+            "start",
+            |_: &()| "done".to_owned(),
+            |update| {
+                update("step 1");
+                update("step 2");
+                Ok::<(), &str>(())
+            },
+        );
+        // No panic = updater callable without error. Message side-effects go to stderr.
+        drop(messages);
     }
 }


### PR DESCRIPTION
## 概要

- `with_spinner` を追加。fallible なクロージャをスピナーで包み、`Ok` で finish / `Err` で cancel するヘルパー。`?` 伝播時にスピナー状態管理が不要になる。
- `crate::cli` から `Spinner` と並べて `with_spinner` を export。`new_with_tty` の可視性は `spinner.rs` 内テストでしか使わへんので `pub(crate)` → `pub(super)` に絞り込み。
- `rurico` 依存を `216f25f` → `350effd` に更新 (`Cargo.lock` で transitive 6件あわせて bump)。

## 変更

| File | Notes |
|---|---|
| `src/cli/spinner.rs` | `with_spinner` 関数追加 (+28行); テスト T-012/013/014 (+43行); `new_with_tty` を `pub(super)` に |
| `src/cli.rs` | `Spinner` と並べて `with_spinner` を re-export |
| `Cargo.toml` | `rurico` rev を `350effd` に bump |
| `Cargo.lock` | transitive 6 crate の lockfile 更新 |

## テスト計画

- [ ] `cargo test` パス (T-012: 成功時 `Ok(T)` 返却 / T-013: エラー伝播 / T-014: progress updater が panic せず呼べる)
- [ ] `cargo clippy -- -D warnings` パス
- [ ] `cargo build` パス (`pub(super)` 化による未使用 import や可視性 regression が無い)
- [ ] `with_spinner` 呼び出し箇所で成功時にスピナー finish、エラー時にスピナー消滅 (残り出力なし) を手動確認
