### PR TITLE
feat(model): degrade_with_warn と record_degraded ヘルパーを追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -6,7 +6,7 @@ sae/yomu/recall ツールチェーンで共有するモデルローディング�
 
 | Module | Contents |
 | ------ | -------- |
-| `model` | `DegradedReason`, `degraded_reason_user_note`, `ModelLoad<T>`, `ModelDownloadError`, `download_and_verify_model` |
+| `model` | `DegradedReason`, `degraded_reason_user_note`, `degrade_with_warn`, `record_degraded`, `ModelLoad<T>`, `ModelDownloadError`, `download_and_verify_model` |
 | `model::embedder` | `try_load_embedder_with` — エンベディングモデルをロード |
 | `model::reranker` | `try_load_reranker_with` — リランキングモデルをロード |
 | `storage::filter` | `in_placeholders`, `anon_placeholders`, `as_sql_params`, `append_eq_filter`, … — SQL `WHERE` 句とパラメータの構築ヘルパー |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Shared model-loading, storage helpers, and CLI utilities for the sae/yomu/recall
 
 | Module | Contents |
 | ------ | -------- |
-| `model` | `DegradedReason`, `degraded_reason_user_note`, `ModelLoad<T>`, `ModelDownloadError`, `download_and_verify_model` |
+| `model` | `DegradedReason`, `degraded_reason_user_note`, `degrade_with_warn`, `record_degraded`, `ModelLoad<T>`, `ModelDownloadError`, `download_and_verify_model` |
 | `model::embedder` | `try_load_embedder_with` — loads the embedding model |
 | `model::reranker` | `try_load_reranker_with` — loads the reranking model |
 | `storage::filter` | `in_placeholders`, `anon_placeholders`, `as_sql_params`, `append_eq_filter`, … — SQL `WHERE` clause and parameter builders |
@@ -92,6 +92,73 @@ those as a separate factory if your CLI mixes both.
 two: `EsaClient::from_env_with`, `data_dir_with`) is expected to be
 migrated to `Option<String>` during downstream rollout — `get(k).ok()`
 is the adapter when an existing site cannot move yet.
+
+### Degraded path notification
+
+When a typed error is collapsed into a `DegradedReason` (embedder/reranker
+unavailable, probe failed, …), emit a `tracing::warn!` event so the original
+error and the degraded reason are both observable in logs. Silent collapse
+(`map_err(|_| DegradedReason::ProbeFailed)`) and ad-hoc inline `warn!` calls
+hide regressions and drift across crates.
+
+Use one of the two helpers in `amici::model`:
+
+- `degrade_with_warn(context, reason)` — returns a `map_err` closure. Use when
+  the call site has a typed error that needs to be collapsed.
+- `record_degraded(reason, context)` — direct emit. Use when the call site
+  already holds a `DegradedReason` value (no original error to preserve).
+
+Both emit a structured warn event with the message `"operation degraded"` and
+the fields `reason`, `context`, and (for `degrade_with_warn`) `error`.
+
+**Before** (silent collapse):
+
+```rust
+let task_emb = embedder.embed_query(task)
+    .map_err(|_| DegradedReason::ProbeFailed)?;
+```
+
+**After**:
+
+```rust
+use amici::model::{degrade_with_warn, DegradedReason};
+
+let task_emb = embedder.embed_query(task)
+    .map_err(degrade_with_warn(
+        "brief seed inference: embed_query",
+        DegradedReason::ProbeFailed,
+    ))?;
+```
+
+**Before** (inline warn that drifts in wording across call sites):
+
+```rust
+match self.infer_seed_paths(/* ... */) {
+    Ok(paths) => { /* ... */ }
+    Err(reason) => {
+        eprintln!("warning: seed inference degraded ({reason})");
+        degraded = true;
+    }
+}
+```
+
+**After**:
+
+```rust
+use amici::model::record_degraded;
+
+match self.infer_seed_paths(/* ... */) {
+    Ok(paths) => { /* ... */ }
+    Err(reason) => {
+        record_degraded(reason, "brief: seed inference");
+        degraded = true;
+    }
+}
+```
+
+The two helpers compose with `notify_schema_change` and
+`try_load_embedder_with` — pick the helper whose input shape matches the call
+site instead of mixing notification policies.
 
 ### Exit code convention
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -56,6 +56,66 @@ pub fn degraded_reason_user_note(reason: DegradedReason) -> Option<&'static str>
     }
 }
 
