### PR TITLE
embed_with_spinners 追加とテストアサーションメッセージ改善

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,4 +2,4 @@ mod shorthand;
 mod spinner;
 
 pub use shorthand::try_expand_shorthand;
-pub use spinner::{Spinner, with_spinner};
+pub use spinner::{Spinner, embed_with_spinners, with_spinner};

--- a/src/cli/spinner.rs
+++ b/src/cli/spinner.rs
@@ -92,6 +92,29 @@ impl Drop for Spinner {
     }
 }
 
+/// Runs model load then embedding under two spinners, short-circuiting when `pending == 0`.
+///
+/// - `Ok(None)` — nothing to embed (pending was zero)
+/// - `Ok(Some(result))` — embedding completed successfully
+/// - `Err` — model load or embedding failed
+pub fn embed_with_spinners<M, R, E>(
+    pending: u32,
+    load_model: impl FnOnce(&dyn Fn(&str)) -> Result<M, E>,
+    finish_msg: impl FnOnce(&R) -> String,
+    run_embed: impl FnOnce(M, &dyn Fn(&str)) -> Result<R, E>,
+) -> Result<Option<R>, E> {
+    if pending == 0 {
+        return Ok(None);
+    }
+    let model = with_spinner("Loading model...", |_| "Model ready".to_owned(), load_model)?;
+    let result = with_spinner(
+        &format!("Embedding... 0/{pending} chunks"),
+        finish_msg,
+        |update| run_embed(model, update),
+    )?;
+    Ok(Some(result))
+}
+
 /// Runs `work` under a spinner, finishing or cancelling based on the result.
 ///
 /// `work` receives a message-updater closure it can call to show progress.
@@ -130,7 +153,10 @@ mod tests {
         let spinner = Spinner::new("loading...");
         let done = Arc::clone(&spinner.done);
         spinner.cancel();
-        assert!(done.load(Ordering::Relaxed));
+        assert!(
+            done.load(Ordering::Relaxed),
+            "done flag should be true after cancel"
+        );
     }
 
     // T-031: set_message_updates_message
@@ -207,5 +233,29 @@ mod tests {
             },
         );
         // No panic = updater callable without error. Message side-effects go to stderr.
+    }
+
+    // T-038: embed_with_spinners_pending_zero_returns_none
+    #[test]
+    fn embed_with_spinners_pending_zero_returns_none() {
+        let result = embed_with_spinners(
+            0,
+            |_| Ok::<u32, &str>(42),
+            |v: &u32| format!("done {v}"),
+            |_, _| unreachable!("run_embed must not be called when pending is zero"),
+        );
+        assert_eq!(result, Ok(None));
+    }
+
+    // T-039: embed_with_spinners_nonzero_pending_returns_some
+    #[test]
+    fn embed_with_spinners_nonzero_pending_returns_some() {
+        let result = embed_with_spinners(
+            5,
+            |_| Ok::<u32, &str>(99),
+            |v: &u32| format!("done {v}"),
+            |model, _| Ok::<u32, &str>(model + 1),
+        );
+        assert_eq!(result, Ok(Some(100)));
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -242,9 +242,18 @@ mod tests {
     // T-020: debug_output_contains_variant_name
     #[test]
     fn debug_output_contains_variant_name() {
-        assert!(format!("{:?}", ModelLoad::Ready(1)).contains("Ready"));
-        assert!(format!("{:?}", ModelLoad::<i32>::Absent).contains("Absent"));
-        assert!(format!("{:?}", ModelLoad::<i32>::Failed("msg".into())).contains("Failed"));
+        let ready = format!("{:?}", ModelLoad::Ready(1));
+        assert!(ready.contains("Ready"), "expected 'Ready', got: {ready}");
+        let absent = format!("{:?}", ModelLoad::<i32>::Absent);
+        assert!(
+            absent.contains("Absent"),
+            "expected 'Absent', got: {absent}"
+        );
+        let failed = format!("{:?}", ModelLoad::<i32>::Failed("msg".into()));
+        assert!(
+            failed.contains("Failed"),
+            "expected 'Failed', got: {failed}"
+        );
     }
 
     // T-021: emit_load_hint_does_not_panic
@@ -288,10 +297,10 @@ mod tests {
             |_| unreachable!("delete must not be called on BackendUnavailable"),
             || {},
         );
-        assert!(matches!(
-            result,
-            Err(ModelDownloadError::BackendUnavailable)
-        ));
+        assert!(
+            matches!(result, Err(ModelDownloadError::BackendUnavailable)),
+            "expected BackendUnavailable, got {result:?}"
+        );
     }
 
     // T-024: probe_err_captured_in_probe_failed


### PR DESCRIPTION
## 概要

2フェーズ（モデルロード + 埋め込み）処理を一括でスピナー表示する `embed_with_spinners` を追加し、呼び出し側の重複を排除する。
あわせて、テスト失敗時に実際の値が表示されないアサーションを改善する。

## 変更内容

- `src/cli/spinner.rs`: `embed_with_spinners` を追加。`with_spinner` を2回合成し、`pending == 0` の場合は即 `Ok(None)` で短絡する。T-038・T-039 のテストを追加
- `src/cli.rs`: `embed_with_spinners` を `pub use` で再エクスポート
- `src/model.rs`: T-020・T-023 のアサーションに実測値を表示するメッセージを追加。`src/cli/spinner.rs` の T-030 も同様に改善

## 設計判断

- `embed_with_spinners` の戻り値を `Ok(None)` / `Ok(Some(R))` に分けることで、呼び出し側が「処理なし」と「処理完了」を型レベルで区別できる
- `pending == 0` の短絡を関数内に閉じ込め、呼び出し側での条件分岐を不要にした

## テスト方法

1. `cargo test` を実行する
2. T-038・T-039・T-020・T-023・T-030 がすべて pass することを確認する