### PR TITLE
feat(logging): default filter に rurico=warn を merge

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -7,6 +7,12 @@ use std::io;
 
 use tracing_subscriber::EnvFilter;
 
+/// Default directive automatically merged into every CLI's filter so rurico's
+/// recoverable-anomaly warnings (embedder / reranker / model_probe degraded
+/// paths) are visible to operators by default. Callers can override via
+/// `RUST_LOG`.
+const RURICO_DEFAULT_DIRECTIVE: &str = "rurico=warn";
+
 /// Installs a `tracing_subscriber::fmt` subscriber that writes to stderr and
 /// reads its filter from `RUST_LOG`, falling back to `default_filter` when the
 /// environment variable is unset or unparseable.
@@ -25,6 +31,12 @@ use tracing_subscriber::EnvFilter;
 /// not preserved — callers who relied on implicit sae logs should export
 /// `RUST_LOG=sae=info` explicitly.
 ///
+/// `rurico=warn` is appended to `default_filter` so rurico's degraded-path
+/// warnings surface in operator logs without each downstream CLI having to
+/// opt in. Setting `RUST_LOG` overrides the merged default entirely; export
+/// `RUST_LOG=<crate>=<level>,rurico=warn` to keep the rurico directive while
+/// customizing the rest.
+///
 /// # Panics
 ///
 /// Panics if `default_filter` is not a valid
@@ -33,10 +45,19 @@ use tracing_subscriber::EnvFilter;
 /// [`tracing_subscriber::fmt::SubscriberBuilder::init`] installs the global
 /// default subscriber.
 pub fn init_subscriber(default_filter: &str) {
+    let merged = merge_default_directives(default_filter);
     tracing_subscriber::fmt()
         .with_writer(io::stderr)
-        .with_env_filter(resolve_env_filter(default_filter))
+        .with_env_filter(resolve_env_filter(&merged))
         .init();
+}
+
+fn merge_default_directives(default_filter: &str) -> String {
+    if default_filter.is_empty() {
+        RURICO_DEFAULT_DIRECTIVE.to_owned()
+    } else {
+        format!("{default_filter},{RURICO_DEFAULT_DIRECTIVE}")
+    }
 }
 
 fn resolve_env_filter(default_filter: &str) -> EnvFilter {
@@ -57,5 +78,29 @@ mod tests {
     #[test]
     fn resolve_env_filter_accepts_multi_directive() {
         let _filter = resolve_env_filter("sae=info,hyper=warn");
+    }
+
+    // T-023: merge_default_directives_appends_rurico_warn
+    #[test]
+    fn merge_default_directives_appends_rurico_warn() {
+        assert_eq!(
+            merge_default_directives("yomu=warn"),
+            "yomu=warn,rurico=warn"
+        );
+    }
+
+    // T-024: merge_default_directives_handles_empty_default
+    #[test]
+    fn merge_default_directives_handles_empty_default() {
+        assert_eq!(merge_default_directives(""), "rurico=warn");
+    }
+
+    // T-025: merge_default_directives_produces_parseable_filter
+    #[test]
+    fn merge_default_directives_produces_parseable_filter() {
+        let merged = merge_default_directives("sae=info,hyper=warn");
+        // EnvFilter::new panics on invalid directive; reaching the assertion
+        // proves the merged string parses cleanly.
+        drop(EnvFilter::new(&merged));
     }
 }


### PR DESCRIPTION
## 概要

issue #36 — amici 単独 (Phase 1 = amici / Phase 2 = recall rev bump 別 PR)。

- `init_subscriber` で `default_filter` 末尾に `rurico=warn` を自動 merge。rurico の degraded-path warn (embedder / reranker / model_probe の内部 recovery 経路) が下流 CLI の operator log に default で surface する
- `RUST_LOG` 設定時は環境変数を尊重 (既存挙動維持)
- rustdoc に migration note を追加

## 検証

- [x] `cargo test --all-features` — unit / integration / doctest 全 pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] CI green
- [ ] merge 後: recall の amici rev bump で acceptance criteria #4 (recall 再 build & 回帰なし) を消化