### PR TITLE
feat(cli): downstream CLI 共通の env_lookup と CliError を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Shared model-loading, storage helpers, and CLI utilities for the sae/yomu/recall
 | `model::reranker` | `try_load_reranker_with` — loads the reranking model |
 | `storage::filter` | `in_placeholders`, `anon_placeholders`, `as_sql_params`, `append_eq_filter`, … — SQL `WHERE` clause and parameter builders |
 | `storage::query_helpers` | `collect_rows`, `fetch_by_in_clause` — `Connection`-bound row collectors and IN-clause bulk fetch (generic over collection and error type) |
-| `cli` | `Spinner`, `with_spinner`, `try_expand_shorthand` |
+| `cli` | `Spinner`, `with_spinner`, `try_expand_shorthand`, `env_lookup`, `CliError`, `exit_code::codes` |
 | `migration` | `notify_schema_change` — unified `tracing::warn!` for schema-clear notices |
 | `logging` | `init_subscriber` — `RUST_LOG`-aware `tracing_subscriber::fmt` setup for CLI `main.rs` |
 
@@ -21,6 +21,140 @@ Shared model-loading, storage helpers, and CLI utilities for the sae/yomu/recall
 [dependencies]
 amici = { git = "https://github.com/thkt/amici", rev = "<rev>" }
 ```
+
+## CLI conventions
+
+### Dependency injection for env-var lookup
+
+CLIs that read environment variables in a constructor cannot be tested
+deterministically — `for_test` helpers silently bypass the env path, so the
+code that runs in production never sees a unit test. Split the constructor
+into `from_env()` and `from_env_with(impl Fn(&str) -> Option<String>)`, and
+use `amici::cli::env_lookup()` as the production lookup.
+
+**Before** (yomu `tools.rs`):
+
+```rust
+impl Yomu {
+    pub fn with_root(root: PathBuf, options: YomuOptions) -> Result<Self, YomuError> {
+        // ...
+        let embed_disabled = options.no_embed || env::var("YOMU_EMBED").as_deref() == Ok("0");
+        let rerank_enabled = env::var("YOMU_RERANK").as_deref() == Ok("1");
+        // ...
+    }
+}
+```
+
+**After**:
+
+```rust
+use amici::cli::env_lookup;
+
+pub struct YomuConfig {
+    pub embed_disabled: bool,
+    pub rerank_enabled: bool,
+}
+
+impl YomuConfig {
+    pub fn from_env() -> Self {
+        Self::from_env_with(env_lookup())
+    }
+    pub fn from_env_with<F: Fn(&str) -> Option<String>>(get: F) -> Self {
+        Self {
+            embed_disabled: get("YOMU_EMBED").as_deref() == Some("0"),
+            rerank_enabled: get("YOMU_RERANK").as_deref() == Some("1"),
+        }
+    }
+}
+
+impl Yomu {
+    pub fn with_root(root: PathBuf, options: YomuOptions, config: YomuConfig) -> Result<Self, YomuError> {
+        let embed_disabled = options.no_embed || config.embed_disabled;
+        // ...
+    }
+}
+```
+
+Tests then construct `YomuConfig` directly without touching process env:
+
+```rust
+let cfg = YomuConfig::from_env_with(|k| match k {
+    "YOMU_EMBED" => Some("0".into()),
+    _ => None,
+});
+```
+
+`env::var_os` (path resolution returning `OsString`) is out of scope — keep
+those as a separate factory if your CLI mixes both.
+
+`Option<String>` is the canonical signature for amici. Any pre-existing
+`from_env_with(impl Fn(&str) -> Result<String, VarError>)` site (sae has
+two: `EsaClient::from_env_with`, `data_dir_with`) is expected to be
+migrated to `Option<String>` during downstream rollout — `get(k).ok()`
+is the adapter when an existing site cannot move yet.
+
+### Exit code convention
+
+Implement `amici::cli::CliError` on the crate-level error enum so `main.rs`
+can call `e.exit_code()` directly instead of maintaining a hand-written
+`exit_code_for(&e)` helper. Distinct codes per variant let LLMs and shell
+scripts branch on retry policy.
+
+The `amici::cli::exit_code::codes` module exposes the
+[sysexits.h](https://man.openbsd.org/sysexits.3) convention as `u8` constants
+(see the module doc for why `u8` rather than `ExitCode`). These are
+**recommended, not required** — pick any schema that gives distinct codes
+per variant.
+
+**Before** (yomu `main.rs`):
+
+```rust
+fn exit_code_for(e: &YomuError) -> ExitCode {
+    match e {
+        YomuError::InvalidInput(_) => ExitCode::from(2),
+        YomuError::Internal(_) => ExitCode::from(4),
+        YomuError::Storage(_)
+        | YomuError::Io(_)
+        | YomuError::Index(_)
+        | YomuError::Query(_)
+        | YomuError::EmbedderUnavailable(_) => ExitCode::FAILURE, // collapsed
+    }
+}
+```
+
+**After**:
+
+```rust
+use amici::cli::CliError;
+use amici::cli::exit_code::codes;
+use std::process::ExitCode;
+
+impl CliError for YomuError {
+    fn exit_code(&self) -> ExitCode {
+        match self {
+            Self::InvalidInput(_)        => ExitCode::from(codes::USAGE),
+            Self::Internal(_)            => ExitCode::from(codes::SOFTWARE),
+            Self::Storage(_)             => ExitCode::from(codes::CANT_CREAT),
+            Self::Io(_)                  => ExitCode::from(codes::IO_ERR),
+            Self::Index(_)               => ExitCode::from(codes::CANT_CREAT),
+            Self::Query(_)               => ExitCode::from(codes::SOFTWARE),
+            Self::EmbedderUnavailable(_) => ExitCode::from(codes::TEMP_FAIL),
+        }
+    }
+}
+
+// main.rs
+return e.exit_code();
+```
+
+Document the chosen mapping in each CLI's README or `--help` output so callers
+can write deterministic retry logic.
+
+> **Migration note**: switching from a CLI's existing schema (e.g. yomu's
+> `2` / `4` / `FAILURE`) to sysexits constants changes the **numeric exit
+> codes** observed by callers (e.g. `2` → `64`, `4` → `70`). Shell scripts,
+> CI pipelines, and parent processes that branch on a specific number must
+> be updated. Announce the change in the CLI's release notes.
 
 ## Development
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,11 @@
+mod config;
+pub mod exit_code;
 mod message;
 mod shorthand;
 mod spinner;
 
+pub use config::env_lookup;
+pub use exit_code::CliError;
 pub use message::{deprecation_warn, exit_error, hint_arrow, info, progress_step};
 pub use shorthand::try_expand_shorthand;
 pub use spinner::{Spinner, done, embed_with_spinners, with_spinner};

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,0 +1,42 @@
+//! Factory for env-var lookup, used by `from_env_with` constructors.
+//!
+//! Constructors that read environment variables should split into two: a
+//! production `from_env()` that calls [`env_lookup()`], and a generic
+//! `from_env_with(impl Fn(&str) -> Option<String>)` that accepts the lookup
+//! as a parameter. Tests then pass a closure returning fixture values,
+//! removing global env state from the test path.
+//!
+//! ```no_run
+//! use amici::cli::env_lookup;
+//!
+//! pub struct Config {
+//!     pub flag: bool,
+//! }
+//!
+//! impl Config {
+//!     pub fn from_env() -> Self {
+//!         Self::from_env_with(env_lookup())
+//!     }
+//!     pub fn from_env_with<F: Fn(&str) -> Option<String>>(get: F) -> Self {
+//!         Self { flag: get("MY_FLAG").as_deref() == Some("1") }
+//!     }
+//! }
+//! ```
+
+use std::env::var;
+
+/// Returns the production env-var lookup: `std::env::var(k).ok()`.
+///
+/// Pair with `from_env_with(impl Fn(&str) -> Option<String>)` constructors.
+/// Tests pass their own closure (e.g. matching keys against a fixture map)
+/// instead of mutating process env.
+///
+/// # Examples
+///
+/// ```no_run
+/// let get = amici::cli::env_lookup();
+/// let _home = get("HOME");
+/// ```
+pub fn env_lookup() -> impl Fn(&str) -> Option<String> {
+    |k| var(k).ok()
+}

