### PR TITLE
feat(storage): escape_like と like_prefix_match ヘルパーを追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1855,7 +1855,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=e83581c#e83581cd3976363522bca282e489194567f034cf"
+source = "git+https://github.com/thkt/rurico?rev=7b739d1#7b739d100596d962a871a5bf2956c7bc698d0ba1"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=e83581c#e83581cd3976363522bca282e489194567f034cf"
+source = "git+https://github.com/thkt/rurico?rev=7b739d1#7b739d100596d962a871a5bf2956c7bc698d0ba1"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,9 +1915,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "log",
  "once_cell",
@@ -1939,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3003,9 +3003,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ license = "MIT"
 repository = "https://github.com/thkt/amici"
 
 [dependencies]
-rurico             = { git = "https://github.com/thkt/rurico", rev = "e83581c" }
+rurico             = { git = "https://github.com/thkt/rurico", rev = "7b739d1" }
 rusqlite           = { version = "0.39", features = ["bundled"] }
 tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "e83581c", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "7b739d1", features = ["test-support"] }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -50,6 +50,31 @@ pub fn append_eq_filter(
     }
 }
 
+/// Escapes LIKE metacharacters (`%`, `_`, `\`) in `s` for use with `ESCAPE '\'`.
+///
+/// The backslash is replaced first so the subsequent `%`/`_` replacements do
+/// not double-escape already-escaped sequences.
+pub fn escape_like(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
+/// Returns `true` iff `prefix` matches the leading bytes of `value` under
+/// ASCII case-insensitive comparison, mirroring SQLite LIKE semantics.
+///
+/// An empty `prefix` always matches. When `prefix` is longer than `value`, the
+/// result is `false`.
+///
+/// Use this on the Rust side when post-filtering rows already narrowed by a
+/// `LIKE ? ESCAPE '\'` clause, so that SQL and Rust agree on case semantics.
+pub fn like_prefix_match(value: &str, prefix: &str) -> bool {
+    value
+        .as_bytes()
+        .get(..prefix.len())
+        .is_some_and(|p| p.eq_ignore_ascii_case(prefix.as_bytes()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -104,5 +129,59 @@ mod tests {
         append_eq_filter(&mut sql, &mut params, "p.lang", Some("ja"));
         assert_eq!(sql, "SELECT 1 AND p.category = ? AND p.lang = ?");
         assert_eq!(params.len(), 2);
+    }
+
+    // T-018: escape_like_escapes_metachars
+    #[test]
+    fn escape_like_escapes_metachars() {
+        assert_eq!(escape_like("100%"), "100\\%");
+        assert_eq!(escape_like("foo_bar"), "foo\\_bar");
+        assert_eq!(escape_like("path\\to"), "path\\\\to");
+    }
+
+    // T-019: escape_like_preserves_regular_chars
+    #[test]
+    fn escape_like_preserves_regular_chars() {
+        assert_eq!(escape_like("hello"), "hello");
+        assert_eq!(escape_like(""), "");
+        assert_eq!(escape_like("日本語"), "日本語");
+    }
+
+    // T-020: escape_like_order_does_not_double_escape
+    #[test]
+    fn escape_like_order_does_not_double_escape() {
+        // Backslash must be escaped first so that `\%` introduced by the `%`
+        // replacement is not re-escaped into `\\\%`.
+        assert_eq!(escape_like("%"), "\\%");
+        assert_eq!(escape_like("\\%"), "\\\\\\%");
+    }
+
+    // T-021: like_prefix_match_case_insensitive
+    #[test]
+    fn like_prefix_match_case_insensitive() {
+        assert!(like_prefix_match("HelloWorld", "hello"));
+        assert!(like_prefix_match("helloworld", "HELLO"));
+        assert!(like_prefix_match("abc", "abc"));
+    }
+
+    // T-022: like_prefix_match_non_matching_returns_false
+    #[test]
+    fn like_prefix_match_non_matching_returns_false() {
+        assert!(!like_prefix_match("HelloWorld", "world"));
+        assert!(!like_prefix_match("abc", "xyz"));
+    }
+
+    // T-023: like_prefix_match_empty_prefix_always_matches
+    #[test]
+    fn like_prefix_match_empty_prefix_always_matches() {
+        assert!(like_prefix_match("anything", ""));
+        assert!(like_prefix_match("", ""));
+    }
+
+    // T-024: like_prefix_match_prefix_longer_than_value_is_false
+    #[test]
+    fn like_prefix_match_prefix_longer_than_value_is_false() {
+        assert!(!like_prefix_match("ab", "abc"));
+        assert!(!like_prefix_match("", "x"));
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -150,9 +150,6 @@ mod tests {
     // T-020: escape_like_order_does_not_double_escape
     #[test]
     fn escape_like_order_does_not_double_escape() {
-        // Backslash must be escaped first so that `\%` introduced by the `%`
-        // replacement is not re-escaped into `\\\%`.
-        assert_eq!(escape_like("%"), "\\%");
         assert_eq!(escape_like("\\%"), "\\\\\\%");
     }
 


### PR DESCRIPTION
## 概要
- recall / yomu が個別に持っている LIKE フィルタ用のヘルパーを amici に集約し、SQL `LIKE` と Rust 側 post-filter の case parity を1箇所で担保する (#13)。
- `cargo update` による transitive deps 更新と、`rurico` rev の `7b739d1` への bump（rurico 上流 PR #39 の transitive dep sync を取り込み）を併せて実施。

## 変更内容
- `escape_like(s: &str) -> String` — `%` / `_` / `\` を `ESCAPE '\'` 用にエスケープ。バックスラッシュを最初に置換することで、後続の `%` / `_` 置換が既存のエスケープを二重化しないよう保証。
- `like_prefix_match(value: &str, prefix: &str) -> bool` — SQLite LIKE セマンティクスをミラーする ASCII case-insensitive な前方一致。`LIKE ? ESCAPE '\'` で絞った後の Rust 側 post-filter 用。
- 両関数は既存の `append_eq_filter` と同じく `src/storage.rs` 直下に配置（一貫性優先）。フィルタ関連ヘルパーが3つ以上に増えた時点で `storage/filter.rs` サブモジュールへ切り出しを検討。

## テスト計画
- [x] `cargo test` — 80 lib + 10 integration 全通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — warning なし
- [x] `cargo fmt --check` — 差分なし
- [x] 新規テスト T-018〜T-024 で網羅: メタ文字エスケープ / 通常文字（非ASCII含む）の passthrough / 順序不変式（`\%` が二重エスケープされない）/ case-insensitive 前方一致 / 非一致 / 空 prefix / prefix が value より長いケース。

## フォローアップ（別PR）
- **recall**: `src/search.rs:64-68` の独自 `escape_like` とインラインな `as_bytes().get(..).is_some_and(...)` 前方一致を `amici::storage::{escape_like, like_prefix_match}` に置換。
- **yomu**: `src/storage/search.rs:88-105` の独自 `escape_like` / LIKE ビルダーを amici 版に置換。hybrid-search の post-filter が入るタイミングで Rust 側 `like_prefix_match` も導入し、FTS↔vec の対称性を確保。

Closes #13