### PR TITLE
feat(logging): default filter に amici=warn を merge (amici#36 続き)

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -7,9 +7,10 @@ use std::io;
 
 use tracing_subscriber::EnvFilter;
 
-/// Default directive merged into every CLI's filter. See
+/// Default directives merged into every CLI's filter. See
 /// [`init_subscriber`] for the merge semantics and `RUST_LOG` interaction.
 const RURICO_DEFAULT_DIRECTIVE: &str = "rurico=warn";
+const AMICI_DEFAULT_DIRECTIVE: &str = "amici=warn";
 
 /// Installs a `tracing_subscriber::fmt` subscriber that writes to stderr and
 /// reads its filter from `RUST_LOG`, falling back to `default_filter` when the
@@ -29,11 +30,11 @@ const RURICO_DEFAULT_DIRECTIVE: &str = "rurico=warn";
 /// not preserved — callers who relied on implicit sae logs should export
 /// `RUST_LOG=sae=info` explicitly.
 ///
-/// `rurico=warn` is appended to `default_filter` so rurico's degraded-path
-/// warnings surface in operator logs without each downstream CLI having to
-/// opt in. Setting `RUST_LOG` overrides the merged default entirely; export
-/// `RUST_LOG=<crate>=<level>,rurico=warn` to keep the rurico directive while
-/// customizing the rest.
+/// Upstream crate warn directives are appended to `default_filter` so each
+/// crate's degraded-path warnings surface in operator logs without downstream
+/// CLI opt-in. Setting `RUST_LOG` overrides the merged default entirely;
+/// export `RUST_LOG=<crate>=<level>,rurico=warn,amici=warn` to keep the
+/// upstream directives while customizing the rest.
 ///
 /// # Panics
 ///
@@ -51,10 +52,11 @@ pub fn init_subscriber(default_filter: &str) {
 }
 
 fn merge_default_directives(default_filter: &str) -> String {
+    let upstream = format!("{RURICO_DEFAULT_DIRECTIVE},{AMICI_DEFAULT_DIRECTIVE}");
     if default_filter.is_empty() {
-        RURICO_DEFAULT_DIRECTIVE.to_owned()
+        upstream
     } else {
-        format!("{default_filter},{RURICO_DEFAULT_DIRECTIVE}")
+        format!("{default_filter},{upstream}")
     }
 }
 
@@ -66,31 +68,25 @@ fn resolve_env_filter(default_filter: &str) -> EnvFilter {
 mod tests {
     use super::*;
 
-    // T-021: resolve_env_filter_accepts_directive
-    #[test]
-    fn resolve_env_filter_accepts_directive() {
-        let _filter = resolve_env_filter("yomu=warn");
-    }
-
     // T-022: resolve_env_filter_accepts_multi_directive
     #[test]
     fn resolve_env_filter_accepts_multi_directive() {
         let _filter = resolve_env_filter("sae=info,hyper=warn");
     }
 
-    // T-023: merge_default_directives_appends_rurico_warn
+    // T-023: merge_default_directives_appends_upstream_warns
     #[test]
-    fn merge_default_directives_appends_rurico_warn() {
+    fn merge_default_directives_appends_upstream_warns() {
         assert_eq!(
             merge_default_directives("yomu=warn"),
-            "yomu=warn,rurico=warn"
+            "yomu=warn,rurico=warn,amici=warn"
         );
     }
 
     // T-024: merge_default_directives_handles_empty_default
     #[test]
     fn merge_default_directives_handles_empty_default() {
-        assert_eq!(merge_default_directives(""), "rurico=warn");
+        assert_eq!(merge_default_directives(""), "rurico=warn,amici=warn");
     }
 
     // T-025: merge_default_directives_produces_parseable_filter


### PR DESCRIPTION
## What & Why

amici 内の `tracing::warn!` (`degrade_with_warn` / `record_degraded` など) が下流 CLI (yomu/sae/recall) の default filter に見えてこない問題を解消する。`amici=warn` directive を `merge_default_directives` に append して、operator が `RUST_LOG` を設定せずとも degraded-path warnings が見えるようにする。

## Changes

- `AMICI_DEFAULT_DIRECTIVE = "amici=warn"` 追加 (`logging.rs:13`)
- `merge_default_directives` で rurico=warn と amici=warn を両方 append (`logging.rs:55-62`)
- doc コメントを policy 文に簡素化 (`logging.rs:32-36`) — 将来 directive 追加時の drift 範囲を縮小
- T-023 を `appends_upstream_warns` に rename + expected 更新
- T-024 expected 更新 (`"rurico=warn,amici=warn"`)
- T-021 / T-077 削除 — それぞれ T-022 / T-023 のサブセット (/polish cleanup)

## Scope

- **Not included**: 下流 CLI (sae / recall) の amici rev bump — merge 後に別 PR で対応

## Design Decisions

- doc コメントの directive list 表現を「Upstream crate warn directives」と generic にし、具体値は export example 1箇所に集約。将来 3つ目 directive 追加時の drift を減らすため (/polish CQ-1)
- T-077 (`contains("amici=warn")`) は T-023 の完全一致 assert (`"yomu=warn,rurico=warn,amici=warn"`) に包含されるため削除 (/polish CQ-2)
- T-021 (`resolve_env_filter("yomu=warn")`) は T-022 (`"sae=info,hyper=warn"`) と同じ `unwrap_or_else` branch を richer input でカバーするため削除 (/polish Phase 2)

## How to Test

1. `cargo test --lib logging` → 5 tests pass
2. `cargo clippy --all-targets -- -D warnings` → warnings なし
3. 下流検証 (別 PR で): yomu / sae / recall の Cargo.toml で amici rev を本 PR merge 後の SHA に bump し、`RUST_LOG=<crate>=warn` (amici 指定なし) で degraded path を実行 → stderr に `amici::model: operation degraded ...` が出ること

## Related

- Closes #47
- Detected via: thkt/yomu#131 (codex review)
- Same pattern as: amici#36 (rurico=warn merge)
- Downstream rev bump (follow-up): sae / recall
