### PR TITLE
タイムスタンプ列向け day-inclusive cutoff helper を追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,9 +1149,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -4,5 +4,6 @@ pub mod fts;
 pub use filter::{
     anon_placeholders, append_date_string_cutoff_filter, append_eq_filter, append_exclude_ids,
     append_in_filter, append_include_ids, append_like_prefix_filter,
-    append_timestamp_cutoff_filter, as_sql_params, escape_like, in_placeholders, like_prefix_match,
+    append_timestamp_cutoff_filter, append_timestamp_day_cutoff_filter, as_sql_params, escape_like,
+    in_placeholders, like_prefix_match,
 };

--- a/src/storage/filter.rs
+++ b/src/storage/filter.rs
@@ -272,7 +272,9 @@ pub fn append_timestamp_cutoff_filter(
 ///
 /// Intended for SQLite `TEXT` columns storing dates like `"2026-04-23"`, where
 /// lexical ordering coincides with chronological ordering. Use
-/// [`append_timestamp_cutoff_filter`] for integer millisecond columns.
+/// [`append_timestamp_cutoff_filter`] for integer millisecond columns, or
+/// [`append_timestamp_day_cutoff_filter`] when the column may hold RFC 3339
+/// timestamps and the caller wants a day-inclusive `before`.
 ///
 /// See [`append_eq_filter`] for the `column` security contract.
 pub fn append_date_string_cutoff_filter(
@@ -286,6 +288,43 @@ pub fn append_date_string_cutoff_filter(
         sql.push_str(" AND ");
         sql.push_str(column);
         sql.push_str(if before { " <= ?" } else { " >= ?" });
+        params.push(Box::new(date.to_owned()));
+    }
+}
+
+/// Appends a day-inclusive cutoff comparison for RFC 3339 timestamp columns.
+///
+/// - `date_iso` `None` → no-op.
+/// - `before = true`  → `" AND {column} < date(?, '+1 day')"` (rows whose
+///   timestamp falls on or before the cutoff day, inclusive of T-suffix
+///   values that lexically follow the bare `YYYY-MM-DD` string).
+/// - `before = false` → `" AND {column} >= ?"` (rows whose timestamp is on or
+///   after the cutoff day; RFC 3339's `YYYY-MM-DDTHH:MM:SS±HH:MM` prefix
+///   already sorts correctly against the bare date).
+///
+/// Intended for SQLite `TEXT` columns storing RFC 3339 timestamps such as
+/// `"2025-03-01T12:00:00+00:00"`. The `+1 day` arithmetic is delegated to
+/// SQLite's `date()`, so callers only bind a `%Y-%m-%d` string — no Rust-side
+/// date math is required. Use [`append_date_string_cutoff_filter`] when the
+/// column is guaranteed to be date-only; the plain `<= ?` comparison there is
+/// sufficient and avoids the `date()` call.
+///
+/// See [`append_eq_filter`] for the `column` security contract.
+pub fn append_timestamp_day_cutoff_filter(
+    sql: &mut String,
+    params: &mut Vec<Box<dyn ToSql>>,
+    column: &'static str,
+    before: bool,
+    date_iso: Option<&str>,
+) {
+    if let Some(date) = date_iso {
+        sql.push_str(" AND ");
+        sql.push_str(column);
+        if before {
+            sql.push_str(" < date(?, '+1 day')");
+        } else {
+            sql.push_str(" >= ?");
+        }
         params.push(Box::new(date.to_owned()));
     }
 }
@@ -751,5 +790,147 @@ mod tests {
             .collect::<Result<_, _>>()
             .unwrap();
         assert_eq!(rows, vec!["2026-03-01".to_owned()]);
+    }
+
+    // T-050: append_timestamp_day_cutoff_filter_none_noop
+    #[test]
+    fn append_timestamp_day_cutoff_filter_none_noop() {
+        let mut sql = "SELECT 1".to_owned();
+        let mut params: Vec<Box<dyn ToSql>> = Vec::new();
+        append_timestamp_day_cutoff_filter(&mut sql, &mut params, "p.updated_at", true, None);
+        assert_eq!(sql, "SELECT 1");
+        assert!(params.is_empty());
+    }
+
+    // T-051: append_timestamp_day_cutoff_filter_before_true_appends_lt_plus_one_day
+    #[test]
+    fn append_timestamp_day_cutoff_filter_before_true_appends_lt_plus_one_day() {
+        let mut sql = "SELECT 1".to_owned();
+        let mut params: Vec<Box<dyn ToSql>> = Vec::new();
+        append_timestamp_day_cutoff_filter(
+            &mut sql,
+            &mut params,
+            "p.updated_at",
+            true,
+            Some("2025-03-01"),
+        );
+        assert_eq!(sql, "SELECT 1 AND p.updated_at < date(?, '+1 day')");
+        assert_eq!(params.len(), 1);
+    }
+
+    // T-052: append_timestamp_day_cutoff_filter_before_false_appends_ge
+    #[test]
+    fn append_timestamp_day_cutoff_filter_before_false_appends_ge() {
+        let mut sql = "SELECT 1".to_owned();
+        let mut params: Vec<Box<dyn ToSql>> = Vec::new();
+        append_timestamp_day_cutoff_filter(
+            &mut sql,
+            &mut params,
+            "p.updated_at",
+            false,
+            Some("2025-03-01"),
+        );
+        assert_eq!(sql, "SELECT 1 AND p.updated_at >= ?");
+        assert_eq!(params.len(), 1);
+    }
+
+    // T-053: append_timestamp_day_cutoff_filter_day_inclusive_on_rfc3339_via_sqlite
+    // End-to-end: the helper must treat `--before 2025-03-01` as "on or before
+    // 2025-03-01", including RFC 3339 rows that fall anywhere within the
+    // boundary day. Verifies `date(?, '+1 day')` lifts the upper bound past
+    // the T-suffix timestamps that would otherwise sort after `"2025-03-01"`.
+    #[test]
+    fn append_timestamp_day_cutoff_filter_day_inclusive_on_rfc3339_via_sqlite() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute("CREATE TABLE t (updated_at TEXT)", [])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO t VALUES \
+             ('2025-02-28T23:59:59+00:00'), \
+             ('2025-03-01'), \
+             ('2025-03-01T00:00:00+00:00'), \
+             ('2025-03-01T12:00:00+00:00'), \
+             ('2025-03-01T23:59:59+00:00'), \
+             ('2025-03-02T00:00:00+00:00')",
+            [],
+        )
+        .unwrap();
+
+        let mut sql = "SELECT updated_at FROM t WHERE 1=1".to_owned();
+        let mut params: Vec<Box<dyn ToSql>> = Vec::new();
+        append_timestamp_day_cutoff_filter(
+            &mut sql,
+            &mut params,
+            "updated_at",
+            true,
+            Some("2025-03-01"),
+        );
+        sql.push_str(" ORDER BY updated_at");
+
+        let mut stmt = conn.prepare(&sql).unwrap();
+        let rows: Vec<String> = stmt
+            .query_map(rusqlite::params_from_iter(params.iter()), |row| row.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                "2025-02-28T23:59:59+00:00".to_owned(),
+                "2025-03-01".to_owned(),
+                "2025-03-01T00:00:00+00:00".to_owned(),
+                "2025-03-01T12:00:00+00:00".to_owned(),
+                "2025-03-01T23:59:59+00:00".to_owned(),
+            ]
+        );
+    }
+
+    // T-054: append_timestamp_day_cutoff_filter_before_false_start_inclusive_on_rfc3339_via_sqlite
+    // End-to-end for `before = false`. The helper relies on RFC 3339 prefix
+    // sorting against a bare `YYYY-MM-DD` lower bound, so the boundary day
+    // must include both the bare date and every T-suffix value of that day
+    // while excluding the preceding day's final timestamp.
+    #[test]
+    fn append_timestamp_day_cutoff_filter_before_false_start_inclusive_on_rfc3339_via_sqlite() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute("CREATE TABLE t (updated_at TEXT)", [])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO t VALUES \
+             ('2025-02-28T23:59:59+00:00'), \
+             ('2025-03-01'), \
+             ('2025-03-01T00:00:00+00:00'), \
+             ('2025-03-01T12:00:00+00:00'), \
+             ('2025-03-02T00:00:00+00:00')",
+            [],
+        )
+        .unwrap();
+
+        let mut sql = "SELECT updated_at FROM t WHERE 1=1".to_owned();
+        let mut params: Vec<Box<dyn ToSql>> = Vec::new();
+        append_timestamp_day_cutoff_filter(
+            &mut sql,
+            &mut params,
+            "updated_at",
+            false,
+            Some("2025-03-01"),
+        );
+        sql.push_str(" ORDER BY updated_at");
+
+        let mut stmt = conn.prepare(&sql).unwrap();
+        let rows: Vec<String> = stmt
+            .query_map(rusqlite::params_from_iter(params.iter()), |row| row.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                "2025-03-01".to_owned(),
+                "2025-03-01T00:00:00+00:00".to_owned(),
+                "2025-03-01T12:00:00+00:00".to_owned(),
+                "2025-03-02T00:00:00+00:00".to_owned(),
+            ]
+        );
     }
 }

