### PR TITLE
rurico の rev を 0c0e0f6 に bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,11 +1916,10 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=ef26de2#ef26de21cf0ef3d50f8c6dfbc8b06cf65bab0e16"
+source = "git+https://github.com/thkt/rurico?rev=0c0e0f6#0c0e0f6c93c2705d1d76304a15fc8549da07052b"
 dependencies = [
  "bytemuck",
  "hf-hub",
- "log",
  "mlx-rs",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
@@ -1930,13 +1929,14 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokenizers",
+ "tracing",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=ef26de2#ef26de21cf0ef3d50f8c6dfbc8b06cf65bab0e16"
+source = "git+https://github.com/thkt/rurico?rev=0c0e0f6#0c0e0f6c93c2705d1d76304a15fc8549da07052b"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ required-features = ["eval-harness"]
 [dependencies]
 rand               = "0.10"
 rand_chacha        = "0.10"
-rurico             = { git = "https://github.com/thkt/rurico", rev = "ef26de2" }
+rurico             = { git = "https://github.com/thkt/rurico", rev = "0c0e0f6" }
 rusqlite           = { version = "0.39", features = ["bundled"] }
 serde              = { version = "1", features = ["derive"] }
 serde_json         = "1"
@@ -28,7 +28,7 @@ tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico      = { git = "https://github.com/thkt/rurico", rev = "ef26de2", features = ["test-support"] }
+rurico      = { git = "https://github.com/thkt/rurico", rev = "0c0e0f6", features = ["test-support"] }
 serial_test = "3"
 tempfile    = "3"
 


### PR DESCRIPTION
## 概要と背景

amici が参照する rurico の git rev を `ef26de2` → `0c0e0f6` に bump。rurico 側の log → tracing 移行 (rurico#89) と pre-commit hook 追加 (rurico#90) を取り込み、ロギングスタックを統一する。

## 変更点

- `Cargo.toml` の `[dependencies]` と `[dev-dependencies]` (test-support) の rurico rev を `0c0e0f6` に同期
- `cargo update -p rurico` で `Cargo.lock` 再生成。transitive で `log` 削除 / `tracing` 追加が反映

## スコープ

- **対象外**: tracing 関連の amici 側コード変更。直前の `27c1df4` で `rurico=warn` を default filter に merge 済みのため本 PR では設定変更不要

## 設計判断

- 中間 rev での段階 bump ではなく rurico の最新 HEAD まで一気に揃える: rurico に breaking 差分なく、amici 側も既に tracing 移行済みのため
- dep と dev-dep の rev を厳密に同期: 同一 sha でないと test-support feature の build が分岐するリスクがある

## 動作確認

1. `cargo build` → rurico-ffi → rurico → amici が再ビルドされて成功 (4.17s)
2. `cargo test` → 131 unit + 15 doc test 全 pass
3. pre-commit (`cargo fmt --check` + `cargo clippy --all-targets --all-features -- -D warnings`) で warning 0

## 関連

- thkt/rurico#89 (log → tracing migration)
- thkt/rurico#90 (pre-commit hook)
