### PR TITLE
ModelDownloadError と download_and_verify_model を追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,7 @@ version = "0.1.0"
 dependencies = [
  "rurico",
  "rusqlite",
+ "tracing",
 ]
 
 [[package]]
@@ -2456,7 +2457,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/thkt/amici"
 [dependencies]
 rurico   = { git = "https://github.com/thkt/rurico", rev = "350effd" }
 rusqlite = { version = "0.39", features = ["bundled"] }
+tracing  = "0.1"
+
+[dev-dependencies]
+rurico = { git = "https://github.com/thkt/rurico", rev = "350effd", features = ["test-support"] }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Shared model-loading, storage helpers, and CLI utilities for the sae/yomu/recall
 
 | Module | Contents |
 | ------ | -------- |
-| `model` | `DegradedReason`, `degraded_reason_user_note`, `ModelLoad<T>` |
+| `model` | `DegradedReason`, `degraded_reason_user_note`, `ModelLoad<T>`, `ModelDownloadError`, `download_and_verify_model` |
 | `model::embedder` | `try_load_embedder_with` — loads the embedding model |
 | `model::reranker` | `try_load_reranker_with` — loads the reranking model |
 | `storage` | `in_placeholders`, `anon_placeholders`, `as_sql_params`, `append_eq_filter` |
-| `cli` | `Spinner`, `try_expand_shorthand` |
+| `cli` | `Spinner`, `with_spinner`, `try_expand_shorthand` |
 
 ## Usage
 