--- a/src/storage/filter.rs
+++ b/src/storage/filter.rs
@@ -303,11 +303,9 @@ pub fn append_date_string_cutoff_filter(
 ///   already sorts correctly against the bare date).
 ///
 /// Intended for SQLite `TEXT` columns storing RFC 3339 timestamps such as
-/// `"2025-03-01T12:00:00+00:00"`. The `+1 day` arithmetic is delegated to
-/// SQLite's `date()`, so callers only bind a `%Y-%m-%d` string — no Rust-side
-/// date math is required. Use [`append_date_string_cutoff_filter`] when the
-/// column is guaranteed to be date-only; the plain `<= ?` comparison there is
-/// sufficient and avoids the `date()` call.
+/// `"2025-03-01T12:00:00+00:00"`. Use [`append_date_string_cutoff_filter`]
+/// when the column is guaranteed to be date-only (plain `<= ?` suffices), or
+/// [`append_timestamp_cutoff_filter`] for integer millisecond columns.
 ///
 /// See [`append_eq_filter`] for the `column` security contract.
 pub fn append_timestamp_day_cutoff_filter(
@@ -835,10 +833,7 @@ mod tests {
     }
 
     // T-053: append_timestamp_day_cutoff_filter_day_inclusive_on_rfc3339_via_sqlite
-    // End-to-end: the helper must treat `--before 2025-03-01` as "on or before
-    // 2025-03-01", including RFC 3339 rows that fall anywhere within the
-    // boundary day. Verifies `date(?, '+1 day')` lifts the upper bound past
-    // the T-suffix timestamps that would otherwise sort after `"2025-03-01"`.
+    // Locks in that `date(?, '+1 day')` lifts the upper bound past T-suffix rows.
     #[test]
     fn append_timestamp_day_cutoff_filter_day_inclusive_on_rfc3339_via_sqlite() {
         let conn = rusqlite::Connection::open_in_memory().unwrap();
@@ -886,10 +881,7 @@ mod tests {
     }
 
     // T-054: append_timestamp_day_cutoff_filter_before_false_start_inclusive_on_rfc3339_via_sqlite
-    // End-to-end for `before = false`. The helper relies on RFC 3339 prefix
-    // sorting against a bare `YYYY-MM-DD` lower bound, so the boundary day
-    // must include both the bare date and every T-suffix value of that day
-    // while excluding the preceding day's final timestamp.
+    // Locks in that RFC 3339 prefix sort against a bare `YYYY-MM-DD` lower bound works.
     #[test]
     fn append_timestamp_day_cutoff_filter_before_false_start_inclusive_on_rfc3339_via_sqlite() {
         let conn = rusqlite::Connection::open_in_memory().unwrap();


### PR DESCRIPTION
## Summary

- Closes #20
- `append_timestamp_day_cutoff_filter` ヘルパーを `src/storage/filter.rs` に新設。RFC 3339 タイムスタンプ列に対して day-inclusive な日付カットオフ SQL 条件を追加する
- SQLite 組み込みの `date()` 関数で `+1 day` 計算をクエリ側に閉じることで、caller 側での Rust date math を不要にする

## 変更内容

- **`append_timestamp_day_cutoff_filter` を新設** — `before = true` のとき `{col} < date(?, '+1 day')` を生成し境界日を包含。`<= "YYYY-MM-DD"` 比較では RFC 3339 の T-suffix 付き値（例: `2025-03-01T12:00:00+00:00`）が境界日に落ちるバグを SQLite の `date()` 関数で解消する
- **`before = false` の end-to-end 検証を追加（T-054）** — `{col} >= ?` が RFC 3339 prefix sort に正しく依拠することを SQLite 実行レベルで検証
- **doc の相互参照を整理** — 既存の `append_date_string_cutoff_filter`（date-only TEXT 列向け）・`append_timestamp_cutoff_filter`（integer ms 列向け）との棲み分けを doc コメントの nav リンクで明示
- **`pub use` 漏れを修正（REUSE-002）** — `src/storage.rs` からのエクスポートを補完
- **`libc` 0.2.185 → 0.2.186** — `Cargo.lock` の依存更新のみ、別コミット化

## スコープ

- **含まない**: `EXPLAIN QUERY PLAN` による index range scan への影響確認 — 実 index を持つ sae 側で実施予定（フォローアップ参照）

## 設計の判断

- **`date(?, '+1 day')` を SQL 側に閉じる** — Rust の `succ_opt()` 等を caller に要求せず、helper 内で完結させる。同じ知識がテスト済みの共有 crate に lock-in されることで sae/yomu/recall の再利用コストを下げる
- **`before = false` は `>=` のみ** — RFC 3339 文字列は辞書順と時系列順が一致するため、date() ラップは不要

## テスト方法

- [ ] `cargo test --lib` を実行し 115/115 が passed であることを確認
- [ ] `cargo clippy --lib --tests -- -D warnings` で 0 warnings であることを確認
- [ ] T-050 〜 T-054 の 5 テストが `filter::tests` モジュール内に存在することを確認
- [ ] T-054（`before = false` の SQLite 実行検証）が境界日当日・翌日・前日の 3 ケースをカバーしていることを確認

## フォローアップ

- **sae #73**: `updated_at` フィルタを `append_date_string_cutoff_filter` から本 helper に差し替える方針に更新。現状の実装は境界日の T-suffix 投稿が落ちるバグが存在するため
- **EXPLAIN QUERY PLAN 検証**: `date(?, '+1 day')` が index range scan を阻害しないかの確認は、実 index を持つ sae 側で実施予定

## 関連

Closes #20
