### PR TITLE
chore(ci): rust-cache を v2.9.1 / rust-toolchain stable SHA を最新化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
           components: clippy, rustfmt
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Check
         run: cargo check
@@ -54,12 +54,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-targets: false
 


### PR DESCRIPTION
## 概要

- GitHub Actions runner が Node.js 20 を deprecate したため、Node.js 24 対応版の `Swatinem/rust-cache` v2.9.1 に更新
- `dtolnay/rust-toolchain@stable` の SHA も最新化（stable は mutable branch のため定期リピンが必要）
- `actions/checkout@v6.0.2` は既に最新のため変更なし

## 変更内容

| Action | Before | After |
| --- | --- | --- |
| `Swatinem/rust-cache` | `9d47c6ad...` (v2.7.8) | `c19371144d...` (v2.9.1) |
| `dtolnay/rust-toolchain` | `56f84321...` (stable) | `29eef336d9...` (stable 最新) |

Cargo.toml の `rust-version = "1.95"` は既に設定済みで、CI は `toolchain: stable` 指定なので自動的に最新 stable (現 1.95.0) で走る。

## 動作確認

- [ ] `test` ジョブ (macos-latest): check / test / test --all-features / clippy / fmt が通る
- [ ] `security` ジョブ (ubuntu-latest): cargo deny / cargo audit が通る
- [ ] Node.js 20 deprecation warning が CI ログから消える