--- a/src/cli/spinner.rs
+++ b/src/cli/spinner.rs
@@ -124,7 +124,7 @@ pub fn with_spinner<T, E>(
 mod tests {
     use super::*;
 
-    // T-007: cancel() が Drop をトリガーし done フラグが true になる
+    // T-030: cancel_signals_done
     #[test]
     fn cancel_signals_done() {
         let spinner = Spinner::new("loading...");
@@ -133,7 +133,7 @@ mod tests {
         assert!(done.load(Ordering::Relaxed));
     }
 
-    // T-008: set_message() でメッセージが更新される
+    // T-031: set_message_updates_message
     #[test]
     fn set_message_updates_message() {
         let spinner = Spinner::new("initial");
@@ -143,14 +143,14 @@ mod tests {
         spinner.cancel();
     }
 
-    // T-009: 非TTY 環境で finish() がパニックしない
+    // T-032: finish_non_tty_does_not_panic
     #[test]
     fn finish_non_tty_does_not_panic() {
         let spinner = Spinner::new("loading...");
         spinner.finish("done");
     }
 
-    // T-010: new_with_tty(false) → thread is None (non-TTY path)
+    // T-033: new_with_tty_false_has_no_thread
     #[test]
     fn new_with_tty_false_has_no_thread() {
         let spinner = Spinner::new_with_tty("loading...", false);
@@ -161,7 +161,7 @@ mod tests {
         spinner.cancel();
     }
 
-    // T-011: new_with_tty(true) → thread is Some (TTY path)
+    // T-034: new_with_tty_true_has_thread
     #[test]
     fn new_with_tty_true_has_thread() {
         let spinner = Spinner::new_with_tty("loading...", true);
@@ -172,7 +172,7 @@ mod tests {
         spinner.cancel();
     }
 
-    // T-012: with_spinner success path returns Ok(T)
+    // T-035: with_spinner_success_returns_ok
     #[test]
     fn with_spinner_success_returns_ok() {
         let result = with_spinner(
@@ -183,7 +183,7 @@ mod tests {
         assert_eq!(result, Ok(42));
     }
 
-    // T-013: with_spinner error path cancels spinner and returns Err
+    // T-036: with_spinner_error_propagates
     #[test]
     fn with_spinner_error_propagates() {
         let result = with_spinner(
@@ -194,10 +194,9 @@ mod tests {
         assert_eq!(result, Err("boom"));
     }
 
-    // T-014: with_spinner progress updater is callable inside work
+    // T-037: with_spinner_progress_updater_works
     #[test]
     fn with_spinner_progress_updater_works() {
-        let messages: std::cell::RefCell<Vec<String>> = std::cell::RefCell::new(Vec::new());
         let _ = with_spinner(
             "start",
             |_: &()| "done".to_owned(),
@@ -208,6 +207,5 @@ mod tests {
             },
         );
         // No panic = updater callable without error. Message side-effects go to stderr.
-        drop(messages);
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,7 +1,17 @@
 pub mod embedder;
 pub mod reranker;
 
+use std::convert::Infallible;
+use std::error::Error;
 use std::fmt;
+use std::io;
+
+use rurico::embed::{
+    Artifacts, Embed, EmbedInitError, Embedder, ModelId, ProbeStatus, download_model,
+};
+
+use self::embedder::try_load_embedder_with_fns;
+use crate::cli::with_spinner;
 
 /// Reason a model could not be loaded.
 ///
@@ -95,11 +105,133 @@ impl<T> fmt::Debug for ModelLoad<T> {
     }
 }
 
+/// Error returned by [`download_and_verify_model`].
+#[derive(Debug)]
+pub enum ModelDownloadError {
+    /// The HTTP download failed.
+    DownloadFailed(String),
+    /// The hardware/OS backend (e.g. MLX) is not available on this machine.
+    BackendUnavailable,
+    /// The downloaded model files could not be loaded.
+    /// The inner `String` carries the probe error string; it is empty when
+    /// model-file corruption prevented error capture (see `ModelCorrupt` handling).
+    ProbeFailed(String),
+}
+
+impl fmt::Display for ModelDownloadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DownloadFailed(msg) => {
+                write!(
+                    f,
+                    "download failed: {msg}; check your network and try again"
+                )
+            }
+            Self::BackendUnavailable => write!(
+                f,
+                "MLX backend unavailable; requires Apple Silicon with macOS 14 or later"
+            ),
+            Self::ProbeFailed(detail) if detail.is_empty() => {
+                write!(f, "model probe failed; try again or re-download the model")
+            }
+            Self::ProbeFailed(detail) => write!(
+                f,
+                "model probe failed: {detail}; try again or re-download the model"
+            ),
+        }
+    }
+}
+
+impl Error for ModelDownloadError {}
+
+/// Download the default embedding model and verify it loads correctly.
+///
+/// Shows a spinner on stderr during download and probe phases.
+///
+/// # Prerequisites
+///
+/// The calling binary must invoke `rurico::model_probe::handle_probe_if_needed()`
+/// at the very start of `main()`. Without it, the post-download probe returns
+/// [`ModelDownloadError::ProbeFailed`] even when the download succeeds.
+///
+/// # Errors
+///
+/// - [`ModelDownloadError::DownloadFailed`] — the HTTP download from the model
+///   registry failed.
+/// - [`ModelDownloadError::BackendUnavailable`] — the hardware/OS backend
+///   (e.g. MLX) is not available on this machine.
+/// - [`ModelDownloadError::ProbeFailed`] — the downloaded model files could not
+///   be loaded. Corrupt artifacts are deleted automatically so a subsequent
+///   call can re-download. Non-corrupt probe or init failures leave artifacts
+///   intact.
+pub fn download_and_verify_model() -> Result<(), ModelDownloadError> {
+    with_spinner(
+        "Downloading model...",
+        |_| "Model ready".to_owned(),
+        |update| {
+            try_download_and_verify_with_fns(
+                || {
+                    download_model(ModelId::default()).map_err(|e| {
+                        tracing::error!(error = %e, "model download failed");
+                        e
+                    })
+                },
+                |e| tracing::warn!(error = %e, "failed to delete artifacts after failed probe"),
+                Embedder::probe,
+                Embedder::new,
+                Artifacts::delete_files,
+                || update("Verifying model..."),
+            )
+        },
+    )
+}
+
+fn try_download_and_verify_with_fns<A, E, DE>(
+    download_fn: impl FnOnce() -> Result<A, DE>,
+    on_delete_error: impl FnOnce(io::Error),
+    probe_fn: impl FnOnce(&A) -> Result<ProbeStatus, EmbedInitError>,
+    new_fn: impl FnOnce(&A) -> Result<E, EmbedInitError>,
+    delete_fn: impl FnOnce(A) -> Result<(), io::Error>,
+    on_download_complete: impl FnOnce(),
+) -> Result<(), ModelDownloadError>
+where
+    DE: fmt::Display,
+    E: Embed + 'static,
+{
+    let paths = download_fn().map_err(|e| ModelDownloadError::DownloadFailed(e.to_string()))?;
+    on_download_complete();
+    let mut probe_detail: Option<String> = None;
+    try_load_embedder_with_fns(
+        || Ok::<_, Infallible>(Some(paths)),
+        on_delete_error,
+        |e| probe_detail = Some(e.to_string()),
+        probe_fn,
+        new_fn,
+        delete_fn,
+    )
+    .map(|_| ())
+    .map_err(|reason| match reason {
+        DegradedReason::BackendUnavailable => ModelDownloadError::BackendUnavailable,
+        DegradedReason::ProbeFailed => {
+            ModelDownloadError::ProbeFailed(probe_detail.unwrap_or_default())
+        }
+        DegradedReason::NotInstalled | DegradedReason::Disabled => {
+            unreachable!(
+                "loader with cache=Some cannot produce NotInstalled; Disabled is caller-only"
+            )
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+
+    use rurico::embed::MockEmbedder;
+
     use super::*;
 
-    // T-019: as_ref() — Ready→Some, Absent→None, Failed→None
+    // T-019: as_ref_returns_inner_only_for_ready
     #[test]
     fn as_ref_returns_inner_only_for_ready() {
         assert_eq!(ModelLoad::Ready(42).as_ref(), Some(&42));
@@ -107,7 +239,7 @@ mod tests {
         assert_eq!(ModelLoad::<i32>::Failed("e".into()).as_ref(), None);
     }
 
-    // T-020: Debug 出力が各バリアントの文字列を含む
+    // T-020: debug_output_contains_variant_name
     #[test]
     fn debug_output_contains_variant_name() {
         assert!(format!("{:?}", ModelLoad::Ready(1)).contains("Ready"));
@@ -115,12 +247,109 @@ mod tests {
         assert!(format!("{:?}", ModelLoad::<i32>::Failed("msg".into())).contains("Failed"));
     }
 
-    // T-021: emit_load_hint — Absent→hint出力、Failed→warning出力、Ready→no-op
-    // (stderr の捕捉が困難なため smoke test のみ: パニックしないことを確認)
+    // T-021: emit_load_hint_does_not_panic
     #[test]
     fn emit_load_hint_does_not_panic() {
         ModelLoad::<i32>::Absent.emit_load_hint("not found", "model");
         ModelLoad::Ready(1).emit_load_hint("not found", "model");
         ModelLoad::<i32>::Failed("err".into()).emit_load_hint("not found", "model");
+    }
+
+    // T-022: download_err_returns_download_failed
+    #[test]
+    fn download_err_returns_download_failed() {
+        let complete_called = Cell::new(false);
+        let result = try_download_and_verify_with_fns::<(), MockEmbedder, _>(
+            || Err::<(), _>("network timeout".to_owned()),
+            |_| unreachable!("on_delete_error must not fire on download failure"),
+            |_| unreachable!("probe must not be called on download failure"),
+            |_| unreachable!("new must not be called on download failure"),
+            |_| unreachable!("delete must not be called on download failure"),
+            || complete_called.set(true),
+        );
+        assert!(
+            matches!(result, Err(ModelDownloadError::DownloadFailed(ref msg)) if msg.contains("network timeout")),
+            "expected DownloadFailed with message, got {result:?}"
+        );
+        assert!(
+            !complete_called.get(),
+            "on_download_complete must not fire on download failure"
+        );
+    }
+
+    // T-023: probe_backend_unavailable_returns_backend_unavailable
+    #[test]
+    fn probe_backend_unavailable_returns_backend_unavailable() {
+        let result = try_download_and_verify_with_fns::<_, MockEmbedder, String>(
+            || Ok::<_, String>(()),
+            |_| {},
+            |_| Ok(ProbeStatus::BackendUnavailable),
+            |_| unreachable!("new must not be called on BackendUnavailable"),
+            |_| unreachable!("delete must not be called on BackendUnavailable"),
+            || {},
+        );
+        assert!(matches!(
+            result,
+            Err(ModelDownloadError::BackendUnavailable)
+        ));
+    }
+
+    // T-024: probe_err_captured_in_probe_failed
+    #[test]
+    fn probe_err_captured_in_probe_failed() {
+        let result = try_download_and_verify_with_fns::<_, MockEmbedder, String>(
+            || Ok::<_, String>(()),
+            |_| unreachable!("on_delete_error must not fire on non-corrupt probe error"),
+            |_| Err(EmbedInitError::Backend("backend down".into())),
+            |_| unreachable!("new must not be called when probe fails"),
+            |_| unreachable!("delete must not be called on non-corrupt probe error"),
+            || {},
+        );
+        match result {
+            Err(ModelDownloadError::ProbeFailed(detail)) => assert!(
+                detail.contains("backend down"),
+                "probe_detail should carry error message, got {detail:?}"
+            ),
+            other => panic!("expected ProbeFailed, got {other:?}"),
+        }
+    }
+
+    // T-025: success_returns_ok
+    #[test]
+    fn success_returns_ok() {
+        let complete_called = Cell::new(false);
+        let result = try_download_and_verify_with_fns::<_, MockEmbedder, String>(
+            || Ok::<_, String>(()),
+            |_| unreachable!("on_delete_error must not fire on success"),
+            |_| Ok(ProbeStatus::Available),
+            |_| Ok(MockEmbedder::default()),
+            |_| unreachable!("delete must not be called on success"),
+            || complete_called.set(true),
+        );
+        assert!(result.is_ok(), "expected Ok(()), got {result:?}");
+        assert!(
+            complete_called.get(),
+            "on_download_complete must fire after successful download"
+        );
+    }
+
+    // T-026: new_fn_err_captured_in_probe_failed
+    #[test]
+    fn new_fn_err_captured_in_probe_failed() {
+        let result = try_download_and_verify_with_fns::<_, MockEmbedder, String>(
+            || Ok::<_, String>(()),
+            |_| {},
+            |_| Ok(ProbeStatus::Available),
+            |_| Err(EmbedInitError::Backend("alloc failed".into())),
+            |_| unreachable!("delete must not be called on non-corrupt new_fn failure"),
+            || {},
+        );
+        match result {
+            Err(ModelDownloadError::ProbeFailed(detail)) => assert!(
+                detail.contains("alloc failed"),
+                "probe_detail should carry new_fn error message, got {detail:?}"
+            ),
+            other => panic!("expected ProbeFailed, got {other:?}"),
+        }
     }
 }

--- a/src/model/embedder.rs
+++ b/src/model/embedder.rs
@@ -15,8 +15,8 @@ pub use super::{DegradedReason, degraded_reason_user_note};
 /// - [`DegradedReason::ProbeFailed`] — `cache_check` returned `Err(_)`, the
 ///   probe or `new_fn` reported `ModelCorrupt` (artifacts deleted before
 ///   returning), the probe returned another error, or `new_fn` failed.
-///   `on_probe_err` is invoked for probe errors only; it is **not** called for
-///   `ModelCorrupt` or other `new_fn` errors.
+///   `on_probe_err` is invoked for probe errors and non-corrupt `new_fn`
+///   errors; it is **not** called for `ModelCorrupt`.
 ///
 /// # Corrupt-model handling
 ///
@@ -39,7 +39,7 @@ pub fn try_load_embedder_with<CE>(
     )
 }
 
-fn try_load_embedder_with_fns<A, E, CE>(
+pub(super) fn try_load_embedder_with_fns<A, E, CE>(
     cache_check: impl FnOnce() -> Result<Option<A>, CE>,
     on_delete_error: impl FnOnce(io::Error),
     on_probe_err: impl FnOnce(EmbedInitError),
@@ -77,7 +77,10 @@ where
             }
             Err(DegradedReason::ProbeFailed)
         }
-        Err(_) => Err(DegradedReason::ProbeFailed),
+        Err(e) => {
+            on_probe_err(e);
+            Err(DegradedReason::ProbeFailed)
+        }
     }
 }
 
@@ -85,32 +88,18 @@ where
 mod tests {
     use std::cell::Cell;
 
-    use rurico::embed::{ChunkedEmbedding, EmbedError};
+    use rurico::embed::MockEmbedder;
 
     use super::*;
-
-    struct StubEmbedder;
-
-    impl Embed for StubEmbedder {
-        fn embed_query(&self, _: &str) -> Result<Vec<f32>, EmbedError> {
-            Ok(vec![])
-        }
-        fn embed_document(&self, _: &str) -> Result<ChunkedEmbedding, EmbedError> {
-            Ok(ChunkedEmbedding { chunks: vec![] })
-        }
-        fn embed_text(&self, _: &str, _: &str) -> Result<Vec<f32>, EmbedError> {
-            Ok(vec![])
-        }
-    }
 
     fn cache_present() -> impl FnOnce() -> Result<Option<()>, &'static str> {
         || Ok(Some(()))
     }
 
-    // T-101: cache_check=Ok(None) → Err(NotInstalled)
+    // T-101: cache_none_returns_not_installed
     #[test]
-    fn t101_cache_none_returns_not_installed() {
-        let result = try_load_embedder_with_fns::<(), StubEmbedder, &str>(
+    fn cache_none_returns_not_installed() {
+        let result = try_load_embedder_with_fns::<(), MockEmbedder, &str>(
             || Ok(None),
             |_| unreachable!("on_delete_error must not be called when cache is empty"),
             |_| unreachable!("on_probe_err must not be called when cache is empty"),
@@ -121,10 +110,10 @@ mod tests {
         assert_eq!(result.err(), Some(DegradedReason::NotInstalled));
     }
 
-    // T-102: cache_check=Err → Err(ProbeFailed)
+    // T-102: cache_err_returns_probe_failed
     #[test]
-    fn t102_cache_err_returns_probe_failed() {
-        let result = try_load_embedder_with_fns::<(), StubEmbedder, _>(
+    fn cache_err_returns_probe_failed() {
+        let result = try_load_embedder_with_fns::<(), MockEmbedder, _>(
             || Err::<Option<()>, _>("cache broken"),
             |_| {},
             |_| unreachable!("on_probe_err must not be called when cache_check fails"),
@@ -135,10 +124,10 @@ mod tests {
         assert_eq!(result.err(), Some(DegradedReason::ProbeFailed));
     }
 
-    // T-103: probe=BackendUnavailable → Err(BackendUnavailable)
+    // T-103: backend_unavailable_returns_backend_unavailable
     #[test]
-    fn t103_backend_unavailable_returns_backend_unavailable() {
-        let result = try_load_embedder_with_fns::<_, StubEmbedder, _>(
+    fn backend_unavailable_returns_backend_unavailable() {
+        let result = try_load_embedder_with_fns::<_, MockEmbedder, _>(
             cache_present(),
             |_| {},
             |_| unreachable!("on_probe_err must not be called on BackendUnavailable"),
@@ -149,12 +138,12 @@ mod tests {
         assert_eq!(result.err(), Some(DegradedReason::BackendUnavailable));
     }
 
-    // T-104: probe=ModelCorrupt, delete=Ok → on_delete_error NOT called, Err(ProbeFailed)
+    // T-104: corrupt_delete_ok_skips_on_delete_error
     #[test]
-    fn t104_corrupt_delete_ok_skips_on_delete_error() {
+    fn corrupt_delete_ok_skips_on_delete_error() {
         let on_delete_error_called = Cell::new(false);
         let delete_called = Cell::new(false);
-        let result = try_load_embedder_with_fns::<_, StubEmbedder, _>(
+        let result = try_load_embedder_with_fns::<_, MockEmbedder, _>(
             cache_present(),
             |_| on_delete_error_called.set(true),
             |_| unreachable!("on_probe_err must not be called on ModelCorrupt"),
@@ -177,11 +166,11 @@ mod tests {
         );
     }
 
-    // T-105: probe=ModelCorrupt, delete=Err(io::Error) → on_delete_error called, Err(ProbeFailed)
+    // T-105: corrupt_delete_err_invokes_on_delete_error
     #[test]
-    fn t105_corrupt_delete_err_invokes_on_delete_error() {
+    fn corrupt_delete_err_invokes_on_delete_error() {
         let captured: Cell<Option<String>> = Cell::new(None);
-        let result = try_load_embedder_with_fns::<_, StubEmbedder, _>(
+        let result = try_load_embedder_with_fns::<_, MockEmbedder, _>(
             cache_present(),
             |e| captured.set(Some(e.to_string())),
             |_| unreachable!("on_probe_err must not be called on ModelCorrupt"),
@@ -201,26 +190,25 @@ mod tests {
         );
     }
 
-    // T-106: cache=Some, probe=Available, new=Ok → Ok(Arc<dyn Embed>)
+    // T-106: success_returns_arc_embed
     #[test]
-    fn t106_success_returns_arc_embed() {
+    fn success_returns_arc_embed() {
         let result = try_load_embedder_with_fns(
             cache_present(),
             |_| {},
             |_| unreachable!("on_probe_err must not be called on success"),
             |_| Ok(ProbeStatus::Available),
-            |_| Ok(StubEmbedder),
+            |_| Ok(MockEmbedder::default()),
             |_| unreachable!("delete must not be called on success"),
         );
-        let embedder = result.expect("loader should succeed");
-        assert!(embedder.embed_query("hello").is_ok());
+        assert!(result.is_ok(), "loader should succeed");
     }
 
-    // T-107: probe=Backend err → on_probe_err called with error detail
+    // T-107: probe_backend_err_invokes_on_probe_err
     #[test]
-    fn t107_probe_backend_err_invokes_on_probe_err() {
+    fn probe_backend_err_invokes_on_probe_err() {
         let captured: Cell<Option<String>> = Cell::new(None);
-        let result = try_load_embedder_with_fns::<_, StubEmbedder, _>(
+        let result = try_load_embedder_with_fns::<_, MockEmbedder, _>(
             cache_present(),
             |_| unreachable!("on_delete_error must not be called"),
             |e| captured.set(Some(e.to_string())),
@@ -236,9 +224,9 @@ mod tests {
         );
     }
 
-    // T-108: public wrapper delegates correctly — cache empty → NotInstalled (wiring test)
+    // T-108: public_wrapper_absent_when_cache_empty
     #[test]
-    fn t108_public_wrapper_absent_when_cache_empty() {
+    fn public_wrapper_absent_when_cache_empty() {
         let result = try_load_embedder_with(
             || Ok::<Option<Artifacts>, &str>(None),
             |_| unreachable!("on_delete_error must not be called"),
@@ -247,28 +235,32 @@ mod tests {
         assert_eq!(result.err(), Some(DegradedReason::NotInstalled));
     }
 
-    // T-115: probe=Available, new_fn=Err → Err(ProbeFailed)
+    // T-115: new_fn_err_invokes_on_probe_err
     #[test]
-    fn t115_new_fn_err_returns_probe_failed() {
-        let result = try_load_embedder_with_fns::<_, StubEmbedder, _>(
+    fn new_fn_err_invokes_on_probe_err() {
+        let captured: Cell<Option<String>> = Cell::new(None);
+        let result = try_load_embedder_with_fns::<_, MockEmbedder, _>(
             cache_present(),
             |_| {},
-            |_| unreachable!("on_probe_err must not be called when probe succeeds"),
+            |e| captured.set(Some(e.to_string())),
             |_| Ok(ProbeStatus::Available),
             |_| Err(EmbedInitError::Backend("alloc failed".into())),
             |_| unreachable!("delete must not be called on new_fn failure"),
         );
         assert_eq!(result.err(), Some(DegradedReason::ProbeFailed));
+        let msg = captured.into_inner().expect("on_probe_err should fire");
+        assert!(
+            msg.contains("alloc failed"),
+            "on_probe_err message should carry detail, got {msg:?}"
+        );
     }
 
-    // T-116: probe=Available, new_fn=ModelCorrupt → delete_fn called, on_probe_err NOT called, Err(ProbeFailed)
-    // Note: Embedder::new currently documents only EmbedInitError::Backend, but the type
-    // allows ModelCorrupt; this test defends against future changes in the backend.
+    // T-116: new_fn_corrupt_deletes_artifacts
     #[test]
-    fn t116_new_fn_corrupt_deletes_artifacts() {
+    fn new_fn_corrupt_deletes_artifacts() {
         let on_delete_error_called = Cell::new(false);
         let delete_called = Cell::new(false);
-        let result = try_load_embedder_with_fns::<_, StubEmbedder, _>(
+        let result = try_load_embedder_with_fns::<_, MockEmbedder, _>(
             cache_present(),
             |_| on_delete_error_called.set(true),
             |_| unreachable!("on_probe_err must not be called when new_fn reports ModelCorrupt"),

--- a/src/model/reranker.rs
+++ b/src/model/reranker.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use rurico::reranker::{Artifacts, ProbeStatus, Rerank, Reranker, RerankerInitError};
 
-use crate::model::DegradedReason;
+use super::DegradedReason;
 
 /// Try to load the reranking model.
 ///
@@ -87,36 +87,15 @@ where
 mod tests {
     use std::cell::Cell;
 
-    use rurico::reranker::{RankedResult, RerankerError};
+    use rurico::reranker::{Artifacts, MockReranker};
 
     use super::*;
-
-    struct StubReranker;
-
-    impl Rerank for StubReranker {
-        fn score(&self, _: &str, _: &str) -> Result<f32, RerankerError> {
-            Ok(0.0)
-        }
-        fn score_batch(&self, pairs: &[(&str, &str)]) -> Result<Vec<f32>, RerankerError> {
-            Ok(vec![0.0; pairs.len()])
-        }
-        fn rerank(&self, _: &str, documents: &[&str]) -> Result<Vec<RankedResult>, RerankerError> {
-            Ok(documents
-                .iter()
-                .enumerate()
-                .map(|(i, _)| RankedResult {
-                    index: i,
-                    score: 0.0,
-                })
-                .collect())
-        }
-    }
 
     fn cache_present() -> impl FnOnce() -> Result<Option<()>, &'static str> {
         || Ok(Some(()))
     }
 
-    // T-006: cache_check=Ok(None) → Err(NotInstalled)
+    // T-040: cache_none_returns_not_installed
     #[test]
     fn cache_none_returns_not_installed() {
         let result = try_load_reranker_with(
@@ -127,18 +106,18 @@ mod tests {
         assert_eq!(result.err(), Some(DegradedReason::NotInstalled));
     }
 
-    // T-007: cache_check=Err → Err(ProbeFailed), on_err NOT called
+    // T-041: cache_err_returns_probe_failed
     #[test]
     fn cache_err_returns_probe_failed() {
         let result = try_load_reranker_with(
-            || Err::<Option<rurico::reranker::Artifacts>, _>("cache broken"),
+            || Err::<Option<Artifacts>, _>("cache broken"),
             |_| unreachable!("on_delete_error must not be called on cache error"),
             |_| unreachable!("on_err must not be called on cache error"),
         );
         assert_eq!(result.err(), Some(DegradedReason::ProbeFailed));
     }
 
-    // T-008: probe=Available, new=Ok → Ok
+    // T-042: probe_available_new_ok_returns_ready
     #[test]
     fn probe_available_new_ok_returns_ready() {
         let result = try_load_reranker_with_fns(
@@ -146,16 +125,16 @@ mod tests {
             |_| unreachable!("on_delete_error must not be called on success"),
             |_| unreachable!("on_err must not be called on success"),
             |_| Ok(ProbeStatus::Available),
-            |_| Ok(StubReranker),
+            |_| Ok(MockReranker::default()),
             |_| unreachable!("delete must not be called on success"),
         );
         assert!(result.is_ok());
     }
 
-    // T-009: probe=BackendUnavailable → Err(BackendUnavailable)
+    // T-043: probe_backend_unavailable_returns_backend_unavailable
     #[test]
     fn probe_backend_unavailable_returns_backend_unavailable() {
-        let result = try_load_reranker_with_fns::<_, _, StubReranker>(
+        let result = try_load_reranker_with_fns::<_, _, MockReranker>(
             cache_present(),
             |_| unreachable!("on_delete_error must not be called on BackendUnavailable"),
             |_| unreachable!("on_err must not be called on BackendUnavailable"),
@@ -166,11 +145,11 @@ mod tests {
         assert_eq!(result.err(), Some(DegradedReason::BackendUnavailable));
     }
 
-    // T-010: probe=Err(Backend) → on_err called with error detail, Err(ProbeFailed)
+    // T-044: probe_err_invokes_on_err
     #[test]
     fn probe_err_invokes_on_err() {
         let captured: Cell<Option<String>> = Cell::new(None);
-        let result = try_load_reranker_with_fns::<_, _, StubReranker>(
+        let result = try_load_reranker_with_fns::<_, _, MockReranker>(
             cache_present(),
             |_| unreachable!("on_delete_error must not be called on non-corrupt probe error"),
             |e| captured.set(Some(e.to_string())),
@@ -186,11 +165,11 @@ mod tests {
         );
     }
 
-    // T-011: new=Err → on_err called with error detail, Err(ProbeFailed)
+    // T-045: new_err_invokes_on_err
     #[test]
     fn new_err_invokes_on_err() {
         let captured: Cell<Option<String>> = Cell::new(None);
-        let result = try_load_reranker_with_fns::<_, _, StubReranker>(
+        let result = try_load_reranker_with_fns::<_, _, MockReranker>(
             cache_present(),
             |_| unreachable!("on_delete_error must not be called when probe succeeds"),
             |e| captured.set(Some(e.to_string())),
@@ -206,13 +185,13 @@ mod tests {
         );
     }
 
-    // T-012: probe=ModelCorrupt, delete=Ok → on_delete_error NOT called, on_err NOT called, Err(ProbeFailed)
+    // T-046: corrupt_delete_ok_skips_on_delete_error
     #[test]
     fn corrupt_delete_ok_skips_on_delete_error() {
         let on_delete_error_called = Cell::new(false);
         let on_err_called = Cell::new(false);
         let delete_called = Cell::new(false);
-        let result = try_load_reranker_with_fns::<_, _, StubReranker>(
+        let result = try_load_reranker_with_fns::<_, _, MockReranker>(
             cache_present(),
             |_| on_delete_error_called.set(true),
             |_| on_err_called.set(true),
@@ -239,12 +218,12 @@ mod tests {
         );
     }
 
-    // T-013: probe=ModelCorrupt, delete=Err(io::Error) → on_delete_error called, on_err NOT called, Err(ProbeFailed)
+    // T-047: corrupt_delete_err_invokes_on_delete_error
     #[test]
     fn corrupt_delete_err_invokes_on_delete_error() {
         let captured: Cell<Option<String>> = Cell::new(None);
         let on_err_called = Cell::new(false);
-        let result = try_load_reranker_with_fns::<_, _, StubReranker>(
+        let result = try_load_reranker_with_fns::<_, _, MockReranker>(
             cache_present(),
             |e| captured.set(Some(e.to_string())),
             |_| on_err_called.set(true),
@@ -268,7 +247,7 @@ mod tests {
         );
     }
 
-    // T-014: public wrapper delegates correctly — cache empty → NotInstalled (wiring test)
+    // T-048: public_wrapper_absent_when_cache_empty
     #[test]
     fn public_wrapper_absent_when_cache_empty() {
         let result = try_load_reranker_with(
@@ -279,15 +258,13 @@ mod tests {
         assert_eq!(result.err(), Some(DegradedReason::NotInstalled));
     }
 
-    // T-015: probe=Available, new_fn=ModelCorrupt → delete_fn called, on_err NOT called, Err(ProbeFailed)
-    // Note: Reranker::new currently documents only RerankerInitError::Backend, but the type
-    // allows ModelCorrupt; this test defends against future changes in the backend.
+    // T-049: new_fn_corrupt_deletes_artifacts
     #[test]
     fn new_fn_corrupt_deletes_artifacts() {
         let on_delete_error_called = Cell::new(false);
         let on_err_called = Cell::new(false);
         let delete_called = Cell::new(false);
-        let result = try_load_reranker_with_fns::<_, _, StubReranker>(
+        let result = try_load_reranker_with_fns::<_, _, MockReranker>(
             cache_present(),
             |_| on_delete_error_called.set(true),
             |_| on_err_called.set(true),

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -52,51 +52,51 @@ pub fn append_eq_filter(
 mod tests {
     use super::*;
 
-    // T-012: in_placeholders(3) → "?1, ?2, ?3"
+    // T-012: in_placeholders_numbered
     #[test]
     fn in_placeholders_numbered() {
         assert_eq!(in_placeholders(3), "?1, ?2, ?3");
         assert_eq!(in_placeholders(0), "");
     }
 
-    // T-013: anon_placeholders(3) → "?, ?, ?"
+    // T-013: anon_placeholders_anonymous
     #[test]
     fn anon_placeholders_anonymous() {
         assert_eq!(anon_placeholders(3), "?, ?, ?");
         assert_eq!(anon_placeholders(0), "");
     }
 
-    // T-014: as_sql_params — len matches input
+    // T-014: as_sql_params_len_matches
     #[test]
     fn as_sql_params_len_matches() {
         let values = ["a", "b"];
         assert_eq!(as_sql_params(&values).len(), 2);
     }
 
-    // T-015: append_eq_filter Some(v) → sql 追加・params 追加
+    // T-015: append_eq_filter_some_appends
     #[test]
     fn append_eq_filter_some_appends() {
-        let mut sql = "SELECT 1".to_string();
+        let mut sql = "SELECT 1".to_owned();
         let mut params: Vec<Box<dyn ToSql>> = Vec::new();
         append_eq_filter(&mut sql, &mut params, "p.category", Some("x"));
         assert_eq!(sql, "SELECT 1 AND p.category = ?");
         assert_eq!(params.len(), 1);
     }
 
-    // T-016: append_eq_filter None → 変化なし
+    // T-016: append_eq_filter_none_noop
     #[test]
     fn append_eq_filter_none_noop() {
-        let mut sql = "SELECT 1".to_string();
+        let mut sql = "SELECT 1".to_owned();
         let mut params: Vec<Box<dyn ToSql>> = Vec::new();
         append_eq_filter(&mut sql, &mut params, "p.category", None);
         assert_eq!(sql, "SELECT 1");
         assert!(params.is_empty());
     }
 
-    // T-017: append_eq_filter を2回連続呼び出し → SQL と params.len が両方正しく積まれる
+    // T-017: append_eq_filter_two_consecutive_filters
     #[test]
     fn append_eq_filter_two_consecutive_filters() {
-        let mut sql = "SELECT 1".to_string();
+        let mut sql = "SELECT 1".to_owned();
         let mut params: Vec<Box<dyn ToSql>> = Vec::new();
         append_eq_filter(&mut sql, &mut params, "p.category", Some("book"));
         append_eq_filter(&mut sql, &mut params, "p.lang", Some("ja"));


### PR DESCRIPTION
## 目的

埋め込みモデルをダウンロードし、ロード可能か検証する `download_and_verify_model()` と、その失敗モードを表す `ModelDownloadError` 列挙型を追加する。sae/yomu/recallが初回セットアップ時にモデル取得を行う際の共通エントリーポイントとして機能させる。

## 変更内容

- **`src/model.rs` — `ModelDownloadError` と `download_and_verify_model` を追加**: HTTPダウンロード失敗・バックエンド非対応・プローブ失敗の3バリアントを持つ `ModelDownloadError` を定義し、ダウンロード→プローブ→ロード検証を1回のスピナー付き呼び出しで行う `download_and_verify_model()` を実装。内部ロジックは `try_download_and_verify_with_fns` としてDI可能な形に分離し、単体テスト6件を追加。
- **`src/model/embedder.rs` — `new_fn` エラーを `on_probe_err` に転送するバグを修正**: `try_load_embedder_with_fns` の `Err(_) => Err(DegradedReason::ProbeFailed)` アームが `on_probe_err` を呼ばずにエラーを握り潰していた。`download_and_verify_model` がプローブ詳細を取得するために必須な修正。あわせて `pub(super)` に昇格し、`StubEmbedder` をruricoの `MockEmbedder` に置き換え。
- **`src/model/reranker.rs` — `StubReranker` を `MockReranker` に置き換え**: 手書きのスタブ実装をruricoの `MockReranker` に統一し、テストのボイラープレートを削減。
- **`Cargo.toml` — `tracing` と `rurico` の `test-support` フィーチャーを追加**: ダウンロード処理のエラーログに `tracing`、テスト用モックに `rurico/test-support` を追加。
- **テストコメントとコードの整理**: `spinner.rs` と `storage.rs` のテスト番号を連番に更新し、コメントを英語の説明名に統一。不要な `RefCell<Vec<String>>` を削除。

## スコープ

- **含まない**: 複数モデル (reranker) のダウンロード対応（embedderのみ）。再試行ロジックは `download_model` 側の責務。

## 設計判断

- `try_download_and_verify_with_fns` に全依存関数をDIし、HTTP・ファイルシステム・プロセス起動なしでフルパスをテスト可能にした。`download_and_verify_model` は薄い公開ラッパーとして残し、本体ロジックはテスタブルな内部関数に集約。
- `ModelDownloadError::ProbeFailed(String)` にエラー詳細を持たせることで、呼び出し元が `on_probe_err` コールバックなしで詳細メッセージを取得できるようにした。

## テスト方法

1. `cargo test` を実行し全テストがパスすることを確認。
2. T-022〜T-026（`src/model.rs`）が新規パスしていることを確認。
3. T-115 (`new_fn_err_invokes_on_probe_err`) が `on_probe_err` の呼び出しと詳細メッセージを検証していることを確認（バグ修正のリグレッションテスト）。
