### PR TITLE
rurico rev を e83581c に bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1525,9 +1525,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -2136,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
 dependencies = [
  "cc",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1855,7 +1855,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=bc2ad90#bc2ad90c2cd36b421aaacdc23cffed98d4f51a19"
+source = "git+https://github.com/thkt/rurico?rev=e83581c#e83581cd3976363522bca282e489194567f034cf"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=bc2ad90#bc2ad90c2cd36b421aaacdc23cffed98d4f51a19"
+source = "git+https://github.com/thkt/rurico?rev=e83581c#e83581cd3976363522bca282e489194567f034cf"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ license = "MIT"
 repository = "https://github.com/thkt/amici"
 
 [dependencies]
-rurico             = { git = "https://github.com/thkt/rurico", rev = "bc2ad90" }
+rurico             = { git = "https://github.com/thkt/rurico", rev = "e83581c" }
 rusqlite           = { version = "0.39", features = ["bundled"] }
 tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "bc2ad90", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "e83581c", features = ["test-support"] }
 
 [lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
## 概要と動機

rurico の `prepare_match_query` が第三引数 `vocab_table: &str` を要求するようになった（破壊的変更、rurico#38 で merged）。amici 自体は `prepare_match_query` を利用していないため API 上の影響はないが、下流クレート（recall / sae / yomu）が依存グラフ内で rurico を単一バージョンに解決できるよう rev を揃える必要がある。

## 変更内容

- `Cargo.toml` の `rurico` rev を `bc2ad90` → `e83581c` に bump（dependencies / dev-dependencies 両方）
- `Cargo.lock` の rurico ソース URL が同期

## テスト方法

- `cargo test` — 10 passed
- `cargo build` — 成功

## 影響範囲

API 表面に変更なし。依存解決だけが動くため、呼び出し元は無修正で移行できる。