### PR TITLE
trigram 後処理ヘルパー clean_for_trigram を amici に抽出

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,3 +1,5 @@
+pub mod fts;
+
 use rusqlite::types::ToSql;
 
 /// Returns numbered placeholders without parentheses: `"?1, ?2, ?3"` for len=3.

--- a/src/storage/fts.rs
+++ b/src/storage/fts.rs
@@ -1,37 +1,45 @@
 //! FTS5 trigram tokenizer adapters for `rurico::storage::MatchFtsQuery` output.
 
-/// Adapt a [`MatchFtsQuery`](rurico::storage::MatchFtsQuery) string for an FTS5
-/// `trigram` tokenizer.
+use rurico::storage::MatchFtsQuery;
+
+/// Adapt a [`MatchFtsQuery`] for an FTS5 `trigram` tokenizer.
 ///
 /// The trigram tokenizer rejects `("a" OR "b") "c"` (a parenthesized OR-group
 /// followed by implicit AND). This function distributes OR-groups into flat
 /// alternatives — `(A OR B) C` → `A C OR B C` — and drops sub-trigram terms
 /// (<3 chars) inside OR-groups because the trigram tokenizer cannot index them.
 ///
-/// Callers should pass `rurico::storage::MatchFtsQuery::as_str()`; other
-/// inputs are accepted for testability but bare tokens outside `(...)` or
-/// `"..."` are silently dropped. Control characters are stripped.
-///
-/// Returns an empty string when every OR-group alternative was sub-trigram and
-/// no fixed terms remain — callers should treat this as "no results".
-pub fn clean_for_trigram(match_query: &str) -> String {
+/// Control characters are stripped. Returns `None` when the input contains no
+/// indexable terms (e.g. every OR-group alternative was sub-trigram); callers
+/// should treat this as "no results" rather than passing an empty string to
+/// FTS5 `MATCH`.
+pub fn clean_for_trigram(query: &MatchFtsQuery) -> Option<String> {
+    clean_impl(query.as_str())
+}
+
+fn clean_impl(match_query: &str) -> Option<String> {
     let cleaned: String = match_query.chars().filter(|c| !c.is_control()).collect();
     let (fixed, or_groups) = parse_fts_segments(&cleaned);
 
     if or_groups.is_empty() {
-        return fixed.join(" ");
+        if fixed.is_empty() {
+            return None;
+        }
+        return Some(fixed.join(" "));
     }
 
     let combos = cross_product(&or_groups);
-    combos
-        .iter()
-        .map(|combo| {
-            let mut parts = combo.clone();
-            parts.extend(fixed.iter().cloned());
-            parts.join(" ")
-        })
-        .collect::<Vec<_>>()
-        .join(" OR ")
+    Some(
+        combos
+            .iter()
+            .map(|combo| {
+                let mut parts = combo.clone();
+                parts.extend(fixed.iter().cloned());
+                parts.join(" ")
+            })
+            .collect::<Vec<_>>()
+            .join(" OR "),
+    )
 }
 
 fn parse_fts_segments(cleaned: &str) -> (Vec<String>, Vec<Vec<String>>) {
@@ -64,7 +72,12 @@ fn parse_fts_segments(cleaned: &str) -> (Vec<String>, Vec<Vec<String>>) {
                     break;
                 }
             }
-            fixed.push(term);
+            // Trigram tokenizer cannot index <3 char terms; apply the same
+            // filter used inside OR-groups so the Option<String> contract
+            // stays honest across all input shapes.
+            if term.trim_matches('"').chars().count() >= 3 {
+                fixed.push(term);
+            }
         }
     }
 
