### PR TITLE
refactor(cli): Spinner完了マーカーをTTY/non-TTYで統一

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,4 +2,4 @@ mod shorthand;
 mod spinner;
 
 pub use shorthand::try_expand_shorthand;
-pub use spinner::{Spinner, embed_with_spinners, with_spinner};
+pub use spinner::{Spinner, done, embed_with_spinners, with_spinner};

--- a/src/cli/spinner.rs
+++ b/src/cli/spinner.rs
@@ -19,8 +19,8 @@ impl Spinner {
     /// Creates a spinner, auto-detecting whether stderr is a TTY.
     ///
     /// When stderr is a terminal: starts a background thread that renders an animated
-    /// spinner frame on each tick. When not a terminal: prints `msg` to stderr immediately
-    /// and skips the animation.
+    /// spinner frame on each tick. When not a terminal: creates a no-op spinner that
+    /// prints nothing until [`finish`](Self::finish) is called.
     pub fn new(msg: &str) -> Self {
         Self::new_with_tty(msg, stderr().is_terminal())
     }
@@ -48,7 +48,6 @@ impl Spinner {
                 }
             }))
         } else {
-            eprintln!("{msg}");
             None
         };
 
@@ -66,19 +65,26 @@ impl Spinner {
         }
     }
 
-    /// Clears the spinner line, then prints a success message.
+    /// Clears the spinner line, then prints a success marker line via [`done`].
+    ///
+    /// The marker is shown on both TTY and non-TTY streams so downstream log parsers
+    /// see a consistent `✓ {msg}` format regardless of terminal detection.
     pub fn finish(self, msg: &str) {
-        let is_tty = self.thread.is_some();
         drop(self);
-        if is_tty {
-            eprintln!("\x1b[32m✓\x1b[0m {msg}");
-        } else {
-            eprintln!("{msg}");
-        }
+        done(msg);
     }
 
     /// Stops the spinner silently by consuming it, triggering `Drop`.
     pub fn cancel(self) {}
+}
+
+/// Prints a `✓ {msg}` success line to stderr without running a spinner.
+///
+/// Use for standalone completion markers — for example, "nothing to do" branches
+/// that skip the spinner entirely. Paired with [`Spinner::finish`] so both paths
+/// produce identical output.
+pub fn done(msg: &str) {
+    eprintln!("\x1b[32m✓\x1b[0m {msg}");
 }
 
 impl Drop for Spinner {
@@ -257,5 +263,19 @@ mod tests {
             |model, _| Ok::<u32, &str>(model + 1),
         );
         assert_eq!(result, Ok(Some(100)));
+    }
+
+    // T-040: done_does_not_panic
+    #[test]
+    fn done_does_not_panic() {
+        done("ready");
+    }
+
+    // T-041: finish_non_tty_does_not_panic_after_set_message
+    #[test]
+    fn finish_non_tty_does_not_panic_after_set_message() {
+        let spinner = Spinner::new_with_tty("start", false);
+        spinner.set_message("working");
+        spinner.finish("done");
     }
 }


### PR DESCRIPTION
## 概要

- `Spinner::finish` を TTY/non-TTY 両方で `✓ {msg}` 出力に統一。log parser / CI pipeline での grep 一貫性を確保
- non-TTY 時の `Spinner::new` から早期 `eprintln!` を削除。開始+完了の二重出力を回避し、`finish` の単一行に集約
- `pub fn amici::cli::done(msg)` を新設。スピナー不要の単独完了マーカー用途 (recall の `progress::done` 相当を還元)
- `Spinner::finish` は `done(msg)` に委譲し DRY 化

## 背景

recall の `progress.rs` が採用していた `✓` マーカーの TTY/non-TTY 統一挙動を amici に逆輸入。recall を amici に統合する作業 ([thkt/recall](https://github.com/thkt/recall)) の前段として、yomu/sae/recall で一貫した成功マーカー出力を提供する。

## 挙動変化 (yomu/sae 向け)

| 観点 | 変更前 | 変更後 |
| --- | --- | --- |
| non-TTY の `Spinner::new` | `{msg}` を即 eprintln | 何も出力しない |
| non-TTY の `Spinner::finish` | `{msg}` (マーカーなし) | `✓ {msg}` |
| TTY の `Spinner::finish` | `✓ {msg}` | `✓ {msg}` (変化なし) |

yomu/sae とも `Spinner` 直接使用はなく `embed_with_spinners` 高レベル API 経由のため、影響は「non-TTY/CI ログで開始メッセージが消える + 完了マーカーが統一される」に限定。

## テスト

- [x] `cargo test --lib` — 51 passed
- [x] `cargo clippy --all-targets -- -D warnings` — warnings なし
- [x] `cargo fmt -- --check` — 整形済み
- [x] 新規テスト: `T-040 done_does_not_panic`、`T-041 finish_non_tty_does_not_panic_after_set_message`