### PR TITLE
feat: add Issue Forms + advanced-issue-labeler

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,36 @@
+name: Bug report
+description: File a bug report
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How urgent is this?
+      options:
+        - high
+        - medium
+        - low
+      default: 1
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug
+      placeholder: "When I did X, Y happened instead of Z"
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: How can someone reproduce the issue?
+      placeholder: "1. ...\n2. ...\n3. ..."
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, version, relevant runtime info

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Suggest a new feature or enhancement
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How urgent is this?
+      options:
+        - high
+        - medium
+        - low
+      default: 1
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      placeholder: "Currently when I try to X, ..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      placeholder: "Add an option / command / behavior that ..."
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,0 +1,20 @@
+# Maps Issue Forms dropdown selections to labels.
+# See https://github.com/stefanbuck/advanced-issue-labeler for syntax.
+#
+# Per-repo extension: target repos can append additional `policy` entries
+# (e.g. for area:* labels) by editing this file directly. The shared base
+# below covers priority:* mapping for both bug.yml and feature.yml forms.
+policy:
+  - template:
+      - bug.yml
+      - feature.yml
+    section:
+      - id: priority
+        block-list:
+          - high
+          - medium
+          - low
+        label:
+          - priority:high
+          - priority:medium
+          - priority:low

--- a/.github/workflows/label-from-issue.yml
+++ b/.github/workflows/label-from-issue.yml
@@ -1,0 +1,28 @@
+name: Apply labels from issue form
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply priority labels
+        uses: stefanbuck/[email protected]
+        with:
+          template: bug.yml
+          section: priority
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apply priority labels (feature)
+        uses: stefanbuck/[email protected]
+        with:
+          template: feature.yml
+          section: priority
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Auto-generated from thkt/github-labels shared templates. See ADR-0059 for the rationale.

Adds:
- .github/ISSUE_TEMPLATE/bug.yml
- .github/ISSUE_TEMPLATE/feature.yml
- .github/advanced-issue-labeler.yml
- .github/workflows/label-from-issue.yml

After merge, new issues via the bug/feature form get auto-labeled with priority:high/medium/low.