### PR TITLE
amici::cli に stderr 出力と Spinner 詳細行のヘルパーを追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2706,11 +2706,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2719,7 +2719,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -3018,6 +3018,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,7 @@
+mod message;
 mod shorthand;
 mod spinner;
 
+pub use message::{deprecation_warn, exit_error, hint_arrow, info, progress_step};
 pub use shorthand::try_expand_shorthand;
 pub use spinner::{Spinner, done, embed_with_spinners, with_spinner};

--- a/src/cli/message.rs
+++ b/src/cli/message.rs
@@ -1,0 +1,180 @@
+//! CLI message helpers shared by sae / yomu / recall.
+//!
+//! Unifies the stderr formatting of terminal errors, shorthand expansion
+//! hints, informational notices, deprecation warnings, and multi-line
+//! progress updates. Matching formats across tools keeps log parsers and
+//! user expectations consistent.
+
+/// Prints a terminal error to stderr.
+///
+/// Use at the CLI entry point where the process is about to exit with a
+/// non-zero status. Matches the `anyhow::Error` Display convention.
+///
+/// # Examples
+///
+/// ```no_run
+/// if let Err(e) = run() {
+///     amici::cli::exit_error(&format!("{e}"));
+///     std::process::exit(1);
+/// }
+/// # fn run() -> Result<(), std::io::Error> { Ok(()) }
+/// ```
+pub fn exit_error(msg: &str) {
+    eprintln!("error: {msg}");
+}
+
+/// Prints a shorthand-expansion hint to stderr.
+///
+/// Use after [`try_expand_shorthand`](crate::cli::try_expand_shorthand) rewrites
+/// the argv, to show the user what was actually parsed. Callers convert the
+/// returned `Vec<OsString>` to string slices first — typically via
+/// [`OsStr::to_string_lossy`](std::ffi::OsStr::to_string_lossy) — since this
+/// helper formats for display, not for round-trip shell execution. Items are
+/// joined with a single space and not shell-escaped; inputs that contain
+/// embedded spaces will appear without their original quoting.
+///
+/// # Examples
+///
+/// ```no_run
+/// amici::cli::hint_arrow(&["search", "認証"]);
+/// // stderr: → search 認証
+/// ```
+pub fn hint_arrow<S: AsRef<str>>(items: &[S]) {
+    eprintln!("{}", format_hint_arrow(items));
+}
+
+fn format_hint_arrow<S: AsRef<str>>(items: &[S]) -> String {
+    let joined = items
+        .iter()
+        .map(AsRef::as_ref)
+        .collect::<Vec<&str>>()
+        .join(" ");
+    format!("→ {joined}")
+}
+
+/// Prints `msg` to stderr as an informational notice.
+///
+/// Replaces `println!` usages where the text is CLI guidance rather than the
+/// program's actual result. Output goes to stderr so stdout stays reserved
+/// for pipeable data.
+///
+/// # Examples
+///
+/// ```no_run
+/// amici::cli::info("no pending items; nothing to do");
+/// ```
+pub fn info(msg: &str) {
+    eprintln!("{msg}");
+}
+
+/// Prints a deprecation warning to stderr.
+///
+/// Use when a CLI flag or subcommand is retained for backward compatibility
+/// but callers should migrate to the new form.
+///
+/// # Examples
+///
+/// ```no_run
+/// amici::cli::deprecation_warn("--legacy-flag", "--new-flag");
+/// ```
+pub fn deprecation_warn(old: &str, new: &str) {
+    eprintln!("warning: {old} is deprecated, use {new} instead");
+}
+
+/// Prints a two-space-indented progress line to stderr.
+///
+/// `items` are joined with ` — ` (em dash surrounded by spaces). Use for
+/// multi-field progress such as `page 3/10`, `batch 2`, etc. Intended for
+/// non-TTY callers or alongside a spinner finish marker.
+///
+/// # Examples
+///
+/// ```no_run
+/// amici::cli::progress_step(&["page 3/10", "batch 2"]);
+/// // stderr:   page 3/10 — batch 2
+/// ```
+pub fn progress_step<S: AsRef<str>>(items: &[S]) {
+    eprintln!("{}", format_progress_step(items));
+}
+
+fn format_progress_step<S: AsRef<str>>(items: &[S]) -> String {
+    let joined = items
+        .iter()
+        .map(AsRef::as_ref)
+        .collect::<Vec<&str>>()
+        .join(" — ");
+    format!("  {joined}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // T-043: exit_error_does_not_panic
+    #[test]
+    fn exit_error_does_not_panic() {
+        exit_error("test");
+    }
+
+    // T-044: format_hint_arrow_joins_with_space
+    #[test]
+    fn format_hint_arrow_joins_with_space() {
+        assert_eq!(
+            format_hint_arrow(&["search", "query", "term"]),
+            "→ search query term"
+        );
+    }
+
+    // T-045: format_hint_arrow_accepts_string_owned
+    #[test]
+    fn format_hint_arrow_accepts_string_owned() {
+        let v: Vec<String> = vec!["a".into(), "b".into()];
+        assert_eq!(format_hint_arrow(&v), "→ a b");
+    }
+
+    // T-046: format_hint_arrow_empty_produces_arrow_only
+    #[test]
+    fn format_hint_arrow_empty_produces_arrow_only() {
+        let empty: [&str; 0] = [];
+        assert_eq!(format_hint_arrow(&empty), "→ ");
+    }
+
+    // T-047: hint_arrow_does_not_panic
+    #[test]
+    fn hint_arrow_does_not_panic() {
+        hint_arrow(&["a", "b"]);
+    }
+
+    // T-048: info_does_not_panic
+    #[test]
+    fn info_does_not_panic() {
+        info("some guidance");
+    }
+
+    // T-050: deprecation_warn_does_not_panic
+    #[test]
+    fn deprecation_warn_does_not_panic() {
+        deprecation_warn("--old", "--new");
+    }
+
+    // T-051: format_progress_step_joins_with_em_dash_and_indents
+    #[test]
+    fn format_progress_step_joins_with_em_dash_and_indents() {
+        assert_eq!(
+            format_progress_step(&["page 3/10", "batch 2"]),
+            "  page 3/10 — batch 2"
+        );
+    }
+
+    // T-052: format_progress_step_single_item_indented
+    #[test]
+    fn format_progress_step_single_item_indented() {
+        assert_eq!(format_progress_step(&["step 1"]), "  step 1");
+    }
+
+    // T-053: progress_step_does_not_panic
+    #[test]
+    fn progress_step_does_not_panic() {
+        progress_step(&["a", "b"]);
+    }
+}

--- a/src/cli/spinner.rs
+++ b/src/cli/spinner.rs
@@ -70,8 +70,32 @@ impl Spinner {
     /// The marker is shown on both TTY and non-TTY streams so downstream log parsers
     /// see a consistent `✓ {msg}` format regardless of terminal detection.
     pub fn finish(self, msg: &str) {
+        self.finish_with_detail(msg, None);
+    }
+
+    /// Finishes with the primary success line, then an optional indented detail line.
+    ///
+    /// `detail`, when `Some`, is printed on the following line prefixed with two
+    /// spaces so it reads as a continuation of the success marker. Use for
+    /// non-fatal side notes such as "skipped N items" or partial-failure summaries.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use amici::cli::Spinner;
+    /// let sp = Spinner::new("Indexing...");
+    /// sp.finish_with_detail(
+    ///     "Indexed 100 sessions",
+    ///     Some("Failed to parse 3 files — permission denied"),
+    /// );
+    /// ```
+    pub fn finish_with_detail(self, main: &str, detail: Option<&str>) {
+        // Drop first so the frame-thread clears the spinner line before `done` writes `✓`.
         drop(self);
-        done(msg);
+        done(main);
+        if let Some(d) = detail {
+            eprintln!("  {d}");
+        }
     }
 
     /// Stops the spinner silently by consuming it, triggering `Drop`.
@@ -277,5 +301,19 @@ mod tests {
         let spinner = Spinner::new_with_tty("start", false);
         spinner.set_message("working");
         spinner.finish("done");
+    }
+
+    // T-054: finish_with_detail_none_matches_finish_behavior
+    #[test]
+    fn finish_with_detail_none_matches_finish_behavior() {
+        let spinner = Spinner::new_with_tty("start", false);
+        spinner.finish_with_detail("done", None);
+    }
+
+    // T-055: finish_with_detail_some_does_not_panic
+    #[test]
+    fn finish_with_detail_some_does_not_panic() {
+        let spinner = Spinner::new_with_tty("start", false);
+        spinner.finish_with_detail("done", Some("skipped 3 items"));
     }
 }


### PR DESCRIPTION
Closes #9

## Summary

- Adds `src/cli/message.rs` with five stderr formatting helpers (`exit_error`, `hint_arrow`, `info`, `deprecation_warn`, `progress_step`) that sae, yomu, and recall currently duplicate inline.
- Extends `Spinner` with `finish_with_detail(main, detail)`, which prints an optional indented continuation line after the `✓` marker.
- Refactors `finish` to delegate to `finish_with_detail(msg, None)` so the two code paths stay in sync.
- Cargo.lock includes an unrelated `wasip2` version bump bundled intentionally.
- 68 lib tests + 10 doc tests pass; clippy clean.

## API additions

| Symbol | Output format |
|---|---|
| `cli::exit_error(msg)` | `error: {msg}` on stderr |
| `cli::hint_arrow(items)` | `→ {items joined by space}` on stderr |
| `cli::info(msg)` | `{msg}` on stderr |
| `cli::deprecation_warn(old, new)` | `warning: {old} is deprecated, use {new} instead` on stderr |
| `cli::progress_step(items)` | `  {items joined by " — "}` on stderr |
| `Spinner::finish_with_detail(main, detail)` | `✓ {main}` then `  {detail}` if `Some` |

## Design notes

**`user_warn` omitted.** Three polish rounds concluded that sae, yomu, and recall already call `tracing::warn!(error = %e, ...)` at 34 sites with structured fields. A `&str`-taking wrapper would strip those fields. `amici::logging::init_subscriber` already routes WARN+ to stderr, so `tracing::warn!` alone satisfies the "visible to user" requirement.

**Drop ordering in `finish_with_detail`.** The method calls `drop(self)` explicitly before `done(main)`. The `Spinner` `Drop` impl stops the frame thread and clears the spinner line; if destruction happened at scope end (after `done`), the `✓` line would be overwritten. The explicit drop makes the ordering a compile-time guarantee rather than a layout assumption.

## Test plan

```bash
cargo test --lib
cargo test --doc
cargo clippy --all-targets --all-features -- -D warnings
```

## Related issues

- amici #9 — Phase 2 (this PR)
- sae #66 — Phase 3 consumer
- recall #33 — Phase 3 consumer