@@ -97,45 +110,59 @@ mod tests {
     fn distributes_or_groups() {
         // Control chars removed + sub-trigram dropped + distributed
         assert_eq!(
-            clean_for_trigram("(\"認証の\" OR \"認証\n\" OR \"認証フ\") \"フロー\""),
-            "\"認証の\" \"フロー\" OR \"認証フ\" \"フロー\""
+            clean_impl("(\"認証の\" OR \"認証\n\" OR \"認証フ\") \"フロー\"").as_deref(),
+            Some("\"認証の\" \"フロー\" OR \"認証フ\" \"フロー\"")
         );
 
         // Multi-element group + fixed term → distributed
         assert_eq!(
-            clean_for_trigram("(\"abc\" OR \"def\") \"ghi\""),
-            "\"abc\" \"ghi\" OR \"def\" \"ghi\""
+            clean_impl("(\"abc\" OR \"def\") \"ghi\"").as_deref(),
+            Some("\"abc\" \"ghi\" OR \"def\" \"ghi\"")
         );
 
         // No parens → unchanged
-        assert_eq!(clean_for_trigram("\"hello\""), "\"hello\"");
+        assert_eq!(clean_impl("\"hello\"").as_deref(), Some("\"hello\""));
 
         // Single group, no fixed terms → just OR
         assert_eq!(
-            clean_for_trigram("(\"abc\" OR \"def\")"),
-            "\"abc\" OR \"def\""
+            clean_impl("(\"abc\" OR \"def\")").as_deref(),
+            Some("\"abc\" OR \"def\"")
         );
 
         // Multiple OR groups → cross-product
         assert_eq!(
-            clean_for_trigram("(\"a01\" OR \"a02\") (\"b01\" OR \"b02\")"),
-            "\"a01\" \"b01\" OR \"a01\" \"b02\" OR \"a02\" \"b01\" OR \"a02\" \"b02\""
+            clean_impl("(\"a01\" OR \"a02\") (\"b01\" OR \"b02\")").as_deref(),
+            Some("\"a01\" \"b01\" OR \"a01\" \"b02\" OR \"a02\" \"b01\" OR \"a02\" \"b02\"")
         );
     }
 
     #[test]
-    fn empties_all_sub_trigram() {
+    fn returns_none_when_all_sub_trigram() {
         // All terms in the only OR-group are sub-trigram (<3 chars).
-        // parse_fts_segments filters them, leaving no fixed terms → empty output.
-        assert_eq!(clean_for_trigram("(\"ab\" OR \"cd\")"), "");
+        // parse_fts_segments filters them, leaving no fixed terms → None.
+        assert_eq!(clean_impl("(\"ab\" OR \"cd\")"), None);
+    }
+
+    #[test]
+    fn returns_none_for_empty_input() {
+        assert_eq!(clean_impl(""), None);
+    }
+
+    #[test]
+    fn returns_none_for_sub_trigram_fixed_terms() {
+        // All fixed quoted tokens are <3 chars — trigram tokenizer cannot index them.
+        assert_eq!(clean_impl("\"au\""), None);
+        assert_eq!(clean_impl("\"a\" \"b\""), None);
     }
 
     #[test]
     fn accepts_live_prepare_match_query_output() {
-        // Integration sanity: clean_for_trigram accepts rurico output as-is.
+        // Integration: rurico sanitizes, amici adapts and returns Some.
         let conn = Connection::open_in_memory().unwrap();
         let matched = prepare_match_query(&conn, "hello world", "nonexistent_vocab").unwrap();
-        let cleaned = clean_for_trigram(matched.as_str());
-        assert_eq!(cleaned, "\"hello\" \"world\"");
+        assert_eq!(
+            clean_for_trigram(&matched).as_deref(),
+            Some("\"hello\" \"world\"")
+        );
     }
 }

--- a/src/storage/fts.rs
+++ b/src/storage/fts.rs
@@ -1,0 +1,141 @@
+//! FTS5 trigram tokenizer adapters for `rurico::storage::MatchFtsQuery` output.
+
+/// Adapt a [`MatchFtsQuery`](rurico::storage::MatchFtsQuery) string for an FTS5
+/// `trigram` tokenizer.
+///
+/// The trigram tokenizer rejects `("a" OR "b") "c"` (a parenthesized OR-group
+/// followed by implicit AND). This function distributes OR-groups into flat
+/// alternatives — `(A OR B) C` → `A C OR B C` — and drops sub-trigram terms
+/// (<3 chars) inside OR-groups because the trigram tokenizer cannot index them.
+///
+/// Callers should pass `rurico::storage::MatchFtsQuery::as_str()`; other
+/// inputs are accepted for testability but bare tokens outside `(...)` or
+/// `"..."` are silently dropped. Control characters are stripped.
+///
+/// Returns an empty string when every OR-group alternative was sub-trigram and
+/// no fixed terms remain — callers should treat this as "no results".
+pub fn clean_for_trigram(match_query: &str) -> String {
+    let cleaned: String = match_query.chars().filter(|c| !c.is_control()).collect();
+    let (fixed, or_groups) = parse_fts_segments(&cleaned);
+
+    if or_groups.is_empty() {
+        return fixed.join(" ");
+    }
+
+    let combos = cross_product(&or_groups);
+    combos
+        .iter()
+        .map(|combo| {
+            let mut parts = combo.clone();
+            parts.extend(fixed.iter().cloned());
+            parts.join(" ")
+        })
+        .collect::<Vec<_>>()
+        .join(" OR ")
+}
+
+fn parse_fts_segments(cleaned: &str) -> (Vec<String>, Vec<Vec<String>>) {
+    let mut fixed: Vec<String> = Vec::new();
+    let mut or_groups: Vec<Vec<String>> = Vec::new();
+    let mut chars = cleaned.chars();
+
+    while let Some(c) = chars.next() {
+        if c == '(' {
+            let mut group = String::new();
+            for gc in chars.by_ref() {
+                if gc == ')' {
+                    break;
+                }
+                group.push(gc);
+            }
+            let terms: Vec<String> = group
+                .split(" OR ")
+                .filter(|t| t.trim().trim_matches('"').chars().count() >= 3)
+                .map(|t| t.trim().to_owned())
+                .collect();
+            if !terms.is_empty() {
+                or_groups.push(terms);
+            }
+        } else if c == '"' {
+            let mut term = String::from('"');
+            for tc in chars.by_ref() {
+                term.push(tc);
+                if tc == '"' {
+                    break;
+                }
+            }
+            fixed.push(term);
+        }
+    }
+
+    (fixed, or_groups)
+}
+
+fn cross_product(groups: &[Vec<String>]) -> Vec<Vec<String>> {
+    if groups.is_empty() {
+        return vec![vec![]];
+    }
+    let rest = cross_product(&groups[1..]);
+    let mut result = Vec::new();
+    for term in &groups[0] {
+        for combo in &rest {
+            let mut v = vec![term.clone()];
+            v.extend(combo.iter().cloned());
+            result.push(v);
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rurico::storage::prepare_match_query;
+    use rusqlite::Connection;
+
+    #[test]
+    fn distributes_or_groups() {
+        // Control chars removed + sub-trigram dropped + distributed
+        assert_eq!(
+            clean_for_trigram("(\"認証の\" OR \"認証\n\" OR \"認証フ\") \"フロー\""),
+            "\"認証の\" \"フロー\" OR \"認証フ\" \"フロー\""
+        );
+
+        // Multi-element group + fixed term → distributed
+        assert_eq!(
+            clean_for_trigram("(\"abc\" OR \"def\") \"ghi\""),
+            "\"abc\" \"ghi\" OR \"def\" \"ghi\""
+        );
+
+        // No parens → unchanged
+        assert_eq!(clean_for_trigram("\"hello\""), "\"hello\"");
+
+        // Single group, no fixed terms → just OR
+        assert_eq!(
+            clean_for_trigram("(\"abc\" OR \"def\")"),
+            "\"abc\" OR \"def\""
+        );
+
+        // Multiple OR groups → cross-product
+        assert_eq!(
+            clean_for_trigram("(\"a01\" OR \"a02\") (\"b01\" OR \"b02\")"),
+            "\"a01\" \"b01\" OR \"a01\" \"b02\" OR \"a02\" \"b01\" OR \"a02\" \"b02\""
+        );
+    }
+
+    #[test]
+    fn empties_all_sub_trigram() {
+        // All terms in the only OR-group are sub-trigram (<3 chars).
+        // parse_fts_segments filters them, leaving no fixed terms → empty output.
+        assert_eq!(clean_for_trigram("(\"ab\" OR \"cd\")"), "");
+    }
+
+    #[test]
+    fn accepts_live_prepare_match_query_output() {
+        // Integration sanity: clean_for_trigram accepts rurico output as-is.
+        let conn = Connection::open_in_memory().unwrap();
+        let matched = prepare_match_query(&conn, "hello world", "nonexistent_vocab").unwrap();
+        let cleaned = clean_for_trigram(matched.as_str());
+        assert_eq!(cleaned, "\"hello\" \"world\"");
+    }
+}


### PR DESCRIPTION
## 概要

sae と recall で重複していたトライグラム後処理ヘルパー（`clean_for_trigram`、`parse_fts_segments`、`cross_product`）を amici へ集約する。amici は description でも「sae/yomu/recall 向けの共通ヘルパー」と定義されており、トライグラム tokenizer 固有の後処理はこの責務に収まる。

rurico は `prepare_match_query` で tokenizer neutral な FTS5 クエリを組み立てる責務に専念し、tokenizer 固有のクセに対応する後処理は呼び出し側レイヤ（= amici）が担当するという layering を明確化する。

## 変更内容

- `src/storage.rs`: `pub mod fts;` を追加
- `src/storage/fts.rs` 新規:
  - `clean_for_trigram(match_query: &str) -> String`: 公開 API。`rurico::storage::MatchFtsQuery::as_str()` を受け取り、トライグラム MATCH で安全な文字列へ変換
  - `parse_fts_segments`、`cross_product`: 非公開ヘルパー
- リグレッションテスト 3 件（OR-group distribute / 全 sub-trigram で empty / `prepare_match_query` との実地統合）

## API 設計判断

- 引数は `&str`（`&MatchFtsQuery` ではない）: `MatchFtsQuery` は rurico の public 構築手段が `prepare_match_query` のみのため、テスト容易性を優先。doc で「`MatchFtsQuery::as_str()` を渡すこと」を input contract として明記
- 関数は `pub`、内部ヘルパーは crate-private: 呼び出し側は `clean_for_trigram` 一本だけ知ればよい

## 挙動の変化

なし。sae と recall に既にある同名関数と byte-identical な挙動。

## フォローアップ

別 PR で sae と recall の Cargo.toml の amici rev を bump し、local コピーを削除して `amici::storage::fts::clean_for_trigram` を呼ぶ形に切り替える。

## テスト方法

```bash
cargo test
```

- 10 件の doctests + `storage::fts::tests` 3 件がパス
- `cargo clippy --all-targets --all-features -- -D warnings` 通過