### PR TITLE
chore(logging): /polish レビュー反映 (rustdoc 重複排除 + T-025 try_new 化)

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -7,10 +7,8 @@ use std::io;
 
 use tracing_subscriber::EnvFilter;
 
-/// Default directive automatically merged into every CLI's filter so rurico's
-/// recoverable-anomaly warnings (embedder / reranker / model_probe degraded
-/// paths) are visible to operators by default. Callers can override via
-/// `RUST_LOG`.
+/// Default directive merged into every CLI's filter. See
+/// [`init_subscriber`] for the merge semantics and `RUST_LOG` interaction.
 const RURICO_DEFAULT_DIRECTIVE: &str = "rurico=warn";
 
 /// Installs a `tracing_subscriber::fmt` subscriber that writes to stderr and
@@ -99,8 +97,6 @@ mod tests {
     #[test]
     fn merge_default_directives_produces_parseable_filter() {
         let merged = merge_default_directives("sae=info,hyper=warn");
-        // EnvFilter::new panics on invalid directive; reaching the assertion
-        // proves the merged string parses cleanly.
-        drop(EnvFilter::new(&merged));
+        EnvFilter::try_new(&merged).expect("merged default filter must parse");
     }
 }


### PR DESCRIPTION
## 概要

PR #40 merge 後の `/polish` で検出された軽微な改善を反映。挙動変更なし。

- `RURICO_DEFAULT_DIRECTIVE` の rustdoc を簡潔化し、詳細は `init_subscriber` rustdoc に集約 (重複排除)
- T-025 を `EnvFilter::try_new(...).expect(...)` 化、narrating comment 削除 (意図明示 + 一行削減)

## レビュー経緯

`/polish` Phase 1:
- simplify (3 agent): 5 findings → 2 採用 / 3 不採用 (issue 要件・readability・LANG.md 規約理由)
- codex: No actionable correctness issues
- coderabbit: rate limit でスキップ

`/polish` Phase 2 (enhancer-code): No changes needed

## 検証

- [x] `cargo test --lib logging::` — 5 件全 pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean (pre-commit hook 経由)
- [ ] CI green