+/// Returns a `map_err` closure that logs the original error via `tracing::warn!`
+/// and yields a [`DegradedReason`] for the degraded path.
+///
+/// Use this at call sites that drop a typed error in favor of a coarse
+/// `DegradedReason`. The original error is preserved in the structured
+/// `error` field of the warn event so log consumers can still see the cause.
+///
+/// The structured warn event carries `error`, `reason`, and `context` fields
+/// with the message `"operation degraded"`.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use amici::model::{degrade_with_warn, DegradedReason};
+/// # fn embed_query(_: &str) -> Result<Vec<f32>, &'static str> { Ok(vec![]) }
+/// let task_emb = embed_query("hello").map_err(degrade_with_warn(
+///     "brief seed inference: embed_query",
+///     DegradedReason::ProbeFailed,
+/// ))?;
+/// # Ok::<(), DegradedReason>(())
+/// ```
+pub fn degrade_with_warn<E: fmt::Display>(
+    context: &'static str,
+    reason: DegradedReason,
+) -> impl FnOnce(E) -> DegradedReason {
+    move |e| {
+        tracing::warn!(error = %e, ?reason, context, "operation degraded");
+        reason
+    }
+}
+
+/// Emits a `tracing::warn!` for an already-known [`DegradedReason`] with no
+/// underlying error to preserve.
+///
+/// Use this when the degraded path is reached from a `Result<_, DegradedReason>`
+/// (or similar) where no original error exists and only the reason needs to
+/// be reported. For the `map_err` case, prefer [`degrade_with_warn`].
+///
+/// The structured warn event carries `reason` and `context` fields with the
+/// message `"operation degraded"`.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use amici::model::{record_degraded, DegradedReason};
+/// # fn infer_seed_paths() -> Result<Vec<String>, DegradedReason> { Ok(vec![]) }
+/// let mut degraded = false;
+/// match infer_seed_paths() {
+///     Ok(_paths) => {}
+///     Err(reason) => {
+///         record_degraded(reason, "brief: seed inference");
+///         degraded = true;
+///     }
+/// }
+/// # let _ = degraded;
+/// ```
+pub fn record_degraded(reason: DegradedReason, context: &str) {
+    tracing::warn!(?reason, context, "operation degraded");
+}
+
 /// Outcome of a model-load attempt.
 ///
 /// Callers should inspect the variant to handle the `Failed` case — dropping a
