### PR TITLE
rurico rev を ef26de2 に bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "daachorse"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,7 +1916,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=7d668ab#7d668abf5ff7da9c0381483bf1f700d7938d4563"
+source = "git+https://github.com/thkt/rurico?rev=ef26de2#ef26de21cf0ef3d50f8c6dfbc8b06cf65bab0e16"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -1930,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=7d668ab#7d668abf5ff7da9c0381483bf1f700d7938d4563"
+source = "git+https://github.com/thkt/rurico?rev=ef26de2#ef26de21cf0ef3d50f8c6dfbc8b06cf65bab0e16"
 dependencies = [
  "mlx-sys",
  "rusqlite",
@@ -2442,13 +2448,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.22.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
 dependencies = [
  "ahash",
- "aho-corasick",
  "compact_str",
+ "daachorse",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ required-features = ["eval-harness"]
 [dependencies]
 rand               = "0.10"
 rand_chacha        = "0.10"
-rurico             = { git = "https://github.com/thkt/rurico", rev = "7d668ab" }
+rurico             = { git = "https://github.com/thkt/rurico", rev = "ef26de2" }
 rusqlite           = { version = "0.39", features = ["bundled"] }
 serde              = { version = "1", features = ["derive"] }
 serde_json         = "1"
@@ -28,7 +28,7 @@ tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico      = { git = "https://github.com/thkt/rurico", rev = "7d668ab", features = ["test-support"] }
+rurico      = { git = "https://github.com/thkt/rurico", rev = "ef26de2", features = ["test-support"] }
 serial_test = "3"
 tempfile    = "3"
 


### PR DESCRIPTION
## 概要

rurico の git rev を origin/main HEAD (`ef26de2`) に bump。ADR ディレクトリ整理、eval-harness 削除 (#27 で amici へ移譲済み)、tokenizers 0.22→0.23 を取り込む。

## 変更内容

- `Cargo.toml`: rurico rev `7d668ab` → `ef26de2` (`[dependencies]` / `[dev-dependencies]` 両方)
- `Cargo.lock`: tokenizers 0.22.2 → 0.23.1、daachorse v1.0.1 (transitive) 追加

## 検証手順

1. `cargo test --lib` → 119 passed / 0 failed
2. `cargo clippy --all-targets --all-features -- -D warnings` → clean
3. `cargo fmt -- --check` → pass