### PR TITLE
rurico の rev を 0de6526 に更新

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=e5f4fb5#e5f4fb50c1ad13807513033047bd215413ec6ccb"
+source = "git+https://github.com/thkt/rurico?rev=0de6526#0de65266126ee94fbfa292964d68e6475ddae2d9"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=e5f4fb5#e5f4fb50c1ad13807513033047bd215413ec6ccb"
+source = "git+https://github.com/thkt/rurico?rev=0de6526#0de65266126ee94fbfa292964d68e6475ddae2d9"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ license = "MIT"
 repository = "https://github.com/thkt/amici"
 
 [dependencies]
-rurico   = { git = "https://github.com/thkt/rurico", rev = "e5f4fb5" }
+rurico   = { git = "https://github.com/thkt/rurico", rev = "0de6526" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 tracing  = "0.1"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "e5f4fb5", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "0de6526", features = ["test-support"] }
 
 [lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
## 概要

rurico の git リビジョンを `e5f4fb5` → `0de6526` に更新する。
アップストリームの変更は clippy セクションコメントの英語化のみであり、機能・API への影響はない。

## 変更内容

- `Cargo.toml`: `[dependencies]` / `[dev-dependencies]` の rurico rev を `0de6526` に更新
- `Cargo.lock`: rurico 0.2.0 / rurico-ffi 0.1.0 のソースハッシュを追従更新

## スコープ

- **含まない**: rurico の機能変更・API 変更（アップストリームに存在しない）

## 動作確認

1. `cargo build` → ビルド成功を確認
2. `cargo test` → 全49テスト通過を確認
3. `cargo clippy --all-targets` → 警告なしを確認