--- a/src/cli/exit_code.rs
+++ b/src/cli/exit_code.rs
@@ -1,0 +1,90 @@
+//! Exit code conventions for CLI binaries.
+//!
+//! Provides:
+//! - [`CliError`] trait — implement on the crate-level `Error` enum so
+//!   `main.rs` can call `e.exit_code()` directly.
+//! - [`codes`] module — `u8` constants for the
+//!   [sysexits.h](https://man.openbsd.org/sysexits.3) convention. Wrap with
+//!   `ExitCode::from(codes::USAGE)` at the call site (see *Why `u8`* below).
+//!
+//! These are **convention, not enforcement**. Each CLI is free to pick any
+//! distinct schema — the requirement is only "distinct codes per error variant
+//! so LLMs / scripts can branch on retry policy".
+//!
+//! # Why `u8` rather than `ExitCode` constants
+//!
+//! `ExitCode::from()` is not `const` (stable Rust 1.95), so
+//! `pub const USAGE: ExitCode` does not compile. Exposing `u8` keeps the
+//! constants usable in `const` contexts; convert at the call site.
+//!
+//! ```
+//! use amici::cli::exit_code::{CliError, codes};
+//! use std::process::ExitCode;
+//!
+//! enum MyError {
+//!     BadArgs,
+//!     IoFailure,
+//! }
+//!
+//! impl CliError for MyError {
+//!     fn exit_code(&self) -> ExitCode {
+//!         match self {
+//!             MyError::BadArgs => ExitCode::from(codes::USAGE),
+//!             MyError::IoFailure => ExitCode::from(codes::IO_ERR),
+//!         }
+//!     }
+//! }
+//! ```
+
+use std::process::ExitCode;
+
+/// Maps a CLI-facing error to a process exit code.
+///
+/// Implement on the crate-level `Error` enum (`YomuError`, `SaeError`, etc.)
+/// so `main.rs` can write `return e.exit_code();` directly, replacing
+/// hand-written `exit_code_for(&e)` helpers.
+pub trait CliError {
+    /// Returns the [`ExitCode`] this error should produce when it propagates
+    /// to the CLI entry point.
+    fn exit_code(&self) -> ExitCode;
+}
+
+/// `sysexits.h`-derived `u8` exit-code constants.
+///
+/// Convert with `ExitCode::from(codes::CONST)` — see the module doc for why
+/// these are `u8` rather than `ExitCode`.
+pub mod codes {
+    /// Successful termination.
+    pub const SUCCESS: u8 = 0;
+    /// `EX_USAGE`. Bad command-line usage (missing arg, unknown flag, etc.).
+    pub const USAGE: u8 = 64;
+    /// `EX_SOFTWARE`. Internal software error — invariant violated.
+    pub const SOFTWARE: u8 = 70;
+    /// `EX_CANTCREAT`. Cannot create a (user-visible) output file or path.
+    pub const CANT_CREAT: u8 = 73;
+    /// `EX_IOERR`. I/O error during operation.
+    pub const IO_ERR: u8 = 74;
+    /// `EX_TEMPFAIL`. Transient failure — retry may succeed (downloads,
+    /// optional models unavailable, etc.).
+    pub const TEMP_FAIL: u8 = 75;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::codes;
+
+    // sysexits.h reference values pinned here so a future refactor that
+    // touches `codes::*` fails visibly instead of silently breaking
+    // downstream CLIs that depend on these numbers.
+
+    // T-122: codes_match_sysexits_constants
+    #[test]
+    fn codes_match_sysexits_constants() {
+        assert_eq!(codes::SUCCESS, 0);
+        assert_eq!(codes::USAGE, 64);
+        assert_eq!(codes::SOFTWARE, 70);
+        assert_eq!(codes::CANT_CREAT, 73);
+        assert_eq!(codes::IO_ERR, 74);
+        assert_eq!(codes::TEMP_FAIL, 75);
+    }
+}


### PR DESCRIPTION
## 概要

issue #34 Phase 1 — amici 単独。

- `amici::cli::env_lookup()` factory: production の env-var lookup を返す `impl Fn(&str) -> Option<String>`。downstream CLI の `from_env_with(...)` constructor で DI に使う
- `amici::cli::CliError` trait + `amici::cli::exit_code::codes` module: sysexits.h ベースの `u8` 定数（推奨で必須でない）。各 CLI で error variant ごとに distinct な exit code を返せる
- README: `## CLI conventions` セクション追加。yomu の before/after で DI pattern と Exit code convention を提示、sae signature 統一と exit code 数値変化の migration note も併記

issue AC #1 の `EnvLookup` trait alias は採用見送り。bare `Fn(&str) -> Option<String>` bound で sae 既存 `from_env_with` と同形になる。signature 統一は trait machinery でなく README convention で担保。

Closes #34.

## 検証

- [x] `cargo test --all-features` — unit 130 + doctest 15 全 pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] レビュー — Codex (no blocking), CodeRabbit (0 findings), simplify trio (4 findings 適用), enhancer-code (0 changes)
- [ ] CI green
- [ ] merge 後: yomu / sae / recall に Phase 2 追従 issue を merged amici rev pin で作成