### PR TITLE
マイグレーション通知と tracing 初期化の共通ヘルパーを追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ dependencies = [
  "rurico",
  "rusqlite",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1135,6 +1136,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,6 +1240,15 @@ name = "macro_rules_attribute-proc_macro"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -1380,6 +1396,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2035,6 +2060,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,6 +2274,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2479,6 +2522,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2597,6 +2670,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,10 @@ license = "MIT"
 repository = "https://github.com/thkt/amici"
 
 [dependencies]
-rurico   = { git = "https://github.com/thkt/rurico", rev = "bc2ad90" }
-rusqlite = { version = "0.39", features = ["bundled"] }
-tracing  = "0.1"
+rurico             = { git = "https://github.com/thkt/rurico", rev = "bc2ad90" }
+rusqlite           = { version = "0.39", features = ["bundled"] }
+tracing            = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 rurico = { git = "https://github.com/thkt/rurico", rev = "bc2ad90", features = ["test-support"] }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Shared model-loading, storage helpers, and CLI utilities for the sae/yomu/recall
 | `model::reranker` | `try_load_reranker_with` — loads the reranking model |
 | `storage` | `in_placeholders`, `anon_placeholders`, `as_sql_params`, `append_eq_filter` |
 | `cli` | `Spinner`, `with_spinner`, `try_expand_shorthand` |
+| `migration` | `notify_schema_change` — unified `tracing::warn!` for schema-clear notices |
+| `logging` | `init_subscriber` — `RUST_LOG`-aware `tracing_subscriber::fmt` setup for CLI `main.rs` |
 
 ## Usage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod cli;
+pub mod logging;
+pub mod migration;
 pub mod model;
 pub mod storage;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,61 @@
+//! Tracing subscriber initialization for CLI binaries.
+//!
+//! Wraps the `tracing_subscriber::fmt` setup shared by sae, yomu, and recall
+//! so each `main.rs` can initialize logging in a single call.
+
+use std::io;
+
+use tracing_subscriber::EnvFilter;
+
+/// Installs a `tracing_subscriber::fmt` subscriber that writes to stderr and
+/// reads its filter from `RUST_LOG`, falling back to `default_filter` when the
+/// environment variable is unset or unparseable.
+///
+/// # Examples
+///
+/// ```no_run
+/// amici::logging::init_subscriber("yomu=warn");
+/// // rest of main…
+/// ```
+///
+/// # Migration note
+///
+/// Matches yomu's existing "fallback on missing `RUST_LOG`" semantics. sae's
+/// previous behavior of *always* layering `sae=info` on top of `RUST_LOG` is
+/// not preserved — callers who relied on implicit sae logs should export
+/// `RUST_LOG=sae=info` explicitly.
+///
+/// # Panics
+///
+/// Panics if `default_filter` is not a valid
+/// [`tracing_subscriber::EnvFilter`] directive string. Also panics if called
+/// more than once per process, since
+/// [`tracing_subscriber::fmt::SubscriberBuilder::init`] installs the global
+/// default subscriber.
+pub fn init_subscriber(default_filter: &str) {
+    tracing_subscriber::fmt()
+        .with_writer(io::stderr)
+        .with_env_filter(resolve_env_filter(default_filter))
+        .init();
+}
+
+fn resolve_env_filter(default_filter: &str) -> EnvFilter {
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_filter))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // T-021: resolve_env_filter_accepts_directive
+    #[test]
+    fn resolve_env_filter_accepts_directive() {
+        let _filter = resolve_env_filter("yomu=warn");
+    }
+
+    // T-022: resolve_env_filter_accepts_multi_directive
+    #[test]
+    fn resolve_env_filter_accepts_multi_directive() {
+        let _filter = resolve_env_filter("sae=info,hyper=warn");
+    }
+}

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -1,0 +1,89 @@
+//! Schema migration notification helpers.
+//!
+//! Provides a unified `tracing::warn!` event for the "schema changed →
+//! re-run `<tool> <cmd>`" pattern shared by sae, yomu, and recall.
+
+use tracing::warn;
+
+/// Emits a `warn!` event announcing that a schema migration cleared data and
+/// instructing the user to re-run a rebuild command.
+///
+/// Structured fields `tool`, `item`, `count`, and `rebuild_cmd` are always
+/// attached so log consumers can filter and aggregate without parsing the
+/// message body. The human-readable message omits `count` when it is `0` —
+/// use `0` when the caller does not have a meaningful row count (for example,
+/// when embeddings are cleared en masse without row enumeration).
+///
+/// `item` is the **noun** that was cleared (e.g. `"cached sessions"`,
+/// `"embeddings"`), chosen to avoid collision with the `target:` metadata
+/// target key that `tracing` macros recognize as a reserved keyword.
+///
+/// # Examples
+///
+/// With a known row count:
+///
+/// ```no_run
+/// amici::migration::notify_schema_change("recall", "cached sessions", 42, "recall index");
+/// // "schema changed — clearing 42 cached sessions; run `recall index` to rebuild"
+/// ```
+///
+/// Without a count:
+///
+/// ```no_run
+/// amici::migration::notify_schema_change("sae", "embeddings", 0, "sae embed");
+/// // "schema changed — clearing embeddings; run `sae embed` to rebuild"
+/// ```
+///
+/// Extra fields such as `from` version or `path` should be attached via an
+/// enclosing span so this helper keeps a single signature:
+///
+/// ```no_run
+/// # use tracing::info_span;
+/// # let path = std::path::Path::new("/tmp/x");
+/// let _span = info_span!("migration", from = 7, to = 8, path = %path.display()).entered();
+/// amici::migration::notify_schema_change("yomu", "embeddings", 0, "yomu index");
+/// ```
+pub fn notify_schema_change(tool: &str, item: &str, count: usize, rebuild_cmd: &str) {
+    let msg = format_schema_change_message(item, count, rebuild_cmd);
+    warn!(tool, item, count, rebuild_cmd, "{msg}");
+}
+
+fn format_schema_change_message(item: &str, count: usize, rebuild_cmd: &str) -> String {
+    if count > 0 {
+        format!("schema changed — clearing {count} {item}; run `{rebuild_cmd}` to rebuild")
+    } else {
+        format!("schema changed — clearing {item}; run `{rebuild_cmd}` to rebuild")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // T-018: format_schema_change_message_includes_count_when_positive
+    #[test]
+    fn format_schema_change_message_includes_count_when_positive() {
+        let msg = format_schema_change_message("cached sessions", 42, "recall index");
+        assert_eq!(
+            msg,
+            "schema changed — clearing 42 cached sessions; run `recall index` to rebuild"
+        );
+    }
+
+    // T-019: format_schema_change_message_omits_count_when_zero
+    #[test]
+    fn format_schema_change_message_omits_count_when_zero() {
+        let msg = format_schema_change_message("embeddings", 0, "sae embed");
+        assert_eq!(
+            msg,
+            "schema changed — clearing embeddings; run `sae embed` to rebuild"
+        );
+    }
+
+    // T-020: notify_schema_change_does_not_panic
+    #[test]
+    fn notify_schema_change_does_not_panic() {
+        notify_schema_change("test", "items", 5, "test rebuild");
+        notify_schema_change("test", "items", 0, "test rebuild");
+    }
+}


### PR DESCRIPTION
## 概要

- `amici::migration::notify_schema_change` を追加 — recall / sae / yomu で重複しているスキーマ変更通知を統一した `tracing::warn!` イベントとして提供。構造化フィールド `tool`, `item`, `count`, `rebuild_cmd` を持ち、`count=0` の場合は人間向けメッセージから件数を省略するが、フィールドは保持する。
- `amici::logging::init_subscriber(default_filter)` を追加 — `RUST_LOG` 環境変数に対応した `tracing_subscriber::fmt` 薄いラッパー。各ツールの `main.rs` で1行初期化。
- 依存追加: `tracing-subscriber = { version = "0.3", features = ["env-filter"] }`
- `src/lib.rs` で両モジュールを公開し、README のモジュール一覧も更新。

amici 側の追加のみ。sae / yomu / recall での実際の呼び出し元への置き換えは続くPRで対応する（issue #7「利用先」セクション参照）。

## 主な変更

| ファイル | 変更内容 |
| --- | --- |
| `src/migration.rs` | `notify_schema_change` 関数（新規） |
| `src/logging.rs` | `init_subscriber` 関数（新規） |
| `src/lib.rs` | 両モジュールを `pub mod` で公開 |
| `Cargo.toml` | `tracing-subscriber` with `env-filter` 追加 |
| `README.md` | モジュール一覧に `migration`, `logging` を追記 |

## 設計メモ: `item` フィールド名

issue #7 の提案では `target` だったが、`tracing` の予約フィールド名 `target:` と衝突しコレクター側のフィルタリングセマンティクスに影響するため、`item` に変更した。

## 移行メモ — sae の挙動変更

sae はこれまで RUST_LOG 未設定時に `sae=info` が暗黙的に有効だった。`amici::logging::init_subscriber` へ移行後はこの暗黙の上乗せは**行わない**。

sae のログを受け取るには `RUST_LOG=sae=info` の明示的な設定が必要になる。
（sae 呼び出し元への周知が必要）

## テスト

- `cargo test`: 56 tests + 4 doctests — all pass
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo build`: OK

Closes #7