### PR TITLE
chore(ci): pre-commit hook + clippy --all-targets (yomu #148 横展開)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,21 @@
+#!/bin/sh
+# amici pre-commit hook: enforce fmt + clippy --all-targets before commit.
+#
+# Install (one-time per clone):
+#   git config --local core.hooksPath .githooks
+#
+# Skip for one commit:
+#   git commit --no-verify
+
+set -e
+
+# Only run when Rust / config / CI files are staged (covers add, modify, delete, rename).
+if git diff --cached --name-only | grep -qE '\.rs$|Cargo\.(toml|lock)$|\.github/'; then
+    echo "▶ pre-commit: cargo fmt -- --check"
+    cargo fmt -- --check
+
+    echo "▶ pre-commit: cargo clippy --all-targets --all-features -- -D warnings"
+    cargo clippy --all-targets --all-features -- -D warnings
+
+    echo "✔ pre-commit checks passed"
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: cargo test --all-features
 
       - name: Clippy
-        run: cargo clippy --all-features -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Format check
         run: cargo fmt -- --check

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,43 @@
+# amici
+
+sae/yomu/recall ツールチェーンで共有するモデルローディング、ストレージヘルパー、CLI ユーティリティ。
+
+## モジュール
+
+| Module | Contents |
+| ------ | -------- |
+| `model` | `DegradedReason`, `degraded_reason_user_note`, `ModelLoad<T>`, `ModelDownloadError`, `download_and_verify_model` |
+| `model::embedder` | `try_load_embedder_with` — エンベディングモデルをロード |
+| `model::reranker` | `try_load_reranker_with` — リランキングモデルをロード |
+| `storage` | `in_placeholders`, `anon_placeholders`, `as_sql_params`, `append_eq_filter` |
+| `cli` | `Spinner`, `with_spinner`, `try_expand_shorthand` |
+| `migration` | `notify_schema_change` — スキーマクリア通知用の `tracing::warn!` 統一実装 |
+| `logging` | `init_subscriber` — `RUST_LOG` 対応の `tracing_subscriber::fmt` 初期化（CLI `main.rs` 用） |
+
+## 使い方
+
+```toml
+[dependencies]
+amici = { git = "https://github.com/thkt/amici", rev = "<rev>" }
+```
+
+## 開発
+
+### セットアップ
+
+リポジトリを clone したら一度だけ実行してください：
+
+```sh
+git config --local core.hooksPath .githooks
+```
+
+これで `git commit` 時に `cargo fmt --check` と `cargo clippy --all-targets --all-features -- -D warnings` が自動で走ります。違反があれば commit は中止されます。一時的にスキップしたい場合は `git commit --no-verify`。
+
+### よく使うコマンド
+
+```sh
+just check                                                # test + lint + fmt-check
+cargo test --all-features                                 # tests only
+cargo clippy --all-targets --all-features -- -D warnings  # lint（CI と同条件）
+cargo fmt -- --check                                      # フォーマット検査
+```

--- a/README.md
+++ b/README.md
@@ -20,3 +20,24 @@ Shared model-loading, storage helpers, and CLI utilities for the sae/yomu/recall
 [dependencies]
 amici = { git = "https://github.com/thkt/amici", rev = "<rev>" }
 ```
+
+## Development
+
+### Setup
+
+Run once after cloning:
+
+```sh
+git config --local core.hooksPath .githooks
+```
+
+This installs a pre-commit hook that runs `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` before each commit. Violations abort the commit. To skip for one commit: `git commit --no-verify`.
+
+### Common commands
+
+```sh
+just check                                                # test + lint + fmt-check
+cargo test --all-features                                 # tests only
+cargo clippy --all-targets --all-features -- -D warnings  # lint (matches CI)
+cargo fmt -- --check                                      # format check
+```


### PR DESCRIPTION
## 概要

- CI Clippy step に \`--all-targets\` を追加（test / integration / example target も lint 対象化）
- \`.githooks/pre-commit\` を導入（commit 前に \`cargo fmt --check\` + \`cargo clippy --all-targets --all-features -- -D warnings\` 強制）
- README.md / README.ja.md（新規）に Development section を追加（Setup + Common commands）

yomu #148 の横展開。Issue #35 を解消する。

## 背景

amici の \`[lints.clippy]\` は元々 strict だが、CI Clippy step が \`cargo clippy --all-features -- -D warnings\` で \`--all-targets\` 抜けやったため、test target の lint が CI で素通りしていた。yomu の \`/audit 2026-04-30\` で同型の構造的欠陥が判明し、PR thkt/yomu#148 で修正済み。amici / sae / recall も同様の対応が必要。

## 補足

- ローカル \`cargo clippy --all-targets --all-features -- -D warnings\` は **既存違反ゼロ**（yomu と違い事前修正不要）
- pre-commit hook は yomu 最終版（5949b21 適用後の \`--diff-filter\` 削除版）を採用 — delete/rename commit の素通りを防ぐ
- main branch protection は本 PR マージ後に別途 \`gh api -X PUT\` で適用（test/security を required status checks に設定、yomu と同一構成）

## テスト計画

- [ ] CI が green（test / security 両方）
- [ ] ローカルで \`git config --local core.hooksPath .githooks\` → 適当な \`.rs\` ファイル staged → \`git commit\` で hook 発火を確認
- [ ] マージ後に \`gh api -X PUT repos/thkt/amici/branches/main/protection\` で main protection 適用

Closes #35