@@ -226,10 +286,55 @@ where
 #[cfg(test)]
 mod tests {
     use std::cell::Cell;
+    use std::io;
+    use std::sync::{Arc, Mutex};
 
     use rurico::embed::MockEmbedder;
+    use tracing::subscriber::with_default;
+    use tracing_subscriber::fmt::MakeWriter;
 
     use super::*;
+
+    #[derive(Clone, Default)]
+    struct CapturedWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl CapturedWriter {
+        fn captured(&self) -> String {
+            String::from_utf8(self.0.lock().expect("captured buffer poisoned").clone())
+                .expect("captured bytes are not UTF-8")
+        }
+    }
+
+    impl io::Write for CapturedWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .expect("captured buffer poisoned")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for CapturedWriter {
+        type Writer = Self;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn capture_warn(emit: impl FnOnce()) -> String {
+        let writer = CapturedWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(writer.clone())
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .finish();
+        with_default(subscriber, emit);
+        writer.captured()
+    }
 
     // T-019: as_ref_returns_inner_only_for_ready
     #[test]
@@ -360,5 +465,61 @@ mod tests {
             ),
             other => panic!("expected ProbeFailed, got {other:?}"),
         }
+    }
+
+    fn always_fails(msg: &'static str) -> Result<(), &'static str> {
+        Err(msg)
+    }
+
+    // T-027: degrade_with_warn_returns_closure_yielding_reason
+    #[test]
+    fn degrade_with_warn_returns_closure_yielding_reason() {
+        let to_reason = degrade_with_warn("ctx", DegradedReason::ProbeFailed);
+        let result = always_fails("inner err").map_err(to_reason);
+        assert_eq!(result, Err(DegradedReason::ProbeFailed));
+    }
+
+    // T-028: degrade_with_warn_emits_warn_with_error_and_context
+    #[test]
+    fn degrade_with_warn_emits_warn_with_error_and_context() {
+        let captured = capture_warn(|| {
+            let to_reason = degrade_with_warn("test ctx", DegradedReason::BackendUnavailable);
+            let _ = always_fails("inner err msg").map_err(to_reason);
+        });
+        assert!(captured.contains("WARN"), "missing WARN level: {captured}");
+        assert!(
+            captured.contains("operation degraded"),
+            "missing message: {captured}"
+        );
+        assert!(
+            captured.contains("inner err msg"),
+            "missing original error: {captured}"
+        );
+        assert!(
+            captured.contains("BackendUnavailable"),
+            "missing reason: {captured}"
+        );
+        assert!(captured.contains("test ctx"), "missing context: {captured}");
+    }
+
+    // T-029: record_degraded_emits_warn_with_context
+    #[test]
+    fn record_degraded_emits_warn_with_context() {
+        let captured = capture_warn(|| {
+            record_degraded(DegradedReason::ProbeFailed, "seed inference");
+        });
+        assert!(captured.contains("WARN"), "missing WARN level: {captured}");
+        assert!(
+            captured.contains("operation degraded"),
+            "missing message: {captured}"
+        );
+        assert!(
+            captured.contains("ProbeFailed"),
+            "missing reason: {captured}"
+        );
+        assert!(
+            captured.contains("seed inference"),
+            "missing context: {captured}"
+        );
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -287,6 +287,7 @@ where
 mod tests {
     use std::cell::Cell;
     use std::io;
+    use std::mem;
     use std::sync::{Arc, Mutex};
 
     use rurico::embed::MockEmbedder;
@@ -300,8 +301,8 @@ mod tests {
 
     impl CapturedWriter {
         fn captured(&self) -> String {
-            String::from_utf8(self.0.lock().expect("captured buffer poisoned").clone())
-                .expect("captured bytes are not UTF-8")
+            let bytes = mem::take(&mut *self.0.lock().expect("captured buffer poisoned"));
+            String::from_utf8(bytes).expect("captured bytes are not UTF-8")
         }
     }
 


### PR DESCRIPTION
## 概要

- `amici::model::degrade_with_warn(context, reason)` — `map_err` 用の closure factory。原 err を `tracing::warn!` でログ出力したうえで `DegradedReason` を返す。silent な `map_err(|_| DegradedReason::ProbeFailed)` パターンを置換する。
- `amici::model::record_degraded(reason, context)` — direct emit。`Result<_, DegradedReason>` から伝搬してきて既に `DegradedReason` を握ってる call site 用。
- README "CLI conventions" 章に "Degraded path notification" セクションを追加（Before/After 例つき）、Modules テーブルの `model` 行を更新。

両ヘルパーとも `"operation degraded"` メッセージと `reason` / `context` / (closure 経由は `error`) フィールドを持つ structured warn event を emit。`notify_schema_change` と同じ wire 形式。

## テスト計画

- [x] `cargo test --all-features model::tests` — T-027/028/029 pass（closure return value + subscriber capture × 2）
- [x] `cargo test --all-features --doc model` — doctest 2本コンパイル成功
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

Closes #43