### PR TITLE
feat(storage): query_helpers モジュール追加（collect_rows + fetch_by_in_clause）

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -9,7 +9,8 @@ sae/yomu/recall ツールチェーンで共有するモデルローディング�
 | `model` | `DegradedReason`, `degraded_reason_user_note`, `ModelLoad<T>`, `ModelDownloadError`, `download_and_verify_model` |
 | `model::embedder` | `try_load_embedder_with` — エンベディングモデルをロード |
 | `model::reranker` | `try_load_reranker_with` — リランキングモデルをロード |
-| `storage` | `in_placeholders`, `anon_placeholders`, `as_sql_params`, `append_eq_filter` |
+| `storage::filter` | `in_placeholders`, `anon_placeholders`, `as_sql_params`, `append_eq_filter`, … — SQL `WHERE` 句とパラメータの構築ヘルパー |
+| `storage::query_helpers` | `collect_rows`, `fetch_by_in_clause` — `Connection` を取って行を回収する実行系ヘルパー（コレクション型・エラー型を generic にサポート） |
 | `cli` | `Spinner`, `with_spinner`, `try_expand_shorthand` |
 | `migration` | `notify_schema_change` — スキーマクリア通知用の `tracing::warn!` 統一実装 |
 | `logging` | `init_subscriber` — `RUST_LOG` 対応の `tracing_subscriber::fmt` 初期化（CLI `main.rs` 用） |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Shared model-loading, storage helpers, and CLI utilities for the sae/yomu/recall
 | `model` | `DegradedReason`, `degraded_reason_user_note`, `ModelLoad<T>`, `ModelDownloadError`, `download_and_verify_model` |
 | `model::embedder` | `try_load_embedder_with` — loads the embedding model |
 | `model::reranker` | `try_load_reranker_with` — loads the reranking model |
-| `storage` | `in_placeholders`, `anon_placeholders`, `as_sql_params`, `append_eq_filter` |
+| `storage::filter` | `in_placeholders`, `anon_placeholders`, `as_sql_params`, `append_eq_filter`, … — SQL `WHERE` clause and parameter builders |
+| `storage::query_helpers` | `collect_rows`, `fetch_by_in_clause` — `Connection`-bound row collectors and IN-clause bulk fetch (generic over collection and error type) |
 | `cli` | `Spinner`, `with_spinner`, `try_expand_shorthand` |
 | `migration` | `notify_schema_change` — unified `tracing::warn!` for schema-clear notices |
 | `logging` | `init_subscriber` — `RUST_LOG`-aware `tracing_subscriber::fmt` setup for CLI `main.rs` |

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,5 +1,6 @@
 pub mod filter;
 pub mod fts;
