### PR TITLE
FTS↔vec 対称性テストヘルパー — hybrid search regression 防止

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,11 @@ jobs:
       - name: Test
         run: cargo test
 
+      - name: Test (all features)
+        run: cargo test --all-features
+
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-features -- -D warnings
 
       - name: Format check
         run: cargo fmt -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ description = "Shared model-loading, storage helpers, and CLI utilities for the 
 license = "MIT"
 repository = "https://github.com/thkt/amici"
 
+[features]
+test-support = []
+
 [dependencies]
 rurico             = { git = "https://github.com/thkt/rurico", rev = "7b739d1" }
 rusqlite           = { version = "0.39", features = ["bundled"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,5 @@ pub mod logging;
 pub mod migration;
 pub mod model;
 pub mod storage;
+#[cfg(any(test, feature = "test-support"))]
+pub mod testing;

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,7 @@
+//! Shared test helpers exposed via the `test-support` feature.
+//!
+//! Items under this module are compiled only when the `test-support` feature
+//! is enabled, or during in-crate `#[cfg(test)]` builds. They never enter
+//! downstream production binaries.
+
+pub mod hybrid;

--- a/src/testing/hybrid.rs
+++ b/src/testing/hybrid.rs
@@ -4,14 +4,18 @@
 //! the results. A recurring bug class is "filter applied on FTS path but
 //! ignored on vec path", which lets filter-violating items leak through.
 //!
-//! - recall #35: `session_filter` ignored on vec path — fixed with a
-//!   post-filter `retain` at the merge layer.
-//! - yomu #103: `type_filter` ignored on vec path — fixed by appending the
-//!   filter to the vec SQL directly.
+//! The contract — "filter violations are never returned" — is an outcome
+//! property that does not depend on *where* or *how* the caller enforces
+//! the filter. So the helper in this module treats the whole search as a
+//! black box and asserts the outcome, which keeps the same test valid
+//! across future refactors and across new callers that pick a different
+//! strategy.
 //!
-//! Two different fix strategies, same contract. The helper in this module
-//! treats the search as a black box and asserts the outcome, so it works
-//! regardless of where the caller decided to enforce the filter.
+//! Known fix strategies across the toolchain:
+//!
+//! - SQL append — extend the vec SQL with the filter directly (yomu #103).
+//! - Post-filter retain — drop violating items after the merge (recall #35,
+//!   pre-unification).
 
 use std::fmt::Debug;
 

--- a/src/testing/hybrid.rs
+++ b/src/testing/hybrid.rs
@@ -1,0 +1,137 @@
+//! FTS↔vec symmetry contract tests for hybrid search.
+//!
+//! Hybrid search (FTS + vec) routes one query through two paths and merges
+//! the results. A recurring bug class is "filter applied on FTS path but
+//! ignored on vec path", which lets filter-violating items leak through.
+//!
+//! - recall #35: `session_filter` ignored on vec path — fixed with a
+//!   post-filter `retain` at the merge layer.
+//! - yomu #103: `type_filter` ignored on vec path — fixed by appending the
+//!   filter to the vec SQL directly.
+//!
+//! Two different fix strategies, same contract. The helper in this module
+//! treats the search as a black box and asserts the outcome, so it works
+//! regardless of where the caller decided to enforce the filter.
+
+use std::fmt::Debug;
+
+/// Assert that a hybrid search applies a filter on both FTS and vec paths.
+///
+/// The caller supplies three closures:
+///
+/// 1. `setup` — seed the store and return `(should_appear, should_not_appear)`.
+///    - `should_appear`: passes FTS AND satisfies the filter.
+///    - `should_not_appear`: matches vec only (no FTS hit) AND violates the
+///      filter.
+/// 2. `search_filtered` — run hybrid search with the filter enabled; return
+///    the IDs in the results.
+/// 3. `search_unfiltered` — run the same hybrid search with the filter
+///    disabled. This is a probe: `should_not_appear` must surface here,
+///    otherwise the test setup is broken (the seed is unreachable on the vec
+///    path, or FTS is secretly indexing it).
+///
+/// # Panics
+///
+/// Panics if any of the following does not hold:
+///
+/// - probe: `should_not_appear` is absent from `search_unfiltered()`.
+///   Diagnoses a broken setup before blaming the implementation.
+/// - positive: `should_appear` is absent from `search_filtered()`.
+/// - contract: `should_not_appear` leaks into `search_filtered()` — the
+///   actual FTS↔vec asymmetry bug.
+///
+/// # Examples
+///
+/// ```ignore
+/// use amici::testing::hybrid::assert_filter_symmetric;
+///
+/// assert_filter_symmetric(
+///     || {
+///         // seed_a: FTS-hitting, filter-passing
+///         insert_chunk(&conn, 1, "authentication logic", ChunkType::Function);
+///         // seed_b: vec-only, filter-violating
+///         insert_chunk(&conn, 2, "authenticate", ChunkType::Test);
+///         (1_i64, 2_i64)
+///     },
+///     || search(&conn, "auth", Some(&[ChunkType::Function]))
+///         .into_iter().filter_map(|r| r.chunk_id).collect(),
+///     || search(&conn, "auth", None)
+///         .into_iter().filter_map(|r| r.chunk_id).collect(),
+/// );
+/// ```
+pub fn assert_filter_symmetric<Id>(
+    setup: impl FnOnce() -> (Id, Id),
+    search_filtered: impl FnOnce() -> Vec<Id>,
+    search_unfiltered: impl FnOnce() -> Vec<Id>,
+) where
+    Id: PartialEq + Debug,
+{
+    let (should_appear, should_not_appear) = setup();
+
+    let unfiltered = search_unfiltered();
+    assert!(
+        unfiltered.contains(&should_not_appear),
+        "probe failed: {should_not_appear:?} was not returned by the unfiltered search. \
+         The seed must match on the vec path for this contract to be meaningful; \
+         check the seed's content/embedding before blaming the implementation. \
+         unfiltered results: {unfiltered:?}",
+    );
+
+    let filtered = search_filtered();
+    assert!(
+        filtered.contains(&should_appear),
+        "expected {should_appear:?} (FTS-hitting, filter-passing seed) in filtered results, \
+         got: {filtered:?}",
+    );
+    assert!(
+        !filtered.contains(&should_not_appear),
+        "FTS↔vec asymmetry: {should_not_appear:?} (vec-only match, filter-violating) \
+         leaked into filtered results {filtered:?}. \
+         The filter is honored on the FTS path but ignored on the vec path — \
+         apply it on both, or post-filter the merged output.",
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // T-025: asymmetry_bug_panics_with_diagnostic
+    #[test]
+    #[should_panic(expected = "FTS↔vec asymmetry")]
+    fn asymmetry_bug_panics_with_diagnostic() {
+        // Buggy impl: filter is not applied on the vec path, so "b" leaks in.
+        assert_filter_symmetric(|| ("a", "b"), || vec!["a", "b"], || vec!["a", "b"]);
+    }
+
+    // T-026: missing_should_appear_panics
+    #[test]
+    #[should_panic(expected = "filter-passing seed")]
+    fn missing_should_appear_panics() {
+        // Impl returns nothing for the filtered search — "a" disappears too.
+        assert_filter_symmetric(|| ("a", "b"), Vec::new, || vec!["a", "b"]);
+    }
+
+    // T-027: vacuous_pass_caught_by_probe
+    #[test]
+    #[should_panic(expected = "probe failed")]
+    fn vacuous_pass_caught_by_probe() {
+        // Seed "b" is not actually findable on the vec path — broken setup.
+        // Without the probe, the filtered assertion would pass vacuously.
+        assert_filter_symmetric(|| ("a", "b"), || vec!["a"], || vec!["a"]);
+    }
+
+    // T-028: correct_impl_passes
+    #[test]
+    fn correct_impl_passes() {
+        // Correct impl: "b" matches vec without filter but is filtered out.
+        assert_filter_symmetric(|| ("a", "b"), || vec!["a"], || vec!["a", "b"]);
+    }
+
+    // T-029: supports_numeric_ids
+    #[test]
+    fn supports_numeric_ids() {
+        // Verify the Id generic parameter accepts non-string types (i64, newtype).
+        assert_filter_symmetric::<i64>(|| (1, 2), || vec![1], || vec![1, 2]);
+    }
+}


### PR DESCRIPTION
## 概要

- `amici::testing::hybrid::assert_filter_symmetric` を追加。FTS パスと vec パスの両方でフィルターが対称に適用されることをブラックボックスで検証するテストヘルパー。
- `test-support` feature フラグを追加し、ダウンストリームクレートがオプトインで testing ユーティリティを利用可能に。
- メタテスト 5 件（T-025〜T-029）で非対称検出・偽陽性防止（vacuous pass 検出）・ハッピーパス・数値 Id ジェネリックを網羅。
- CI に `cargo test --all-features` ステップを追加し、`cargo clippy` も `--all-features` で実行するよう拡張（デフォルト feature の regression カバレッジは既存の bare `cargo test` が継続担保）。

## 変更点

| ファイル | 変更内容 |
| --- | --- |
| `src/testing/hybrid.rs` | `assert_filter_symmetric` 本体 + メタテスト T-025〜T-029（新規 137 行） |
| `src/testing.rs` | `pub mod hybrid;` エクスポート追加 |
| `src/lib.rs` | `#[cfg(any(test, feature = "test-support"))] pub mod testing;` で条件付き公開 |
| `Cargo.toml` | `[features] test-support = []` 追加 |
| `.github/workflows/ci.yml` | `Test (all features)` ステップ追加、Clippy を `--all-features` に拡張 |

## 設計判断

Issue #14 は `<S, Q, R>` 型パラメーター抽象を提案していたが、**3 クロージャのブラックボックス形式**を採用した。

理由：契約「フィルター違反アイテムが結果に含まれない」は outcome 属性であり、fix 戦略（どこでどう filter を適用するか）とは独立。型パラメーター抽象は search のシグネチャに依存してしまうため、戦略が変わるたびにヘルパーの再実装を強いる。クロージャベースの結果検証型ヘルパーは、**現状 recall/yomu で採られている戦略が将来統一されても、新しい第三戦略が登場しても、同一の契約テストがそのまま通る**。

現状の fix 戦略（参考）：

- yomu #103 — vec SQL への filter 直接付加（SQL append）
- recall #35 — merge 後の `retain` による post-filter（SQL append へ統一する follow-up を検討中）

また、`search_unfiltered` プローブクロージャを必須引数とすることで「`should_not_appear` が vec 経由でそもそも到達不可能」という vacuous pass を事前に検出し、テストが虚偽の成功を報告することを防いでいる。

## 検証

| コマンド | 結果 |
| --- | --- |
| `cargo test` | default features、既存テスト全パス |
| `cargo test --all-features` | test-support 有効、T-025〜T-029 全パス |
| `cargo clippy --all-features -- -D warnings` | 警告なし |

## 関連

- recall #35: https://github.com/thkt/recall/issues/35
- yomu #103: https://github.com/thkt/yomu/issues/103
- amici #13（前段・マージ済み）: https://github.com/thkt/amici/issues/13

Closes #14