### PR TITLE
chore(deps): rurico を 42d0ca4 に更新し破壊的変更へ追従 (#49 #50 #54-#57)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,7 +1916,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=0c0e0f6#0c0e0f6c93c2705d1d76304a15fc8549da07052b"
+source = "git+https://github.com/thkt/rurico?rev=dda7962#dda7962b77d29185d42d30062e284448a361d7e0"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=0c0e0f6#0c0e0f6c93c2705d1d76304a15fc8549da07052b"
+source = "git+https://github.com/thkt/rurico?rev=dda7962#dda7962b77d29185d42d30062e284448a361d7e0"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
 name = "amici"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rurico",
@@ -1916,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=dda7962#dda7962b77d29185d42d30062e284448a361d7e0"
+source = "git+https://github.com/thkt/rurico?rev=42d0ca4#42d0ca49ab9eab47de4a2a733260e3f4cff991d2"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -1936,7 +1937,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=dda7962#dda7962b77d29185d42d30062e284448a361d7e0"
+source = "git+https://github.com/thkt/rurico?rev=42d0ca4#42d0ca49ab9eab47de4a2a733260e3f4cff991d2"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ required-features = ["eval-harness"]
 [dependencies]
 rand               = "0.10"
 rand_chacha        = "0.10"
-rurico             = { git = "https://github.com/thkt/rurico", rev = "0c0e0f6" }
+rurico             = { git = "https://github.com/thkt/rurico", rev = "dda7962" }
 rusqlite           = { version = "0.39", features = ["bundled"] }
 serde              = { version = "1", features = ["derive"] }
 serde_json         = "1"
@@ -28,7 +28,7 @@ tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico      = { git = "https://github.com/thkt/rurico", rev = "0c0e0f6", features = ["test-support"] }
+rurico      = { git = "https://github.com/thkt/rurico", rev = "dda7962", features = ["test-support"] }
 serial_test = "3"
 tempfile    = "3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,10 @@ path = "src/bin/eval_harness.rs"
 required-features = ["eval-harness"]
 
 [dependencies]
+bytemuck           = "1"
 rand               = "0.10"
 rand_chacha        = "0.10"
-rurico             = { git = "https://github.com/thkt/rurico", rev = "dda7962" }
+rurico             = { git = "https://github.com/thkt/rurico", rev = "42d0ca4" }
 rusqlite           = { version = "0.39", features = ["bundled"] }
 serde              = { version = "1", features = ["derive"] }
 serde_json         = "1"
@@ -28,7 +29,7 @@ tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico      = { git = "https://github.com/thkt/rurico", rev = "dda7962", features = ["test-support"] }
+rurico      = { git = "https://github.com/thkt/rurico", rev = "42d0ca4", features = ["test-support"] }
 serial_test = "3"
 tempfile    = "3"
 

--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -46,7 +46,7 @@ use rurico::retrieval::{
 };
 use rurico::sandbox::exit_if_seatbelt;
 use rurico::storage::QueryNormalizationConfig;
-use rurico::{embed, model_probe, reranker};
+use rurico::{embed, reranker};
 
 /// Mock-friendly bundle of every external seam the four mode handlers touch.
 ///
@@ -405,7 +405,7 @@ impl MetricSpec {
 }
 
 fn main() -> ExitCode {
-    model_probe::handle_probe_if_needed();
+    rurico::handle_probe_if_needed();
     exit_if_seatbelt(env!("CARGO_BIN_NAME"));
 
     let args: Vec<String> = env::args().skip(1).collect();

--- a/src/eval/pipeline.rs
+++ b/src/eval/pipeline.rs
@@ -9,6 +9,7 @@
 use std::collections::HashMap;
 use std::time::Instant;
 
+use bytemuck::cast_slice;
 use rurico::embed::{EMBEDDING_DIMS, Embed, EmbedError};
 use rurico::reranker::{Rerank, RerankerError};
 use rurico::retrieval::{
@@ -16,7 +17,7 @@ use rurico::retrieval::{
     WeightedRrf,
 };
 use rurico::storage::{
-    QueryNormalizationConfig, SanitizeError, ensure_sqlite_vec, f32_as_bytes, normalize_for_fts,
+    QueryNormalizationConfig, SanitizeError, ensure_sqlite_vec, normalize_for_fts,
     prepare_match_query,
 };
 use rusqlite::{Connection, params};
@@ -260,7 +261,7 @@ fn index_corpus<E: Embed>(
                 .iter()
                 .zip(&chunked_embedding.chunk_ids)
             {
-                insert_vec.execute(params![f32_as_bytes(chunk_vec), &doc.id, chunk_id])?;
+                insert_vec.execute(params![cast_slice::<f32, u8>(chunk_vec), &doc.id, chunk_id])?;
             }
         }
     }
@@ -379,7 +380,7 @@ fn retrieve_vec<E: Embed>(
     limit: usize,
 ) -> Result<Vec<Candidate>, PipelineError> {
     let embedding = embedder.embed_query(query)?;
-    let bytes = f32_as_bytes(&embedding);
+    let bytes = cast_slice::<f32, u8>(&embedding);
     let k_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
     let mut stmt = conn.prepare_cached(
         "SELECT doc_id, chunk_id, distance FROM vec_docs WHERE embedding MATCH ? AND k = ?",

--- a/src/eval/pipeline.rs
+++ b/src/eval/pipeline.rs
@@ -261,7 +261,8 @@ fn index_corpus<E: Embed>(
                 .iter()
                 .zip(&chunked_embedding.chunk_ids)
             {
-                insert_vec.execute(params![cast_slice::<f32, u8>(chunk_vec), &doc.id, chunk_id])?;
+                let chunk_bytes: &[u8] = cast_slice(chunk_vec);
+                insert_vec.execute(params![chunk_bytes, &doc.id, chunk_id])?;
             }
         }
     }
@@ -380,7 +381,7 @@ fn retrieve_vec<E: Embed>(
     limit: usize,
 ) -> Result<Vec<Candidate>, PipelineError> {
     let embedding = embedder.embed_query(query)?;
-    let bytes = cast_slice::<f32, u8>(&embedding);
+    let bytes: &[u8] = cast_slice(&embedding);
     let k_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
     let mut stmt = conn.prepare_cached(
         "SELECT doc_id, chunk_id, distance FROM vec_docs WHERE embedding MATCH ? AND k = ?",

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,9 +6,8 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 
-use rurico::embed::{
-    Artifacts, Embed, EmbedInitError, Embedder, ModelId, ProbeStatus, download_model,
-};
+use rurico::embed::{Artifacts, Embed, EmbedInitError, Embedder, ModelId, download_model};
+use rurico::model_probe::ProbeStatus;
 
 use self::embedder::try_load_embedder_with_fns;
 use crate::cli::with_spinner;
@@ -210,7 +209,7 @@ impl Error for ModelDownloadError {}
 ///
 /// # Prerequisites
 ///
-/// The calling binary must invoke `rurico::model_probe::handle_probe_if_needed()`
+/// The calling binary must invoke `rurico::handle_probe_if_needed()`
 /// at the very start of `main()`. Without it, the post-download probe returns
 /// [`ModelDownloadError::ProbeFailed`] even when the download succeeds.
 ///

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,7 +6,8 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 
-use rurico::embed::{Artifacts, Embed, EmbedInitError, Embedder, ModelId, download_model};
+use rurico::embed::{Artifacts, Embed, Embedder, ModelId, download_model};
+use rurico::model_init::ModelInitError;
 use rurico::model_probe::ProbeStatus;
 
 use self::embedder::try_load_embedder_with_fns;
@@ -248,8 +249,8 @@ pub fn download_and_verify_model() -> Result<(), ModelDownloadError> {
 fn try_download_and_verify_with_fns<A, E, DE>(
     download_fn: impl FnOnce() -> Result<A, DE>,
     on_delete_error: impl FnOnce(io::Error),
-    probe_fn: impl FnOnce(&A) -> Result<ProbeStatus, EmbedInitError>,
-    new_fn: impl FnOnce(&A) -> Result<E, EmbedInitError>,
+    probe_fn: impl FnOnce(&A) -> Result<ProbeStatus, ModelInitError>,
+    new_fn: impl FnOnce(&A) -> Result<E, ModelInitError>,
     delete_fn: impl FnOnce(A) -> Result<(), io::Error>,
     on_download_complete: impl FnOnce(),
 ) -> Result<(), ModelDownloadError>
@@ -414,7 +415,12 @@ mod tests {
         let result = try_download_and_verify_with_fns::<_, MockEmbedder, String>(
             || Ok::<_, String>(()),
             |_| unreachable!("on_delete_error must not fire on non-corrupt probe error"),
-            |_| Err(EmbedInitError::Backend("backend down".into())),
+            |_| {
+                Err(ModelInitError::Backend {
+                    message: "backend down".into(),
+                    source: None,
+                })
+            },
             |_| unreachable!("new must not be called when probe fails"),
             |_| unreachable!("delete must not be called on non-corrupt probe error"),
             || {},
@@ -454,7 +460,12 @@ mod tests {
             || Ok::<_, String>(()),
             |_| {},
             |_| Ok(ProbeStatus::Available),
-            |_| Err(EmbedInitError::Backend("alloc failed".into())),
+            |_| {
+                Err(ModelInitError::Backend {
+                    message: "alloc failed".into(),
+                    source: None,
+                })
+            },
             |_| unreachable!("delete must not be called on non-corrupt new_fn failure"),
             || {},
         );

--- a/src/model/embedder.rs
+++ b/src/model/embedder.rs
@@ -1,7 +1,8 @@
 use std::io;
 use std::sync::Arc;
 
-use rurico::embed::{Artifacts, Embed, EmbedInitError, Embedder, ModelId, cached_artifacts};
+use rurico::embed::{Artifacts, Embed, Embedder, ModelId, cached_artifacts};
+use rurico::model_init::ModelInitError;
 use rurico::model_probe::ProbeStatus;
 
 pub use super::{DegradedReason, degraded_reason_user_note};
@@ -21,14 +22,14 @@ pub use super::{DegradedReason, degraded_reason_user_note};
 ///
 /// # Corrupt-model handling
 ///
-/// When the probe or `new_fn` reports `EmbedInitError::ModelCorrupt`, the loader
+/// When the probe or `new_fn` reports `ModelInitError::ModelCorrupt`, the loader
 /// deletes the artifact files so a subsequent call can re-download. If deletion
 /// itself fails, `on_delete_error` is invoked with the `io::Error` so the caller
 /// can log or surface it — this crate never calls tracing directly.
 pub fn try_load_embedder_with<CE>(
     cache_check: impl FnOnce() -> Result<Option<Artifacts>, CE>,
     on_delete_error: impl FnOnce(io::Error),
-    on_probe_err: impl FnOnce(EmbedInitError),
+    on_probe_err: impl FnOnce(ModelInitError),
 ) -> Result<Arc<dyn Embed>, DegradedReason> {
     try_load_embedder_with_fns(
         cache_check,
@@ -70,8 +71,8 @@ pub fn try_load_embedder_default_logging() -> Result<Arc<dyn Embed>, DegradedRea
 
 pub(super) fn try_load_embedder_default_logging_with_fns<A, E, CE>(
     cache_check: impl FnOnce() -> Result<Option<A>, CE>,
-    probe_fn: impl FnOnce(&A) -> Result<ProbeStatus, EmbedInitError>,
-    new_fn: impl FnOnce(&A) -> Result<E, EmbedInitError>,
+    probe_fn: impl FnOnce(&A) -> Result<ProbeStatus, ModelInitError>,
+    new_fn: impl FnOnce(&A) -> Result<E, ModelInitError>,
     delete_fn: impl FnOnce(A) -> Result<(), io::Error>,
 ) -> Result<Arc<dyn Embed>, DegradedReason>
 where
@@ -79,8 +80,8 @@ where
 {
     try_load_embedder_with_fns(
         cache_check,
-        |e| tracing::warn!(error = %e, "failed to delete corrupt model files"),
-        |e| tracing::warn!(error = %e, "embedder probe failed"),
+        |e| tracing::warn!(error = %e, model_kind = "embed", "failed to delete corrupt model files"),
+        |e| tracing::warn!(error = %e, model_kind = "embed", "embedder probe failed"),
         probe_fn,
         new_fn,
         delete_fn,
@@ -90,9 +91,9 @@ where
 pub(super) fn try_load_embedder_with_fns<A, E, CE>(
     cache_check: impl FnOnce() -> Result<Option<A>, CE>,
     on_delete_error: impl FnOnce(io::Error),
-    on_probe_err: impl FnOnce(EmbedInitError),
-    probe_fn: impl FnOnce(&A) -> Result<ProbeStatus, EmbedInitError>,
-    new_fn: impl FnOnce(&A) -> Result<E, EmbedInitError>,
+    on_probe_err: impl FnOnce(ModelInitError),
+    probe_fn: impl FnOnce(&A) -> Result<ProbeStatus, ModelInitError>,
+    new_fn: impl FnOnce(&A) -> Result<E, ModelInitError>,
     delete_fn: impl FnOnce(A) -> Result<(), io::Error>,
 ) -> Result<Arc<dyn Embed>, DegradedReason>
 where
@@ -106,7 +107,7 @@ where
     match probe_fn(&artifacts) {
         Ok(ProbeStatus::Available) => {}
         Ok(ProbeStatus::BackendUnavailable) => return Err(DegradedReason::BackendUnavailable),
-        Err(EmbedInitError::ModelCorrupt { .. }) => {
+        Err(ModelInitError::ModelCorrupt { .. }) => {
             if let Err(io_err) = delete_fn(artifacts) {
                 on_delete_error(io_err);
             }
@@ -119,7 +120,7 @@ where
     }
     match new_fn(&artifacts) {
         Ok(e) => Ok(Arc::new(e) as Arc<dyn Embed>),
-        Err(EmbedInitError::ModelCorrupt { .. }) => {
+        Err(ModelInitError::ModelCorrupt { .. }) => {
             if let Err(io_err) = delete_fn(artifacts) {
                 on_delete_error(io_err);
             }
@@ -196,7 +197,7 @@ mod tests {
             |_| on_delete_error_called.set(true),
             |_| unreachable!("on_probe_err must not be called on ModelCorrupt"),
             |_| {
-                Err(EmbedInitError::ModelCorrupt {
+                Err(ModelInitError::ModelCorrupt {
                     reason: "bad weights".into(),
                 })
             },
@@ -223,7 +224,7 @@ mod tests {
             |e| captured.set(Some(e.to_string())),
             |_| unreachable!("on_probe_err must not be called on ModelCorrupt"),
             |_| {
-                Err(EmbedInitError::ModelCorrupt {
+                Err(ModelInitError::ModelCorrupt {
                     reason: "bad weights".into(),
                 })
             },
@@ -260,7 +261,12 @@ mod tests {
             cache_present(),
             |_| unreachable!("on_delete_error must not be called"),
             |e| captured.set(Some(e.to_string())),
-            |_| Err(EmbedInitError::Backend("spawn failed".into())),
+            |_| {
+                Err(ModelInitError::Backend {
+                    message: "spawn failed".into(),
+                    source: None,
+                })
+            },
             |_| unreachable!("new must not be called when probe fails"),
             |_| unreachable!("delete must not be called on non-corrupt probe error"),
         );
@@ -292,7 +298,12 @@ mod tests {
             |_| {},
             |e| captured.set(Some(e.to_string())),
             |_| Ok(ProbeStatus::Available),
-            |_| Err(EmbedInitError::Backend("alloc failed".into())),
+            |_| {
+                Err(ModelInitError::Backend {
+                    message: "alloc failed".into(),
+                    source: None,
+                })
+            },
             |_| unreachable!("delete must not be called on new_fn failure"),
         );
         assert_eq!(result.err(), Some(DegradedReason::ProbeFailed));
@@ -314,7 +325,7 @@ mod tests {
             |_| unreachable!("on_probe_err must not be called when new_fn reports ModelCorrupt"),
             |_| Ok(ProbeStatus::Available),
             |_| {
-                Err(EmbedInitError::ModelCorrupt {
+                Err(ModelInitError::ModelCorrupt {
                     reason: "bad weights".into(),
                 })
             },

--- a/src/model/embedder.rs
+++ b/src/model/embedder.rs
@@ -1,9 +1,8 @@
 use std::io;
 use std::sync::Arc;
 
-use rurico::embed::{
-    Artifacts, Embed, EmbedInitError, Embedder, ModelId, ProbeStatus, cached_artifacts,
-};
+use rurico::embed::{Artifacts, Embed, EmbedInitError, Embedder, ModelId, cached_artifacts};
+use rurico::model_probe::ProbeStatus;
 
 pub use super::{DegradedReason, degraded_reason_user_note};
 

--- a/src/model/reranker.rs
+++ b/src/model/reranker.rs
@@ -1,7 +1,8 @@
 use std::io;
 
+use rurico::model_init::ModelInitError;
 use rurico::model_probe::ProbeStatus;
-use rurico::reranker::{Artifacts, Rerank, Reranker, RerankerInitError};
+use rurico::reranker::{Artifacts, Rerank, Reranker};
 
 use super::DegradedReason;
 
@@ -20,14 +21,14 @@ use super::DegradedReason;
 ///
 /// # Corrupt-model handling
 ///
-/// When the probe or `new_fn` reports `RerankerInitError::ModelCorrupt`, the
+/// When the probe or `new_fn` reports `ModelInitError::ModelCorrupt`, the
 /// loader deletes the artifact files so a subsequent call can re-download. If
 /// deletion itself fails, `on_delete_error` is invoked with the `io::Error` so
 /// the caller can log or surface it — this crate never calls tracing directly.
 pub fn try_load_reranker_with<CE>(
     cache_check: impl FnOnce() -> Result<Option<Artifacts>, CE>,
     on_delete_error: impl FnOnce(io::Error),
-    on_err: impl FnOnce(RerankerInitError),
+    on_err: impl FnOnce(ModelInitError),
 ) -> Result<Box<dyn Rerank>, DegradedReason> {
     try_load_reranker_with_fns(
         cache_check,
@@ -42,9 +43,9 @@ pub fn try_load_reranker_with<CE>(
 fn try_load_reranker_with_fns<A, CE, R>(
     cache_check: impl FnOnce() -> Result<Option<A>, CE>,
     on_delete_error: impl FnOnce(io::Error),
-    on_err: impl FnOnce(RerankerInitError),
-    probe_fn: impl FnOnce(&A) -> Result<ProbeStatus, RerankerInitError>,
-    new_fn: impl FnOnce(&A) -> Result<R, RerankerInitError>,
+    on_err: impl FnOnce(ModelInitError),
+    probe_fn: impl FnOnce(&A) -> Result<ProbeStatus, ModelInitError>,
+    new_fn: impl FnOnce(&A) -> Result<R, ModelInitError>,
     delete_fn: impl FnOnce(A) -> Result<(), io::Error>,
 ) -> Result<Box<dyn Rerank>, DegradedReason>
 where
@@ -58,7 +59,7 @@ where
     match probe_fn(&artifacts) {
         Ok(ProbeStatus::Available) => {}
         Ok(ProbeStatus::BackendUnavailable) => return Err(DegradedReason::BackendUnavailable),
-        Err(RerankerInitError::ModelCorrupt { .. }) => {
+        Err(ModelInitError::ModelCorrupt { .. }) => {
             if let Err(io_err) = delete_fn(artifacts) {
                 on_delete_error(io_err);
             }
@@ -71,7 +72,7 @@ where
     }
     match new_fn(&artifacts) {
         Ok(r) => Ok(Box::new(r) as Box<dyn Rerank>),
-        Err(RerankerInitError::ModelCorrupt { .. }) => {
+        Err(ModelInitError::ModelCorrupt { .. }) => {
             if let Err(io_err) = delete_fn(artifacts) {
                 on_delete_error(io_err);
             }
@@ -154,7 +155,12 @@ mod tests {
             cache_present(),
             |_| unreachable!("on_delete_error must not be called on non-corrupt probe error"),
             |e| captured.set(Some(e.to_string())),
-            |_| Err(RerankerInitError::Backend("probe failed".into())),
+            |_| {
+                Err(ModelInitError::Backend {
+                    message: "probe failed".into(),
+                    source: None,
+                })
+            },
             |_| unreachable!("new must not be called when probe fails"),
             |_| unreachable!("delete must not be called on non-corrupt probe error"),
         );
@@ -175,7 +181,12 @@ mod tests {
             |_| unreachable!("on_delete_error must not be called when probe succeeds"),
             |e| captured.set(Some(e.to_string())),
             |_| Ok(ProbeStatus::Available),
-            |_| Err(RerankerInitError::Backend("alloc failed".into())),
+            |_| {
+                Err(ModelInitError::Backend {
+                    message: "alloc failed".into(),
+                    source: None,
+                })
+            },
             |_| unreachable!("delete must not be called on new_fn failure"),
         );
         assert_eq!(result.err(), Some(DegradedReason::ProbeFailed));
@@ -197,7 +208,7 @@ mod tests {
             |_| on_delete_error_called.set(true),
             |_| on_err_called.set(true),
             |_| {
-                Err(RerankerInitError::ModelCorrupt {
+                Err(ModelInitError::ModelCorrupt {
                     reason: "bad weights".into(),
                 })
             },
@@ -229,7 +240,7 @@ mod tests {
             |e| captured.set(Some(e.to_string())),
             |_| on_err_called.set(true),
             |_| {
-                Err(RerankerInitError::ModelCorrupt {
+                Err(ModelInitError::ModelCorrupt {
                     reason: "bad weights".into(),
                 })
             },
@@ -271,7 +282,7 @@ mod tests {
             |_| on_err_called.set(true),
             |_| Ok(ProbeStatus::Available),
             |_| {
-                Err(RerankerInitError::ModelCorrupt {
+                Err(ModelInitError::ModelCorrupt {
                     reason: "bad weights".into(),
                 })
             },

--- a/src/model/reranker.rs
+++ b/src/model/reranker.rs
@@ -1,6 +1,7 @@
 use std::io;
 
-use rurico::reranker::{Artifacts, ProbeStatus, Rerank, Reranker, RerankerInitError};
+use rurico::model_probe::ProbeStatus;
+use rurico::reranker::{Artifacts, Rerank, Reranker, RerankerInitError};
 
 use super::DegradedReason;
 

--- a/src/model/reranker.rs
+++ b/src/model/reranker.rs
@@ -16,7 +16,7 @@ use super::DegradedReason;
 /// - [`DegradedReason::ProbeFailed`] — `cache_check` returned `Err(_)`, the
 ///   probe or `new_fn` reported `ModelCorrupt` (artifacts deleted before
 ///   returning), the probe returned another error, or `new_fn` failed.
-///   `on_err` is invoked for probe and non-corrupt `new_fn` errors; it is
+///   `on_probe_err` is invoked for probe and non-corrupt `new_fn` errors; it is
 ///   **not** called for `ModelCorrupt`.
 ///
 /// # Corrupt-model handling
@@ -28,12 +28,12 @@ use super::DegradedReason;
 pub fn try_load_reranker_with<CE>(
     cache_check: impl FnOnce() -> Result<Option<Artifacts>, CE>,
     on_delete_error: impl FnOnce(io::Error),
-    on_err: impl FnOnce(ModelInitError),
+    on_probe_err: impl FnOnce(ModelInitError),
 ) -> Result<Box<dyn Rerank>, DegradedReason> {
     try_load_reranker_with_fns(
         cache_check,
         on_delete_error,
-        on_err,
+        on_probe_err,
         Reranker::probe,
         Reranker::new,
         Artifacts::delete_files,
@@ -43,7 +43,7 @@ pub fn try_load_reranker_with<CE>(
 fn try_load_reranker_with_fns<A, CE, R>(
     cache_check: impl FnOnce() -> Result<Option<A>, CE>,
     on_delete_error: impl FnOnce(io::Error),
-    on_err: impl FnOnce(ModelInitError),
+    on_probe_err: impl FnOnce(ModelInitError),
     probe_fn: impl FnOnce(&A) -> Result<ProbeStatus, ModelInitError>,
     new_fn: impl FnOnce(&A) -> Result<R, ModelInitError>,
     delete_fn: impl FnOnce(A) -> Result<(), io::Error>,
@@ -66,7 +66,7 @@ where
             return Err(DegradedReason::ProbeFailed);
         }
         Err(e) => {
-            on_err(e);
+            on_probe_err(e);
             return Err(DegradedReason::ProbeFailed);
         }
     }
@@ -79,7 +79,7 @@ where
             Err(DegradedReason::ProbeFailed)
         }
         Err(e) => {
-            on_err(e);
+            on_probe_err(e);
             Err(DegradedReason::ProbeFailed)
         }
     }
@@ -103,7 +103,7 @@ mod tests {
         let result = try_load_reranker_with(
             || Ok::<_, &str>(None),
             |_| unreachable!("on_delete_error must not be called"),
-            |_| unreachable!("on_err must not be called"),
+            |_| unreachable!("on_probe_err must not be called"),
         );
         assert_eq!(result.err(), Some(DegradedReason::NotInstalled));
     }
@@ -114,7 +114,7 @@ mod tests {
         let result = try_load_reranker_with(
             || Err::<Option<Artifacts>, _>("cache broken"),
             |_| unreachable!("on_delete_error must not be called on cache error"),
-            |_| unreachable!("on_err must not be called on cache error"),
+            |_| unreachable!("on_probe_err must not be called on cache error"),
         );
         assert_eq!(result.err(), Some(DegradedReason::ProbeFailed));
     }
@@ -125,7 +125,7 @@ mod tests {
         let result = try_load_reranker_with_fns(
             cache_present(),
             |_| unreachable!("on_delete_error must not be called on success"),
-            |_| unreachable!("on_err must not be called on success"),
+            |_| unreachable!("on_probe_err must not be called on success"),
             |_| Ok(ProbeStatus::Available),
             |_| Ok(MockReranker::default()),
             |_| unreachable!("delete must not be called on success"),
@@ -139,7 +139,7 @@ mod tests {
         let result = try_load_reranker_with_fns::<_, _, MockReranker>(
             cache_present(),
             |_| unreachable!("on_delete_error must not be called on BackendUnavailable"),
-            |_| unreachable!("on_err must not be called on BackendUnavailable"),
+            |_| unreachable!("on_probe_err must not be called on BackendUnavailable"),
             |_| Ok(ProbeStatus::BackendUnavailable),
             |_| unreachable!("new must not be called when backend unavailable"),
             |_| unreachable!("delete must not be called when backend unavailable"),
@@ -147,9 +147,9 @@ mod tests {
         assert_eq!(result.err(), Some(DegradedReason::BackendUnavailable));
     }
 
-    // T-044: probe_err_invokes_on_err
+    // T-044: probe_err_invokes_on_probe_err
     #[test]
-    fn probe_err_invokes_on_err() {
+    fn probe_err_invokes_on_probe_err() {
         let captured: Cell<Option<String>> = Cell::new(None);
         let result = try_load_reranker_with_fns::<_, _, MockReranker>(
             cache_present(),
@@ -165,16 +165,16 @@ mod tests {
             |_| unreachable!("delete must not be called on non-corrupt probe error"),
         );
         assert_eq!(result.err(), Some(DegradedReason::ProbeFailed));
-        let msg = captured.into_inner().expect("on_err should fire");
+        let msg = captured.into_inner().expect("on_probe_err should fire");
         assert!(
             msg.contains("probe failed"),
-            "on_err message should carry detail, got {msg:?}"
+            "on_probe_err message should carry detail, got {msg:?}"
         );
     }
 
-    // T-045: new_err_invokes_on_err
+    // T-045: new_err_invokes_on_probe_err
     #[test]
-    fn new_err_invokes_on_err() {
+    fn new_err_invokes_on_probe_err() {
         let captured: Cell<Option<String>> = Cell::new(None);
         let result = try_load_reranker_with_fns::<_, _, MockReranker>(
             cache_present(),
@@ -190,10 +190,10 @@ mod tests {
             |_| unreachable!("delete must not be called on new_fn failure"),
         );
         assert_eq!(result.err(), Some(DegradedReason::ProbeFailed));
-        let msg = captured.into_inner().expect("on_err should fire");
+        let msg = captured.into_inner().expect("on_probe_err should fire");
         assert!(
             msg.contains("alloc failed"),
-            "on_err message should carry detail, got {msg:?}"
+            "on_probe_err message should carry detail, got {msg:?}"
         );
     }
 
@@ -201,12 +201,12 @@ mod tests {
     #[test]
     fn corrupt_delete_ok_skips_on_delete_error() {
         let on_delete_error_called = Cell::new(false);
-        let on_err_called = Cell::new(false);
+        let on_probe_err_called = Cell::new(false);
         let delete_called = Cell::new(false);
         let result = try_load_reranker_with_fns::<_, _, MockReranker>(
             cache_present(),
             |_| on_delete_error_called.set(true),
-            |_| on_err_called.set(true),
+            |_| on_probe_err_called.set(true),
             |_| {
                 Err(ModelInitError::ModelCorrupt {
                     reason: "bad weights".into(),
@@ -225,8 +225,8 @@ mod tests {
             "on_delete_error must not be called when delete succeeds"
         );
         assert!(
-            !on_err_called.get(),
-            "on_err must not be called on ModelCorrupt"
+            !on_probe_err_called.get(),
+            "on_probe_err must not be called on ModelCorrupt"
         );
     }
 
@@ -234,11 +234,11 @@ mod tests {
     #[test]
     fn corrupt_delete_err_invokes_on_delete_error() {
         let captured: Cell<Option<String>> = Cell::new(None);
-        let on_err_called = Cell::new(false);
+        let on_probe_err_called = Cell::new(false);
         let result = try_load_reranker_with_fns::<_, _, MockReranker>(
             cache_present(),
             |e| captured.set(Some(e.to_string())),
-            |_| on_err_called.set(true),
+            |_| on_probe_err_called.set(true),
             |_| {
                 Err(ModelInitError::ModelCorrupt {
                     reason: "bad weights".into(),
@@ -254,8 +254,8 @@ mod tests {
             "captured error should carry io message, got {msg:?}"
         );
         assert!(
-            !on_err_called.get(),
-            "on_err must not be called on ModelCorrupt"
+            !on_probe_err_called.get(),
+            "on_probe_err must not be called on ModelCorrupt"
         );
     }
 
@@ -265,7 +265,7 @@ mod tests {
         let result = try_load_reranker_with(
             || Ok::<Option<Artifacts>, &str>(None),
             |_| unreachable!("on_delete_error must not be called"),
-            |_| unreachable!("on_err must not be called when cache is empty"),
+            |_| unreachable!("on_probe_err must not be called when cache is empty"),
         );
         assert_eq!(result.err(), Some(DegradedReason::NotInstalled));
     }
@@ -274,12 +274,12 @@ mod tests {
     #[test]
     fn new_fn_corrupt_deletes_artifacts() {
         let on_delete_error_called = Cell::new(false);
-        let on_err_called = Cell::new(false);
+        let on_probe_err_called = Cell::new(false);
         let delete_called = Cell::new(false);
         let result = try_load_reranker_with_fns::<_, _, MockReranker>(
             cache_present(),
             |_| on_delete_error_called.set(true),
-            |_| on_err_called.set(true),
+            |_| on_probe_err_called.set(true),
             |_| Ok(ProbeStatus::Available),
             |_| {
                 Err(ModelInitError::ModelCorrupt {
@@ -301,8 +301,8 @@ mod tests {
             "on_delete_error must not be called when delete succeeds"
         );
         assert!(
-            !on_err_called.get(),
-            "on_err must not be called on ModelCorrupt"
+            !on_probe_err_called.get(),
+            "on_probe_err must not be called on ModelCorrupt"
         );
     }
 }


### PR DESCRIPTION
## なぜこれをやるか

rurico crate を `0c0e0f6` から最新 main `42d0ca4` まで一気に bump し、途中で入った 4 つの破壊的 API 変更を一括追従する。中間 rev (a84ecce / 8973d70 / ca7f2be) は HEAD に subsume されるため、関連する 6 つの open issue (#49 #50 #54 #55 #56 #57) を本 PR で全 close する。

## 変更点

### 依存と Cargo

- `Cargo.toml` rurico rev: `0c0e0f6` → `42d0ca4` ([dependencies] / [dev-dependencies])
- `Cargo.toml` 直接依存に `bytemuck = "1"` 追加 (rurico の `f32_as_bytes` 削除に伴う)
- `Cargo.lock`: `cargo update -p rurico` による rurico + rurico-ffi の 2 件のみ更新。transitive dep の churn は branch 作成前に reset 済みで、本 PR 範囲外の lock 差分は含まない

### rurico API 追従

- **#49 handle_probe_if_needed / ProbeStatus 再配置**: `rurico::model_probe::handle_probe_if_needed` → `rurico::handle_probe_if_needed` (top-level)、`embed::ProbeStatus` / `reranker::ProbeStatus` → `model_probe::ProbeStatus` (集約)
- **#54 ModelInitError 統合**: `EmbedInitError` / `RerankerInitError` 34 sites を `rurico::model_init::ModelInitError` に rename (init/probe phase エラー用に統合)
- **#56 Backend struct variant 化**: `Backend(String)` → `Backend { message: String, source: Option<Box<dyn Error>> }`。test mock 6 sites を struct form に書き換え (`source: None` で初期化)
- **#57 f32_as_bytes 削除**: `rurico::storage::f32_as_bytes` → `bytemuck::cast_slice`。`src/eval/pipeline.rs` の 2 sites を named binding `let bytes: &[u8] = cast_slice(..)` に置換 (turbofish 回避 + 意図保持)

### ロギング整備 (#54 AC)

- default logging preset の `warn!` call site に `model_kind = "embed"` を追加し、`ModelInitError` の Display プレフィックスから kind 情報が消えた分の triage 情報を維持 (src/model/embedder.rs)

### 命名揃え (polish)

- `src/model/reranker.rs` の `on_err` callback を `on_probe_err` に rename し、`embedder.rs` と signature 命名を symmetry 化

## スコープ

- **含まない**: yomu / sae / recall の amici rev bump (本 PR merge 後に別 PR で対応)
- **含まない**: `model_kind` 定数化や test mock 共有 helper (caller 責任の logging policy / DRY gate 3+ 未満 / test-local clarity を優先)

## テスト方法

1. `cargo build --workspace --all-features` → 通る
2. `cargo test --workspace --all-features` → 7 lib + 18 doctest pass / 6 ignored (MLX cache 必要なテストの通常 skip)
3. `cargo clippy --workspace --all-targets --all-features -- -D warnings` → clean
4. `ugrep -rn 'EmbedInitError|RerankerInitError|f32_as_bytes|rurico::(embed|reranker)::ProbeStatus' src/` → 残存ゼロ確認済

## レビュー (/polish)

| Tool | 結果 |
|---|---|
| simplify-readability | CQ-2 (symmetry rename) 採用 / CQ-1 / CQ-3 は triage で skip |
| simplify-reuse | REUSE-01 / REUSE-02 ともに skip (DRY gate 未満) |
| simplify-efficiency | findings 0 (cast_slice は zero-copy 確認済) |
| Codex | regression なし |
| CodeRabbit | findings 0 |
| Gemini | capacity exhausted で skip |
| enhancer-code | cast_slice turbofish の named binding 化のみ |

## 関連

- Closes #49
- Closes #50
- Closes #54
- Closes #55
- Closes #56
- Closes #57
- Follow-up (別 PR): yomu / sae / recall の amici rev bump