### PR TITLE
dependabot を有効化して github-actions / cargo の自動更新を受ける

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: chore
+      include: scope
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - rust
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      patch-and-minor:
+        update-types:
+          - minor
+          - patch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1930,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]


### PR DESCRIPTION
dependabot が設定されていないため、github-actions や cargo 依存のバージョンが手動更新に依存していた。自動更新を受けることで、パッチ・マイナー更新の追跡コストを下げる。

Closes #23

## 変更内容

- `.github/dependabot.yml` を新規追加
  - `github-actions`: weekly 監視、ラベル `dependencies` / `ci`
  - `cargo`: weekly 監視、ラベル `dependencies` / `rust`、minor/patch は `patch-and-minor` グループで 1 PR にまとめる (major は個別 PR)
  - commit-message prefix は `chore`
- `Cargo.lock` を更新 (`cc` 1.2.60 → 1.2.61, `rustls-pki-types` 1.14.0 → 1.14.1)
  - `cargo build` 実行時に解決された transitive patch update。breaking 変更なし

## 検証

- `cargo build` 成功
- `cargo test storage::fts`: 5 件 pass
- `cargo outdated`: All dependencies are up to date