+pub mod query_helpers;
 
 pub use filter::{
     anon_placeholders, append_date_string_cutoff_filter, append_eq_filter, append_exclude_ids,
@@ -7,3 +8,4 @@ pub use filter::{
     append_timestamp_cutoff_filter, append_timestamp_day_cutoff_filter, as_sql_params, escape_like,
     in_placeholders, like_prefix_match,
 };
+pub use query_helpers::{collect_rows, fetch_by_in_clause};

--- a/src/storage/query_helpers.rs
+++ b/src/storage/query_helpers.rs
@@ -1,0 +1,276 @@
+//! Connection-bound row collectors and bulk-fetch helpers.
+//!
+//! Where [`crate::storage::filter`] builds the `WHERE` clause text and
+//! parameter list, this module owns the *execution* side — taking a
+//! [`rusqlite::Connection`], running a prepared statement, and collecting
+//! rows into the caller's chosen collection type.
+//!
+//! Both helpers are generic over `E: From<rusqlite::Error>`, so they
+//! integrate with `thiserror` enums that wrap `rusqlite::Error` via
+//! `#[from]`, as well as with `anyhow::Error` (which provides
+//! `From<rusqlite::Error>` out of the box) and `rusqlite::Error` itself.
+
+use std::iter;
+
+use rusqlite::{Connection, Row, types::ToSql};
+
+use crate::storage::filter::{anon_placeholders, as_sql_params};
+
+/// Collects an iterator of `Result<T, rusqlite::Error>` into any
+/// [`FromIterator`]-implementing collection.
+///
+/// Replaces the recurring `rows.collect::<Result<C, _>>().map_err(Into::into)`
+/// pattern at row-collection sites.
+///
+/// # Examples
+///
+/// Use within a function whose return type fixes `E`. The compiler infers
+/// `E` from the surrounding `Result<_, E>`, so callers never write the
+/// turbofish themselves:
+///
+/// ```
+/// use amici::storage::collect_rows;
+/// use rusqlite::Connection;
+///
+/// #[derive(Debug, thiserror::Error)]
+/// enum AppError {
+///     #[error(transparent)]
+///     Db(#[from] rusqlite::Error),
+/// }
+///
+/// fn load_ids(conn: &Connection) -> Result<Vec<i64>, AppError> {
+///     let mut stmt = conn.prepare("SELECT id FROM t ORDER BY id")?;
+///     let rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
+///     collect_rows(rows)
+/// }
+///
+/// let conn = Connection::open_in_memory().unwrap();
+/// conn.execute("CREATE TABLE t (id INTEGER)", []).unwrap();
+/// conn.execute("INSERT INTO t VALUES (1), (2), (3)", []).unwrap();
+/// assert_eq!(load_ids(&conn).unwrap(), vec![1, 2, 3]);
+/// ```
+///
+/// # Errors
+///
+/// Returns the first row error encountered during collection, converted into
+/// `E` via [`From<rusqlite::Error>`].
+pub fn collect_rows<I, T, C, E>(rows: I) -> Result<C, E>
+where
+    I: Iterator<Item = Result<T, rusqlite::Error>>,
+    C: FromIterator<T>,
+    E: From<rusqlite::Error>,
+{
+    rows.collect::<Result<C, _>>().map_err(Into::into)
+}
+
+/// Runs a SQL `IN ({placeholders})` query against `keys` and collects rows
+/// into any [`FromIterator`]-implementing collection.
+///
+/// `sql_template` must contain the literal token `{placeholders}`, which is
+/// replaced with anonymous `?, ?, ?` matching `keys.len()` before
+/// [`Connection::prepare`]. When `keys.is_empty()`, no SQL is executed and
+/// an empty `C` is returned — this also avoids SQLite's syntax error on
+/// `IN ()`.
+///
+/// # Examples
+///
+/// Bulk-fetch a name lookup keyed by primary key. `E` is inferred from the
+/// enclosing function's return type:
+///
+/// ```
+/// use std::collections::HashMap;
+/// use amici::storage::fetch_by_in_clause;
+/// use rusqlite::Connection;
+///
+/// #[derive(Debug, thiserror::Error)]
+/// enum AppError {
+///     #[error(transparent)]
+///     Db(#[from] rusqlite::Error),
+/// }
+///
+/// fn load_names(conn: &Connection, ids: &[i64]) -> Result<HashMap<i64, String>, AppError> {
+///     fetch_by_in_clause(
+///         conn,
+///         ids,
+///         "SELECT id, name FROM t WHERE id IN ({placeholders})",
+///         |row| Ok((row.get(0)?, row.get(1)?)),
+///     )
+/// }
+///
+/// let conn = Connection::open_in_memory().unwrap();
+/// conn.execute("CREATE TABLE t (id INTEGER, name TEXT)", []).unwrap();
+/// conn.execute("INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')", []).unwrap();
+/// let map = load_names(&conn, &[1, 3]).unwrap();
+/// assert_eq!(map[&1], "a");
+/// assert_eq!(map[&3], "c");
+/// assert!(!map.contains_key(&2));
+/// ```
+///
+/// # Errors
+///
+/// Returns any error from [`Connection::prepare`],
+/// [`rusqlite::Statement::query_map`], or row collection, converted into `E`
+/// via [`From<rusqlite::Error>`].
+pub fn fetch_by_in_clause<P, T, C, E, F>(
+    conn: &Connection,
+    keys: &[P],
+    sql_template: &str,
+    map_row: F,
+) -> Result<C, E>
+where
+    P: ToSql,
+    F: FnMut(&Row<'_>) -> Result<T, rusqlite::Error>,
+    C: FromIterator<T>,
+    E: From<rusqlite::Error>,
+{
+    if keys.is_empty() {
+        return Ok(iter::empty::<T>().collect());
+    }
+    let placeholders = anon_placeholders(keys.len());
+    let sql = sql_template.replace("{placeholders}", &placeholders);
+    let mut stmt = conn.prepare(&sql).map_err(E::from)?;
+    let params = as_sql_params(keys);
+    let rows = stmt
+        .query_map(params.as_slice(), map_row)
+        .map_err(E::from)?;
+    rows.collect::<Result<C, _>>().map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use rusqlite::Connection;
+
+    use super::*;
+
+    #[derive(Debug, thiserror::Error)]
+    enum TestError {
+        #[error("db: {0}")]
+        Db(#[from] rusqlite::Error),
+    }
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute("CREATE TABLE t (id INTEGER, name TEXT)", [])
+            .unwrap();
+        conn.execute("INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')", [])
+            .unwrap();
+        conn
+    }
+
+    // T-055: collect_rows_empty_iterator_returns_empty_collection
+    #[test]
+    fn collect_rows_empty_iterator_returns_empty_collection() {
+        let rows: iter::Empty<Result<i64, rusqlite::Error>> = iter::empty();
+        let v: Vec<i64> = collect_rows::<_, _, _, rusqlite::Error>(rows).unwrap();
+        assert!(v.is_empty());
+    }
+
+    // T-056: collect_rows_collects_vec_from_query_map
+    #[test]
+    fn collect_rows_collects_vec_from_query_map() {
+        let conn = setup_db();
+        let mut stmt = conn.prepare("SELECT id FROM t ORDER BY id").unwrap();
+        let rows = stmt.query_map([], |row| row.get::<_, i64>(0)).unwrap();
+        let ids: Vec<i64> = collect_rows::<_, _, _, rusqlite::Error>(rows).unwrap();
+        assert_eq!(ids, vec![1, 2, 3]);
+    }
+
+    // T-057: collect_rows_collects_hash_map_from_query_map
+    #[test]
+    fn collect_rows_collects_hash_map_from_query_map() {
+        let conn = setup_db();
+        let mut stmt = conn.prepare("SELECT id, name FROM t").unwrap();
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+            })
+            .unwrap();
+        let map: HashMap<i64, String> = collect_rows::<_, _, _, rusqlite::Error>(rows).unwrap();
+        assert_eq!(map.len(), 3);
+        assert_eq!(map[&1], "a");
+        assert_eq!(map[&2], "b");
+        assert_eq!(map[&3], "c");
+    }
+
+    // T-058: collect_rows_propagates_error_via_from_impl
+    #[test]
+    fn collect_rows_propagates_error_via_from_impl() {
+        let conn = setup_db();
+        // 'name' column is TEXT; reading it as i64 forces a type-mismatch
+        // error per row, exercising the From<rusqlite::Error> conversion.
+        let mut stmt = conn.prepare("SELECT name FROM t").unwrap();
+        let rows = stmt.query_map([], |row| row.get::<_, i64>(0)).unwrap();
+        let result: Result<Vec<i64>, TestError> = collect_rows(rows);
+        assert!(
+            matches!(result, Err(TestError::Db(_))),
+            "expected TestError::Db, got: {result:?}"
+        );
+    }
+
+    // T-059: fetch_by_in_clause_empty_keys_returns_empty_collection_without_sql
+    #[test]
+    fn fetch_by_in_clause_empty_keys_returns_empty_collection_without_sql() {
+        let conn = setup_db();
+        // Invalid SQL — if the early return doesn't fire, prepare will error.
+        let keys: &[i64] = &[];
+        let map: HashMap<i64, String> = fetch_by_in_clause::<_, _, _, rusqlite::Error, _>(
+            &conn,
+            keys,
+            "this is not valid SQL {placeholders}",
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+        assert!(map.is_empty());
+    }
+
+    // T-060: fetch_by_in_clause_non_empty_keys_collects_hash_map
+    #[test]
+    fn fetch_by_in_clause_non_empty_keys_collects_hash_map() {
+        let conn = setup_db();
+        let keys: &[i64] = &[1, 3];
+        let map: HashMap<i64, String> = fetch_by_in_clause::<_, _, _, rusqlite::Error, _>(
+            &conn,
+            keys,
+            "SELECT id, name FROM t WHERE id IN ({placeholders})",
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+        assert_eq!(map.len(), 2);
+        assert_eq!(map[&1], "a");
+        assert_eq!(map[&3], "c");
+        assert!(!map.contains_key(&2));
+    }
+
+    // T-061: fetch_by_in_clause_partial_match_returns_only_existing_rows
+    #[test]
+    fn fetch_by_in_clause_partial_match_returns_only_existing_rows() {
+        let conn = setup_db();
+        // 5 keys, only 2 match.
+        let keys: &[i64] = &[1, 99, 2, 100, 101];
+        let set: HashSet<i64> = fetch_by_in_clause::<_, _, _, rusqlite::Error, _>(
+            &conn,
+            keys,
+            "SELECT id FROM t WHERE id IN ({placeholders})",
+            |row| row.get(0),
+        )
+        .unwrap();
+        assert_eq!(set, HashSet::from([1, 2]));
+    }
+
+    // T-062: fetch_by_in_clause_invalid_template_propagates_prepare_error
+    #[test]
+    fn fetch_by_in_clause_invalid_template_propagates_prepare_error() {
+        let conn = setup_db();
+        let keys: &[i64] = &[1];
+        let result: Result<Vec<(i64, String)>, TestError> =
+            fetch_by_in_clause(&conn, keys, "INVALID SQL {placeholders}", |row| {
+                Ok((row.get(0)?, row.get(1)?))
+            });
+        assert!(
+            matches!(result, Err(TestError::Db(_))),
+            "expected TestError::Db, got: {result:?}"
+        );
+    }
+}

--- a/src/storage/query_helpers.rs
+++ b/src/storage/query_helpers.rs
@@ -12,9 +12,9 @@
 
 use std::iter;
 
-use rusqlite::{Connection, Row, types::ToSql};
+use rusqlite::{Connection, Row, params_from_iter, types::ToSql};
 
-use crate::storage::filter::{anon_placeholders, as_sql_params};
+use crate::storage::filter::anon_placeholders;
 
 /// Collects an iterator of `Result<T, rusqlite::Error>` into any
 /// [`FromIterator`]-implementing collection.
@@ -60,7 +60,7 @@ where
     C: FromIterator<T>,
     E: From<rusqlite::Error>,
 {
-    rows.collect::<Result<C, _>>().map_err(Into::into)
+    rows.collect::<Result<C, _>>().map_err(E::from)
 }
 
 /// Runs a SQL `IN ({placeholders})` query against `keys` and collects rows
@@ -110,7 +110,11 @@ where
 ///
 /// Returns any error from [`Connection::prepare`],
 /// [`rusqlite::Statement::query_map`], or row collection, converted into `E`
-/// via [`From<rusqlite::Error>`].
+/// via [`From<rusqlite::Error>`]. In particular, [`Connection::prepare`]
+/// fails when `keys.len()` exceeds SQLite's `SQLITE_MAX_VARIABLE_NUMBER`
+/// (default 32766 in SQLite ≥ 3.32.0, 999 in older builds). The caller is
+/// responsible for chunking larger key sets — this helper does not split
+/// internally.
 pub fn fetch_by_in_clause<P, T, C, E, F>(
     conn: &Connection,
     keys: &[P],
@@ -129,11 +133,10 @@ where
     let placeholders = anon_placeholders(keys.len());
     let sql = sql_template.replace("{placeholders}", &placeholders);
     let mut stmt = conn.prepare(&sql).map_err(E::from)?;
-    let params = as_sql_params(keys);
     let rows = stmt
-        .query_map(params.as_slice(), map_row)
+        .query_map(params_from_iter(keys.iter()), map_row)
         .map_err(E::from)?;
-    rows.collect::<Result<C, _>>().map_err(Into::into)
+    collect_rows(rows)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 概要

`amici::storage::query_helpers` を新設し、yomu / sae / recall の storage 層で重複している以下のパターンを上流化する。Issue #33 を解消。

- `collect_rows<I, T, C, E>`: `Iterator<Item = Result<T, rusqlite::Error>>` を任意の \`FromIterator\` 実装型（\`Vec\` / \`HashMap\` / \`HashSet\` / \`BTreeMap\` / \`BTreeSet\`）に集約
- `fetch_by_in_clause<P, T, C, E, F>`: \`IN ({placeholders})\` クエリを \`keys: &[P]\` に対して実行、empty キーは SQL を実行せず early return

両者とも \`E: From<rusqlite::Error>\` で generic、yomu/sae の \`thiserror\` enum (\`#[from]\`)、recall の \`anyhow::Error\`、\`rusqlite::Error\` 直接、すべて整合する。

## 背景

yomu \`/audit 2026-04-30\` の RC-005（thkt/yomu#144）として抽出された下流共通パターン。amici が既に同領域の SQL builder helper（\`anon_placeholders\`, \`as_sql_params\`, \`append_eq_filter\` 等）を提供しているので、execution side の helper も上流化するのが自然。

調査の結果、key 型は yomu (\`&str\`)・sae (\`i64\`/\`u32\`)・recall (\`String\`) と三者三様、戻り値型も \`HashMap\`・\`HashSet\`・\`Vec\` バラバラだったため、当初案の \`fetch_by_paths<&[&str], HashMap<String, V>>\` 限定から \`P: ToSql\` + \`C: FromIterator<T>\` の generic 設計へ拡張した。命名も \`fetch_by_paths\` → \`fetch_by_in_clause\` に変更（path 文脈に縛らない）。

## 補足

### カバー範囲（下流移行候補、本 PR では実施しない）

| repo   | collect_rows 適用 | fetch_by_in_clause 適用 |
| ------ | ----------------- | ----------------------- |
| yomu   | ~16 sites         | 2 sites                 |
| sae    | ~5 sites          | 2 sites                 |
| recall | ~2 sites          | 0-1 sites               |

→ 計 **27 sites** 上流化候補。**下流側の callsite 移行は別 PR**（scope discipline）。

### 副作用

sae \`existing_embedded_ids\` の empty check 不在バグ（\`IN ()\` で SQLite syntax error）を \`fetch_by_in_clause\` の early return が修正する形になる。

### 対象外（個別実装維持）

- yomu \`get_file_siblings\`（one-to-many HashMap、map_row が \`(K, V)\` の前提と合わない）
- yomu \`get_edges_among_files\` / sae \`rechunk_post\`（IN-clause 2 個で同じ params を 2 倍 extend する特殊形）
- recall \`fetch_session_metadata\`（per-row error handling: 失敗行をスキップして count、fail-fast と方針が違う）

### レビュー反映済み

\`/polish\` で CodeRabbit + Codex + simplify trio + enhancer-code を並列実行。

| 採用                                                            | 出元              |
| --------------------------------------------------------------- | ----------------- |
| \`as_sql_params\` → \`params_from_iter(keys.iter())\` で zero-alloc | efficiency low   |
| \`SQLITE_MAX_VARIABLE_NUMBER\` 制限を \`# Errors\` に明記         | efficiency medium |
| \`Into::into\` / \`E::from\` を \`E::from\` で統一                | readability low + clippy useless_conversion 回避 |
| \`fetch_by_in_clause\` 末尾で \`collect_rows\` 自身を再利用       | enhancer-code     |

## テスト計画

- [x] \`cargo test --all-features\`: query_helpers unit 8 件（T-055 〜 T-062）+ doctest 2 件 + 既存 全件 pass
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`: clean
- [x] \`cargo fmt -- --check\`: clean
- [ ] CI が green（test + security）

Closes #33