### PR TITLE
rurico rev を e5f4fb5 に更新

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "dary_heap"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 dependencies = [
  "serde",
 ]
@@ -2318,9 +2318,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=3cc9cb0#3cc9cb06ca23a2805fa39de2f6c281d85347580b"
+source = "git+https://github.com/thkt/rurico?rev=e5f4fb5#e5f4fb50c1ad13807513033047bd215413ec6ccb"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=3cc9cb0#3cc9cb06ca23a2805fa39de2f6c281d85347580b"
+source = "git+https://github.com/thkt/rurico?rev=e5f4fb5#e5f4fb50c1ad13807513033047bd215413ec6ccb"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,12 @@ license = "MIT"
 repository = "https://github.com/thkt/amici"
 
 [dependencies]
-rurico   = { git = "https://github.com/thkt/rurico", rev = "3cc9cb0" }
+rurico   = { git = "https://github.com/thkt/rurico", rev = "e5f4fb5" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 tracing  = "0.1"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "3cc9cb0", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "e5f4fb5", features = ["test-support"] }
 
 [lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
## 概要

- rurico の rev を `3cc9cb0` → `e5f4fb5` に更新
- 上流変更: rurico 側が MSRV を Rust 1.95 に固定 (`chore(msrv): bump minimum supported rust version to 1.95`)
- amici 側は `rust-version` 未指定のまま（最新追従方針）。Rust 1.95 でビルド成功

## 動作確認

- [x] `cargo build` 成功
- [x] 全 49 テスト通過 (`cargo test`)