### PR TITLE
feat(eval): Oracle pipeline と capture-oracle を追加 (Issue #52 PR1)

### DIFF
--- a/justfile
+++ b/justfile
@@ -41,6 +41,15 @@ eval-reverse:
     cargo run --bin eval_harness --features eval-harness --release -- \
       capture-reverse-baseline output=tests/fixtures/eval/reverse_baseline.json
 
+# Recapture oracle baseline (Issue #52) → tests/fixtures/eval/oracle_baseline.json (MLX required)
+# Forces every relevance_map doc to rank 0 in Stage 2 to surface the
+# retrieval ceiling — pair with `eval-verify` on baseline.json to compute
+# the search-side gap (Phase 2 priority signal).
+eval-oracle:
+    cargo run --bin eval_harness --features eval-harness --release -- \
+      capture-oracle aggregation=identity \
+      output=tests/fixtures/eval/oracle_baseline.json
+
 # Capture a variant baseline to /tmp (agg = identity / max-chunk / dedupe / topk-average)
 eval-baseline-variant agg:
     cargo run --bin eval_harness --features eval-harness --release -- \

--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -10,6 +10,7 @@
 //! eval_harness evaluate [kind=full|identity|reverse|single_doc|shuffled]
 //! eval_harness capture-baseline output=<path>
 //! eval_harness capture-reverse-baseline output=<path>
+//! eval_harness capture-oracle output=<path>
 //! eval_harness verify-baseline baseline=<path>
 //! ```
 //!
@@ -37,6 +38,7 @@ use amici::eval::fixture::{
     EvalDocument, EvalQuery, load_documents, load_known_answers, load_queries,
 };
 use amici::eval::metrics::{MetricResult, bootstrap_ci, mrr_at_k, ndcg_at_k, recall_at_k};
+use amici::eval::oracle_pipeline::{OracleError, evaluate_oracle};
 use amici::eval::pipeline::{PipelineConfig, PipelineError, QueryResult, evaluate as run_pipeline};
 use rurico::embed::Embed;
 use rurico::reranker::Rerank;
@@ -88,7 +90,29 @@ const BOOTSTRAP_SEED: u64 = 42;
 
 /// Closed set of fixture kinds accepted by `evaluate kind=...`. Anchors the
 /// argv validation in `run_evaluate` and the dispatch in `load_fixture_for_kind`.
-const VALID_EVALUATE_KINDS: &[&str] = &["full", "shuffled", "identity", "reverse", "single_doc"];
+///
+/// Kinds ending in `_oracle` route through [`evaluate_oracle`] (Issue #52)
+/// against the underlying fixture (`full_oracle` → `documents.jsonl` +
+/// `queries.jsonl`; `identity_oracle` → `known_answers.jsonl::identity`;
+/// `single_doc_oracle` → `known_answers.jsonl::single_doc`). The `reverse`
+/// and `shuffled` paths have no oracle counterpart — both are designed to
+/// degrade ranking quality, so a forced top-rank inject would defeat the
+/// fixture's purpose.
+const VALID_EVALUATE_KINDS: &[&str] = &[
+    "full",
+    "shuffled",
+    "identity",
+    "reverse",
+    "single_doc",
+    "full_oracle",
+    "identity_oracle",
+    "single_doc_oracle",
+];
+
+/// Suffix on [`VALID_EVALUATE_KINDS`] entries that route through the Oracle
+/// retrieval pipeline. Kept as a single constant so the `_oracle` literal
+/// only appears in one place across argv validation and dispatch.
+const ORACLE_KIND_SUFFIX: &str = "_oracle";
 
 /// Closed set of Stage 3 aggregation kinds accepted by `aggregation=...`.
 /// Anchors argv validation and round-tripping with the `aggregation` field
@@ -293,6 +317,69 @@ where
     }
 }
 
+/// Run [`evaluate_oracle`] with the concrete aggregator selected by
+/// `aggregation`. Mirrors [`dispatch_pipeline`] for the Oracle path
+/// (Issue #52); the two helpers stay separate because their return types
+/// differ ([`PipelineError`] vs [`OracleError`]).
+#[allow(clippy::too_many_arguments)]
+fn dispatch_oracle_pipeline<E, R>(
+    corpus: &[EvalDocument],
+    queries: &[EvalQuery],
+    embedder: &E,
+    reranker: Option<&R>,
+    aggregation: AggregationKind,
+    merge_config: &HybridSearchConfig,
+    normalization: &QueryNormalizationConfig,
+    config: &PipelineConfig,
+) -> Result<Vec<QueryResult>, OracleError>
+where
+    E: Embed,
+    R: Rerank,
+{
+    match aggregation {
+        AggregationKind::Identity => evaluate_oracle(
+            corpus,
+            queries,
+            embedder,
+            reranker,
+            &IdentityAggregator,
+            merge_config,
+            normalization,
+            config,
+        ),
+        AggregationKind::MaxChunk => evaluate_oracle(
+            corpus,
+            queries,
+            embedder,
+            reranker,
+            &MaxChunkAggregator,
+            merge_config,
+            normalization,
+            config,
+        ),
+        AggregationKind::Dedupe => evaluate_oracle(
+            corpus,
+            queries,
+            embedder,
+            reranker,
+            &DedupeAggregator,
+            merge_config,
+            normalization,
+            config,
+        ),
+        AggregationKind::TopKAverage(k) => evaluate_oracle(
+            corpus,
+            queries,
+            embedder,
+            reranker,
+            &TopKAverageAggregator::new(k),
+            merge_config,
+            normalization,
+            config,
+        ),
+    }
+}
+
 /// Parse query-normalization overrides from argv kvs.
 ///
 /// Recognised keys (all optional, all boolean):
@@ -412,7 +499,7 @@ fn main() -> ExitCode {
     let Some(mode) = args.first() else {
         eprintln!(
             "usage: eval_harness <evaluate|capture-baseline|capture-reverse-baseline|\
-             verify-baseline|compare-baselines> [key=value...]"
+             capture-oracle|verify-baseline|compare-baselines> [key=value...]"
         );
         return ExitCode::from(EXIT_USAGE);
     };
@@ -425,6 +512,7 @@ fn main() -> ExitCode {
         "evaluate" => run_evaluate(&kvs),
         "capture-baseline" => run_capture_baseline(&kvs),
         "capture-reverse-baseline" => run_capture_reverse_baseline(&kvs),
+        "capture-oracle" => run_capture_oracle(&kvs),
         "verify-baseline" => run_verify_baseline(&kvs),
         "compare-baselines" => run_compare_baselines(&kvs),
         other => {
@@ -490,19 +578,35 @@ fn run_evaluate_with<E: Embed, R: Rerank>(
         }
     };
     let config = PipelineConfig { k: PIPELINE_K };
-    let mut results = match dispatch_pipeline(
-        &corpus,
-        &queries,
-        &ctx.embedder,
-        Some(&ctx.reranker),
-        aggregation,
-        merge_config,
-        normalization,
-        &config,
-    ) {
+    let pipeline_result = if kind.ends_with(ORACLE_KIND_SUFFIX) {
+        dispatch_oracle_pipeline(
+            &corpus,
+            &queries,
+            &ctx.embedder,
+            Some(&ctx.reranker),
+            aggregation,
+            merge_config,
+            normalization,
+            &config,
+        )
+        .map_err(|e| format!("{e}"))
+    } else {
+        dispatch_pipeline(
+            &corpus,
+            &queries,
+            &ctx.embedder,
+            Some(&ctx.reranker),
+            aggregation,
+            merge_config,
+            normalization,
+            &config,
+        )
+        .map_err(|e| format!("{e}"))
+    };
+    let mut results = match pipeline_result {
         Ok(r) => r,
-        Err(e) => {
-            eprintln!("evaluate({kind}): pipeline failed: {e}");
+        Err(msg) => {
+            eprintln!("evaluate({kind}): pipeline failed: {msg}");
             return ExitCode::from(EXIT_INFRA);
         }
     };
@@ -739,6 +843,136 @@ fn run_capture_reverse_baseline_with<E: Embed, R: Rerank>(
     ExitCode::SUCCESS
 }
 
+/// `capture-oracle output=<path> [aggregation=<kind>] [rrf_k=N] [fts_weight=W]
+/// [vector_weight=W]` — run the Oracle retrieval pipeline (Issue #52) and
+/// write a `BaselineSnapshot` with `kind=Oracle` to `output=`. Mirrors
+/// `capture-baseline` argv shape so operators can swap subcommands without
+/// re-learning options.
+///
+/// Aggregation / merge / normalization knobs flow through the same parsers
+/// because the oracle baseline measures the **post-retrieval ceiling under
+/// the production rerank/aggregation stack**, not a fully idealised
+/// pipeline — Issue #52 design choice anchored to CoSearch's "freeze the
+/// retrieval, vary the reasoning" framing.
+fn run_capture_oracle(kvs: &HashMap<String, String>) -> ExitCode {
+    let Some(output_path_raw) = kvs.get("output") else {
+        eprintln!("capture-oracle: output= argument required");
+        return ExitCode::from(EXIT_USAGE);
+    };
+    let output_path = match validate_output_path(output_path_raw) {
+        Ok(p) => p,
+        Err(msg) => {
+            eprintln!("capture-oracle: {msg}");
+            return ExitCode::from(EXIT_USAGE);
+        }
+    };
+    let aggregation = match AggregationKind::from_kvs(kvs) {
+        Ok(a) => a,
+        Err(msg) => {
+            eprintln!("capture-oracle: {msg}");
+            return ExitCode::from(EXIT_USAGE);
+        }
+    };
+    let merge_config = match parse_merge_config_from_kvs(kvs) {
+        Ok(c) => c,
+        Err(msg) => {
+            eprintln!("capture-oracle: {msg}");
+            return ExitCode::from(EXIT_USAGE);
+        }
+    };
+    let normalization = match parse_normalization_from_kvs(kvs) {
+        Ok(c) => c,
+        Err(msg) => {
+            eprintln!("capture-oracle: {msg}");
+            return ExitCode::from(EXIT_USAGE);
+        }
+    };
+    let ctx = match production_context() {
+        Ok(c) => c,
+        Err(msg) => {
+            eprintln!("capture-oracle: {msg}");
+            return ExitCode::from(EXIT_INFRA);
+        }
+    };
+    log_run_context(&ctx, "capture-oracle", None, Some(&output_path));
+    run_capture_oracle_with(
+        &ctx,
+        &output_path,
+        aggregation,
+        &merge_config,
+        &normalization,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_capture_oracle_with<E: Embed, R: Rerank>(
+    ctx: &EvalContext<E, R>,
+    output_path: &Path,
+    aggregation: AggregationKind,
+    merge_config: &HybridSearchConfig,
+    normalization: &QueryNormalizationConfig,
+) -> ExitCode {
+    let (corpus, queries) = match load_fixture_for_kind(&ctx.fixture_dir, "full") {
+        Ok(v) => v,
+        Err(msg) => {
+            eprintln!("capture-oracle: {msg}");
+            return ExitCode::from(EXIT_INFRA);
+        }
+    };
+    let fixture_hash = match hash_fixture_dir(&ctx.fixture_dir) {
+        Ok(h) => h,
+        Err(msg) => {
+            eprintln!("capture-oracle: {msg}");
+            return ExitCode::from(EXIT_INFRA);
+        }
+    };
+    let config = PipelineConfig { k: PIPELINE_K };
+    let results = match dispatch_oracle_pipeline(
+        &corpus,
+        &queries,
+        &ctx.embedder,
+        Some(&ctx.reranker),
+        aggregation,
+        merge_config,
+        normalization,
+        &config,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("capture-oracle: pipeline failed: {e}");
+            return ExitCode::from(EXIT_INFRA);
+        }
+    };
+
+    let global = build_global_metrics(&results, &queries);
+    let per_category = build_per_category_metrics(&results, &queries);
+    let (latency_p50_ms, latency_p95_ms) = compute_latency_percentiles(&results);
+    let snapshot = BaselineSnapshot {
+        schema_version: BASELINE_SCHEMA_VERSION.to_owned(),
+        kind: BaselineKind::Oracle,
+        captured_with: "eval_harness capture-oracle".to_owned(),
+        timestamp: (ctx.timestamp)(),
+        model_id: embed::ModelId::default().repo_id().to_owned(),
+        model_revision: RURI_V3_310M_REVISION.to_owned(),
+        mlx_rs_version: MLX_RS_VERSION.to_owned(),
+        fixture_hash,
+        aggregation: aggregation.name(),
+        merge_config: merge_config.clone(),
+        normalization: *normalization,
+        global,
+        per_category,
+        latency_p50_ms,
+        latency_p95_ms,
+    };
+
+    if let Err(e) = write_json(&snapshot, output_path) {
+        eprintln!("capture-oracle: write failed: {e}");
+        return ExitCode::from(EXIT_INFRA);
+    }
+    eprintln!("capture-oracle: wrote {}", output_path.display());
+    ExitCode::SUCCESS
+}
+
 /// `verify-baseline baseline=<path>` — re-run evaluation, compare against the
 /// committed baseline.json under ADR 0002 tolerance, exit 0 + stderr banner
 /// `verify-baseline: passed` on success (FR-017 / AC-5.3).
@@ -781,7 +1015,7 @@ fn run_verify_baseline(kvs: &HashMap<String, String>) -> ExitCode {
     if committed.kind != BaselineKind::Forward {
         eprintln!(
             "verify-baseline: failed — committed kind {:?} is not Forward; \
-             did you pass reverse_baseline.json by mistake?",
+             did you pass reverse_baseline.json or oracle_baseline.json by mistake?",
             committed.kind
         );
         return ExitCode::from(EXIT_INFRA);
@@ -929,12 +1163,15 @@ fn validate_baseline_path(raw: &str) -> Result<PathBuf, String> {
 
 /// Load corpus + queries for `kind` from `fixture_dir`. `full` / `shuffled`
 /// use `documents.jsonl` + `queries.jsonl`; the known-answer kinds pull a
-/// sub-fixture from `known_answers.jsonl`.
+/// sub-fixture from `known_answers.jsonl`. `_oracle`-suffixed kinds map to
+/// the underlying fixture (e.g. `identity_oracle` → identity sub-fixture);
+/// the suffix only flips the dispatch in [`run_evaluate_with`].
 fn load_fixture_for_kind(
     fixture_dir: &Path,
     kind: &str,
 ) -> Result<(Vec<EvalDocument>, Vec<EvalQuery>), String> {
-    match kind {
+    let underlying = kind.strip_suffix(ORACLE_KIND_SUFFIX).unwrap_or(kind);
+    match underlying {
         "full" | "shuffled" => {
             let docs = load_documents(&fixture_dir.join("documents.jsonl"))
                 .map_err(|e| format!("load_documents: {e}"))?;

--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -318,9 +318,9 @@ where
 }
 
 /// Run [`evaluate_oracle`] with the concrete aggregator selected by
-/// `aggregation`. Mirrors [`dispatch_pipeline`] for the Oracle path
-/// (Issue #52); the two helpers stay separate because their return types
-/// differ ([`PipelineError`] vs [`OracleError`]).
+/// `aggregation`. Mirrors [`dispatch_pipeline`] for the Oracle path; the
+/// two helpers stay separate because their return types differ
+/// ([`PipelineError`] vs [`OracleError`]).
 #[allow(clippy::too_many_arguments)]
 fn dispatch_oracle_pipeline<E, R>(
     corpus: &[EvalDocument],
@@ -687,7 +687,6 @@ fn run_capture_baseline(kvs: &HashMap<String, String>) -> ExitCode {
     )
 }
 
-#[allow(clippy::too_many_arguments)]
 fn run_capture_baseline_with<E: Embed, R: Rerank>(
     ctx: &EvalContext<E, R>,
     output_path: &Path,
@@ -904,7 +903,6 @@ fn run_capture_oracle(kvs: &HashMap<String, String>) -> ExitCode {
     )
 }
 
-#[allow(clippy::too_many_arguments)]
 fn run_capture_oracle_with<E: Embed, R: Rerank>(
     ctx: &EvalContext<E, R>,
     output_path: &Path,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -9,4 +9,5 @@
 pub mod baseline;
 pub mod fixture;
 pub mod metrics;
+pub mod oracle_pipeline;
 pub mod pipeline;

--- a/src/eval/baseline.rs
+++ b/src/eval/baseline.rs
@@ -39,11 +39,15 @@ pub const UNINFORMATIVE_HALF_WIDTH: f64 = 0.10;
 pub const BASELINE_SCHEMA_VERSION: &str = "1.1";
 
 /// Discriminator distinguishing forward (`capture-baseline`) from reverse
-/// (`capture-reverse-baseline`) baseline files.
+/// (`capture-reverse-baseline`) and oracle (`capture-oracle`) baseline files.
 ///
-/// Both files share the [`BASELINE_SCHEMA_VERSION`] envelope; consumers read
-/// `kind` first to pick the right body shape rather than inferring from the
-/// presence of fields.
+/// All three files share the [`BASELINE_SCHEMA_VERSION`] envelope; consumers
+/// read `kind` first to pick the right body shape rather than inferring
+/// from the presence of fields. `Forward` and `Oracle` share the
+/// [`BaselineSnapshot`] body shape — the discriminator distinguishes the
+/// production-ranker capture from the retrieval-ceiling capture so
+/// `oracle-gap` (Issue #52) can refuse to compare a Forward against a
+/// Forward by mistake.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BaselineKind {
@@ -54,6 +58,11 @@ pub enum BaselineKind {
     /// `capture-reverse-baseline`. Body shape lives in the binary
     /// (`observed_lower_bound`, `k`, `captured_with`).
     Reverse,
+    /// Oracle retrieval-ceiling baseline produced by `capture-oracle`
+    /// (Issue #52). Body matches [`BaselineSnapshot`]; the difference
+    /// from `Forward` is that Stage 2 forced every relevance_map doc to
+    /// rank 0 so Stage 3 + Stage 4 ran against an idealised retrieval.
+    Oracle,
 }
 
 /// Frozen baseline produced by `eval_harness capture-baseline` and verified
@@ -307,6 +316,54 @@ mod tests {
         assert_eq!(parsed.schema_version, BASELINE_SCHEMA_VERSION);
         assert_eq!(parsed.kind, BaselineKind::Forward);
         assert_eq!(parsed.timestamp, "epoch:42");
+    }
+
+    // T-052-301: baseline_kind_oracle_serialises_as_snake_case
+    //
+    // Issue #52: BaselineKind::Oracle round-trips through serde_json as
+    // the snake_case label "oracle". Pinning the wire format guards
+    // against a future kind variant accidentally changing the discriminator
+    // name (which would invalidate every committed oracle_baseline.json).
+    #[test]
+    fn baseline_kind_oracle_serialises_as_snake_case() {
+        let json = serde_json::to_string(&BaselineKind::Oracle).expect("serialise");
+        assert_eq!(
+            json, "\"oracle\"",
+            "Oracle variant must serialise to \"oracle\""
+        );
+        let parsed: BaselineKind = serde_json::from_str(&json).expect("round-trip");
+        assert_eq!(parsed, BaselineKind::Oracle);
+    }
+
+    // T-052-302: baseline_snapshot_round_trips_with_oracle_kind
+    //
+    // The full BaselineSnapshot envelope round-trips with kind=Oracle,
+    // proving Forward and Oracle share a body shape and only differ in
+    // the discriminator. Required for `capture-oracle` to reuse
+    // [`write_json`] without a separate serialisation path.
+    #[test]
+    fn baseline_snapshot_round_trips_with_oracle_kind() {
+        let snap = BaselineSnapshot {
+            schema_version: BASELINE_SCHEMA_VERSION.to_owned(),
+            kind: BaselineKind::Oracle,
+            captured_with: "eval_harness capture-oracle".to_owned(),
+            timestamp: "epoch:42".to_owned(),
+            model_id: "test/model".to_owned(),
+            model_revision: "rev".to_owned(),
+            mlx_rs_version: "0.0.0".to_owned(),
+            fixture_hash: "fnv1a64:0".to_owned(),
+            aggregation: default_aggregation_kind(),
+            merge_config: HybridSearchConfig::default(),
+            normalization: pre_phase_5_disabled(),
+            global: vec![],
+            per_category: BTreeMap::new(),
+            latency_p50_ms: 0.0,
+            latency_p95_ms: 0.0,
+        };
+        let json = serde_json::to_string(&snap).expect("serialise");
+        let parsed: BaselineSnapshot = serde_json::from_str(&json).expect("round-trip");
+        assert_eq!(parsed.kind, BaselineKind::Oracle);
+        assert_eq!(parsed.captured_with, "eval_harness capture-oracle");
     }
 
     // T-021: committed_baseline_json_deserialises_under_new_schema

--- a/src/eval/oracle_pipeline.rs
+++ b/src/eval/oracle_pipeline.rs
@@ -5,20 +5,8 @@
 //! Quantifies the search-side bottleneck so amici can tell apart "rerank /
 //! aggregation is leaving recall on the table" from "retrieval can't surface
 //! the right doc in the first place" (CoSearch-style retrieval ceiling).
-//!
-//! Scope (Issue #52 AC 1, 2, 5, 6):
-//! - [`OracleMerge`] implements [`MergeStrategy`] and prepends every doc in
-//!   `relevant_docs` to the wrapped [`WeightedRrf`] output, dedup-merging
-//!   any natural occurrences so a single relevant doc cannot count twice.
-//! - [`evaluate_oracle`] constructs one [`OracleMerge`] per query from the
-//!   query's `relevance_map` (graded ≥ 1) and runs the same pipeline shape
-//!   as [`crate::eval::pipeline::evaluate`].
-//! - Pre-validates that every relevance_map doc_id exists in the corpus so
-//!   `apply_reranker`'s silent `filter_map(corpus_index.get(...))` never
-//!   eats a missing answer (would otherwise let a typo in the fixture pass
-//!   the AC 4 gate vacuously).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::time::Instant;
 
 use rurico::embed::Embed;
@@ -79,14 +67,9 @@ impl MergeStrategy for OracleMerge {
         if self.relevant_docs.is_empty() {
             return inner_hits;
         }
-        let relevant: HashSet<&str> = self.relevant_docs.iter().map(String::as_str).collect();
         let inner_max = inner_hits.iter().map(|h| h.score).fold(0.0_f64, f64::max);
         let mut output: Vec<MergedHit> =
             Vec::with_capacity(self.relevant_docs.len() + inner_hits.len());
-        // Anchor synthetic scores to `inner_max` so the smallest oracle
-        // score still strictly exceeds every natural hit. The descending
-        // `(len - i) + 1.0` offset keeps relevant_docs[0] highest and
-        // preserves input order under any subsequent sort.
         let count = self.relevant_docs.len();
         for (i, doc_id) in self.relevant_docs.iter().enumerate() {
             #[allow(clippy::cast_precision_loss)]
@@ -99,8 +82,11 @@ impl MergeStrategy for OracleMerge {
                 source_scores: HashMap::new(),
             });
         }
+        // Linear scan against `relevant_docs` (typical len 1–5) is cheaper
+        // than a per-call `HashSet` allocation and keeps the merge body
+        // free of intermediate state.
         for hit in inner_hits {
-            if !relevant.contains(hit.doc_id.as_str()) {
+            if !self.relevant_docs.iter().any(|r| r == &hit.doc_id) {
                 output.push(hit);
             }
         }
@@ -161,24 +147,17 @@ where
     R: Rerank,
     A: Aggregator,
 {
-    let corpus_ids: HashSet<&str> = corpus.iter().map(|d| d.id.as_str()).collect();
-    for query in queries {
-        for doc_id in query.relevance_map.keys() {
-            if !corpus_ids.contains(doc_id.as_str()) {
-                return Err(OracleError::UnknownRelevantDoc {
-                    query_id: query.id.clone(),
-                    doc_id: doc_id.clone(),
-                });
-            }
-        }
-    }
-
-    let conn = setup_pipeline_connection(corpus, embedder, normalization)?;
-
+    // Build the (doc_id → body) lookup once: it doubles as the corpus
+    // membership test for `validate_relevance_map_against_corpus` and as
+    // the rerank-stage body lookup for `run_single_query`. A separate
+    // `HashSet<&str>` would re-walk `corpus` for the same membership check.
     let corpus_index: HashMap<&str, &str> = corpus
         .iter()
         .map(|d| (d.id.as_str(), d.body.as_str()))
         .collect();
+    validate_relevance_map_against_corpus(queries, &corpus_index)?;
+
+    let conn = setup_pipeline_connection(corpus, embedder, normalization)?;
 
     let mut results = Vec::with_capacity(queries.len());
     for query in queries {
@@ -206,6 +185,27 @@ where
     Ok(results)
 }
 
+/// Reject any query whose `relevance_map` references a `doc_id` absent
+/// from `corpus_index`. Surfaces [`OracleError::UnknownRelevantDoc`]
+/// before pipeline setup so `apply_reranker`'s silent `filter_map` cannot
+/// drop the answer downstream.
+fn validate_relevance_map_against_corpus(
+    queries: &[EvalQuery],
+    corpus_index: &HashMap<&str, &str>,
+) -> Result<(), OracleError> {
+    for query in queries {
+        for doc_id in query.relevance_map.keys() {
+            if !corpus_index.contains_key(doc_id.as_str()) {
+                return Err(OracleError::UnknownRelevantDoc {
+                    query_id: query.id.clone(),
+                    doc_id: doc_id.clone(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Project `query.relevance_map` to the deduplicated list of `doc_id`s
 /// whose grade is ≥ 1, preserving a deterministic ordering across runs.
 ///
@@ -223,420 +223,4 @@ fn relevant_doc_ids(query: &EvalQuery) -> Vec<String> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    use rurico::retrieval::CandidateSource;
-
-    fn fts_candidate(doc_id: &str, score: f64, rank: usize) -> Candidate {
-        Candidate {
-            source: CandidateSource::Fts,
-            doc_id: doc_id.to_owned(),
-            chunk_id: None,
-            score,
-            rank,
-        }
-    }
-
-    // T-052-101: oracle_merge_injects_single_relevant_doc_at_rank_zero
-    //
-    // Issue #52 AC 1: OracleMerge forces a relevant doc to rank 0 of the
-    // merged output even when the underlying WeightedRrf would have ranked
-    // it lower. The synthetic `score = f64::MAX` keeps the slot fixed under
-    // any post-merge sort.
-    #[test]
-    fn oracle_merge_injects_single_relevant_doc_at_rank_zero() {
-        let candidates = vec![
-            fts_candidate("d1", -0.5, 0),
-            fts_candidate("d2", -0.6, 1),
-            fts_candidate("d3", -0.7, 2),
-        ];
-        let oracle = OracleMerge::new(HybridSearchConfig::default(), vec!["d3".to_owned()]);
-        let merged = oracle.merge(&candidates);
-
-        assert_eq!(
-            merged[0].doc_id, "d3",
-            "AC 1: relevant doc must occupy rank 0; got merged = {merged:?}"
-        );
-        let max_natural_score = merged
-            .iter()
-            .skip(1)
-            .map(|h| h.score)
-            .fold(f64::NEG_INFINITY, f64::max);
-        assert!(
-            merged[0].score > max_natural_score,
-            "AC 1: oracle hit must outscore every natural hit so post-sort keeps it at rank 0; \
-             got oracle.score = {} vs max_natural_score = {max_natural_score}",
-            merged[0].score
-        );
-    }
-
-    // T-052-102: oracle_merge_dedupes_relevant_doc_appearing_in_inner_result
-    //
-    // When a relevant doc is also produced by WeightedRrf, the oracle hit
-    // takes the rank-0 slot and the natural duplicate is dropped — a single
-    // relevant doc must not count twice in downstream metrics.
-    #[test]
-    fn oracle_merge_dedupes_relevant_doc_appearing_in_inner_result() {
-        let candidates = vec![
-            fts_candidate("d1", -0.5, 0),
-            fts_candidate("d2", -0.6, 1),
-            fts_candidate("d3", -0.7, 2),
-        ];
-        let oracle = OracleMerge::new(HybridSearchConfig::default(), vec!["d1".to_owned()]);
-        let merged = oracle.merge(&candidates);
-
-        assert_eq!(merged[0].doc_id, "d1", "rank 0 must be the oracle slot");
-        let d1_count = merged.iter().filter(|h| h.doc_id == "d1").count();
-        assert_eq!(
-            d1_count, 1,
-            "duplicate relevant doc must be dropped from the natural tail; got {d1_count}"
-        );
-    }
-
-    // T-052-103: oracle_merge_preserves_natural_order_for_non_relevant_docs
-    //
-    // The contract carved in the issue body: "配置済み doc 以外の順位は
-    // 元の WeightedRrf 結果を維持する". After dropping the oracle slot,
-    // the remaining hits must appear in the same order WeightedRrf would
-    // have emitted them.
-    #[test]
-    fn oracle_merge_preserves_natural_order_for_non_relevant_docs() {
-        let candidates = vec![
-            fts_candidate("d1", -0.5, 0),
-            fts_candidate("d2", -0.6, 1),
-            fts_candidate("d3", -0.7, 2),
-        ];
-        let baseline = WeightedRrf::new(HybridSearchConfig::default()).merge(&candidates);
-        let oracle = OracleMerge::new(HybridSearchConfig::default(), vec!["d3".to_owned()]);
-        let merged = oracle.merge(&candidates);
-
-        let baseline_non_d3: Vec<&str> = baseline
-            .iter()
-            .filter(|h| h.doc_id != "d3")
-            .map(|h| h.doc_id.as_str())
-            .collect();
-        let oracle_non_d3: Vec<&str> = merged
-            .iter()
-            .filter(|h| h.doc_id != "d3")
-            .map(|h| h.doc_id.as_str())
-            .collect();
-        assert_eq!(
-            baseline_non_d3, oracle_non_d3,
-            "non-relevant docs must keep their natural ordering"
-        );
-    }
-
-    // T-052-104: oracle_merge_emits_parent_granular_hits_with_empty_source_scores
-    //
-    // Every oracle hit is parent-granular (`chunk_id = None`) so Stage 3
-    // aggregators that bucket by `(doc_id, chunk_id)` cannot collapse it
-    // against a sibling chunk. `source_scores` is empty because no real
-    // retriever contributed.
-    #[test]
-    fn oracle_merge_emits_parent_granular_hits_with_empty_source_scores() {
-        let candidates = vec![fts_candidate("d1", -0.5, 0)];
-        let oracle = OracleMerge::new(HybridSearchConfig::default(), vec!["d2".to_owned()]);
-        let merged = oracle.merge(&candidates);
-
-        assert!(
-            merged[0].chunk_id.is_none(),
-            "oracle hit must be parent-granular; got chunk_id = {:?}",
-            merged[0].chunk_id
-        );
-        assert!(
-            merged[0].source_scores.is_empty(),
-            "oracle hit has no contributing retriever — source_scores must be empty; got {:?}",
-            merged[0].source_scores
-        );
-    }
-
-    // T-052-105: oracle_merge_orders_multiple_relevant_docs_by_input_sequence
-    //
-    // When a query has multiple relevant docs, the prepended slots use
-    // strictly descending synthetic scores so the input order survives
-    // through any post-merge sort.
-    #[test]
-    fn oracle_merge_orders_multiple_relevant_docs_by_input_sequence() {
-        let candidates = vec![fts_candidate("d99", -0.5, 0)];
-        let oracle = OracleMerge::new(
-            HybridSearchConfig::default(),
-            vec!["d1".to_owned(), "d2".to_owned(), "d3".to_owned()],
-        );
-        let merged = oracle.merge(&candidates);
-
-        assert_eq!(
-            merged
-                .iter()
-                .take(3)
-                .map(|h| h.doc_id.as_str())
-                .collect::<Vec<_>>(),
-            vec!["d1", "d2", "d3"],
-            "multi-relevant order must follow the input sequence"
-        );
-        assert!(
-            merged[0].score > merged[1].score && merged[1].score > merged[2].score,
-            "synthetic scores must be strictly descending; got {} {} {}",
-            merged[0].score,
-            merged[1].score,
-            merged[2].score
-        );
-    }
-
-    // T-052-106: oracle_merge_passthrough_when_no_relevant_docs
-    //
-    // Empty `relevant_docs` short-circuits to the WeightedRrf output
-    // verbatim — guards the `evaluate_oracle` path against a query whose
-    // relevance_map happens to be empty (defensive: such a query would not
-    // contribute to recall@k anyway, but it must not crash the pipeline).
-    #[test]
-    fn oracle_merge_passthrough_when_no_relevant_docs() {
-        let candidates = vec![fts_candidate("d1", -0.5, 0), fts_candidate("d2", -0.6, 1)];
-        let baseline = WeightedRrf::new(HybridSearchConfig::default()).merge(&candidates);
-        let oracle = OracleMerge::new(HybridSearchConfig::default(), Vec::new());
-        let merged = oracle.merge(&candidates);
-
-        assert_eq!(
-            merged, baseline,
-            "empty relevant_docs must short-circuit to WeightedRrf output"
-        );
-    }
-
-    // T-052-107: relevant_doc_ids_filters_by_grade_and_sorts_deterministically
-    //
-    // `relevant_doc_ids` drops grade=0 entries (treated as "not relevant"
-    // by amici metrics) and sorts the surviving ids. Sorting matters
-    // because HashMap iteration order is hasher-dependent — without it the
-    // baseline.json byte content would drift across runs.
-    #[test]
-    fn relevant_doc_ids_filters_by_grade_and_sorts_deterministically() {
-        use crate::eval::fixture::EvalQuery;
-        let mut relevance_map = HashMap::new();
-        relevance_map.insert("z9".to_owned(), 0u8);
-        relevance_map.insert("d2".to_owned(), 1u8);
-        relevance_map.insert("a1".to_owned(), 3u8);
-        let query = EvalQuery {
-            id: "q1".to_owned(),
-            text: "stub".to_owned(),
-            category: "C1".to_owned(),
-            relevance_map,
-            annotation: "stub".to_owned(),
-        };
-        let ids = relevant_doc_ids(&query);
-        assert_eq!(
-            ids,
-            vec!["a1".to_owned(), "d2".to_owned()],
-            "must drop grade=0 and sort ascending"
-        );
-    }
-
-    // T-052-201: evaluate_oracle_rejects_relevance_map_pointing_outside_corpus
-    //
-    // Issue #52 P1 (advisor): if a query's relevance_map names a doc_id
-    // that the corpus lacks, `apply_reranker` would silently drop it via
-    // `filter_map(corpus_index.get(...))`. That would let the AC 4 gate
-    // pass vacuously when a fixture typo dropped the answer. evaluate_oracle
-    // must surface this as a typed error before pipeline setup.
-    #[test]
-    fn evaluate_oracle_rejects_relevance_map_pointing_outside_corpus() {
-        use rurico::embed::MockEmbedder;
-        use rurico::reranker::MockReranker;
-        use rurico::retrieval::IdentityAggregator;
-
-        let corpus = vec![EvalDocument {
-            id: "d1".to_owned(),
-            title: "title".to_owned(),
-            body: "body for d1".to_owned(),
-            category_hint: None,
-            source: "test".to_owned(),
-        }];
-        let mut relevance_map = HashMap::new();
-        relevance_map.insert("d1".to_owned(), 1u8);
-        relevance_map.insert("doc_that_does_not_exist".to_owned(), 1u8);
-        let queries = vec![EvalQuery {
-            id: "q1".to_owned(),
-            text: "body".to_owned(),
-            category: "C1".to_owned(),
-            relevance_map,
-            annotation: "stub".to_owned(),
-        }];
-        let embedder = MockEmbedder::default();
-        let reranker: Option<&MockReranker> = None;
-        let aggregator = IdentityAggregator;
-        let merge_config = HybridSearchConfig::default();
-        let normalization = QueryNormalizationConfig::default();
-        let config = PipelineConfig { k: 5 };
-
-        let result = evaluate_oracle(
-            &corpus,
-            &queries,
-            &embedder,
-            reranker,
-            &aggregator,
-            &merge_config,
-            &normalization,
-            &config,
-        );
-
-        assert!(
-            matches!(
-                result,
-                Err(OracleError::UnknownRelevantDoc { ref query_id, ref doc_id })
-                    if query_id == "q1" && doc_id == "doc_that_does_not_exist"
-            ),
-            "must surface UnknownRelevantDoc {{ query_id=q1, doc_id=doc_that_does_not_exist }}; got: {result:?}"
-        );
-    }
-
-    // T-052-202: evaluate_oracle_places_relevant_doc_at_top_under_mock_pipeline
-    //
-    // End-to-end proof that OracleMerge ↔ pipeline composition surfaces the
-    // relevant doc at rank 0 of `ranked_hits` even when the upstream
-    // retrieval order would have buried it. Uses MockEmbedder so the test
-    // runs in the default cargo lane (no MLX).
-    #[test]
-    fn evaluate_oracle_places_relevant_doc_at_top_under_mock_pipeline() {
-        use rurico::embed::MockEmbedder;
-        use rurico::reranker::MockReranker;
-        use rurico::retrieval::IdentityAggregator;
-
-        let corpus = vec![
-            EvalDocument {
-                id: "d1".to_owned(),
-                title: "title-d1".to_owned(),
-                body: "alpha document about retrieval".to_owned(),
-                category_hint: None,
-                source: "test".to_owned(),
-            },
-            EvalDocument {
-                id: "d2".to_owned(),
-                title: "title-d2".to_owned(),
-                body: "beta document about ranking".to_owned(),
-                category_hint: None,
-                source: "test".to_owned(),
-            },
-            EvalDocument {
-                id: "d3".to_owned(),
-                title: "title-d3".to_owned(),
-                body: "gamma document about indexing".to_owned(),
-                category_hint: None,
-                source: "test".to_owned(),
-            },
-        ];
-        let mut relevance_map = HashMap::new();
-        // d3 is far from "alpha retrieval" linguistically — without
-        // OracleMerge it would not surface at rank 0.
-        relevance_map.insert("d3".to_owned(), 1u8);
-        let queries = vec![EvalQuery {
-            id: "q1".to_owned(),
-            text: "alpha retrieval".to_owned(),
-            category: "C1".to_owned(),
-            relevance_map,
-            annotation: "stub".to_owned(),
-        }];
-        let embedder = MockEmbedder::default();
-        let reranker: Option<&MockReranker> = None;
-        let aggregator = IdentityAggregator;
-        let merge_config = HybridSearchConfig::default();
-        let normalization = QueryNormalizationConfig::default();
-        let config = PipelineConfig { k: 5 };
-
-        let results = evaluate_oracle(
-            &corpus,
-            &queries,
-            &embedder,
-            reranker,
-            &aggregator,
-            &merge_config,
-            &normalization,
-            &config,
-        )
-        .expect("oracle pipeline must succeed under MockEmbedder + no reranker");
-
-        assert_eq!(results.len(), 1, "one query in → one QueryResult out");
-        let top = results[0]
-            .ranked_hits
-            .first()
-            .expect("ranked_hits must be non-empty");
-        assert_eq!(
-            top.doc_id, "d3",
-            "AC 1: oracle path must surface d3 at rank 0; got ranked_hits = {:?}",
-            results[0].ranked_hits
-        );
-    }
-
-    // T-052-203: evaluate_oracle_uses_per_query_relevant_docs
-    //
-    // Two queries with different relevance_maps must each surface their
-    // own relevant doc at rank 0 — proves the per-query OracleMerge
-    // construction (vs. a single shared instance) wires the right
-    // relevant_docs through the pipeline loop.
-    #[test]
-    fn evaluate_oracle_uses_per_query_relevant_docs() {
-        use rurico::embed::MockEmbedder;
-        use rurico::reranker::MockReranker;
-        use rurico::retrieval::IdentityAggregator;
-
-        let corpus = vec![
-            EvalDocument {
-                id: "d1".to_owned(),
-                title: "t1".to_owned(),
-                body: "alpha".to_owned(),
-                category_hint: None,
-                source: "test".to_owned(),
-            },
-            EvalDocument {
-                id: "d2".to_owned(),
-                title: "t2".to_owned(),
-                body: "beta".to_owned(),
-                category_hint: None,
-                source: "test".to_owned(),
-            },
-        ];
-        let queries = vec![
-            EvalQuery {
-                id: "qa".to_owned(),
-                text: "alpha".to_owned(),
-                category: "C1".to_owned(),
-                relevance_map: {
-                    let mut m = HashMap::new();
-                    m.insert("d1".to_owned(), 1u8);
-                    m
-                },
-                annotation: "stub".to_owned(),
-            },
-            EvalQuery {
-                id: "qb".to_owned(),
-                text: "beta".to_owned(),
-                category: "C1".to_owned(),
-                relevance_map: {
-                    let mut m = HashMap::new();
-                    m.insert("d2".to_owned(), 1u8);
-                    m
-                },
-                annotation: "stub".to_owned(),
-            },
-        ];
-        let embedder = MockEmbedder::default();
-        let reranker: Option<&MockReranker> = None;
-        let aggregator = IdentityAggregator;
-        let merge_config = HybridSearchConfig::default();
-        let normalization = QueryNormalizationConfig::default();
-        let config = PipelineConfig { k: 5 };
-
-        let results = evaluate_oracle(
-            &corpus,
-            &queries,
-            &embedder,
-            reranker,
-            &aggregator,
-            &merge_config,
-            &normalization,
-            &config,
-        )
-        .expect("per-query oracle pipeline must succeed");
-
-        assert_eq!(results[0].ranked_hits[0].doc_id, "d1", "qa → d1 at rank 0");
-        assert_eq!(results[1].ranked_hits[0].doc_id, "d2", "qb → d2 at rank 0");
-    }
-}
+mod tests;

--- a/src/eval/oracle_pipeline.rs
+++ b/src/eval/oracle_pipeline.rs
@@ -1,0 +1,642 @@
+//! Oracle retrieval pipeline (Issue #52).
+//!
+//! Reuses `pipeline::evaluate` wiring with a per-query [`OracleMerge`] that
+//! force-places known-relevant documents at rank 0 of the Stage 2 output.
+//! Quantifies the search-side bottleneck so amici can tell apart "rerank /
+//! aggregation is leaving recall on the table" from "retrieval can't surface
+//! the right doc in the first place" (CoSearch-style retrieval ceiling).
+//!
+//! Scope (Issue #52 AC 1, 2, 5, 6):
+//! - [`OracleMerge`] implements [`MergeStrategy`] and prepends every doc in
+//!   `relevant_docs` to the wrapped [`WeightedRrf`] output, dedup-merging
+//!   any natural occurrences so a single relevant doc cannot count twice.
+//! - [`evaluate_oracle`] constructs one [`OracleMerge`] per query from the
+//!   query's `relevance_map` (graded ≥ 1) and runs the same pipeline shape
+//!   as [`crate::eval::pipeline::evaluate`].
+//! - Pre-validates that every relevance_map doc_id exists in the corpus so
+//!   `apply_reranker`'s silent `filter_map(corpus_index.get(...))` never
+//!   eats a missing answer (would otherwise let a typo in the fixture pass
+//!   the AC 4 gate vacuously).
+
+use std::collections::{HashMap, HashSet};
+use std::time::Instant;
+
+use rurico::embed::Embed;
+use rurico::reranker::Rerank;
+use rurico::retrieval::{
+    Aggregator, Candidate, HybridSearchConfig, MergeStrategy, MergedHit, WeightedRrf,
+};
+use rurico::storage::QueryNormalizationConfig;
+
+use crate::eval::fixture::{EvalDocument, EvalQuery};
+use crate::eval::pipeline::{
+    PipelineConfig, PipelineError, QueryResult, run_single_query, setup_pipeline_connection,
+};
+
+/// Stage 2 strategy that force-injects known-relevant docs at the top of
+/// the merged ranking.
+///
+/// Wraps [`WeightedRrf`] so the natural fusion order is preserved for every
+/// non-relevant doc; the relevant doc list is **prepended** with synthetic
+/// scores `inner_max + (relevant_docs.len() - i)` so the trait's
+/// "score-descending sorted output" contract holds without re-sorting the
+/// inner result.
+///
+/// Synthetic scores are anchored to `inner_max` (not a bare `f64::MAX`)
+/// because subtracting small integers from `f64::MAX` saturates to the same
+/// value at the precision limit — `f64::MAX - 1.0 == f64::MAX - 2.0 ==
+/// f64::MAX` — which would silently collapse the relevant-doc ordering.
+///
+/// The synthetic [`MergedHit`]s use `chunk_id = None` (parent-granular) and
+/// an empty `source_scores` map — Stage 3 aggregators that bucket by
+/// `(doc_id, chunk_id)` therefore see oracle hits as pure parent rows and
+/// cannot collapse them against sibling chunks. `evaluate_oracle` is the
+/// only documented constructor path; no production retrieval surface uses
+/// this strategy.
+pub struct OracleMerge {
+    inner: WeightedRrf,
+    relevant_docs: Vec<String>,
+}
+
+impl OracleMerge {
+    /// Build an oracle merge for one query.
+    ///
+    /// `relevant_docs` is the deduplicated list of `doc_id`s whose
+    /// relevance grade is ≥ 1; ordering inside the slice is preserved in
+    /// the emitted ranking when multiple relevant docs land at the top.
+    #[must_use]
+    pub fn new(merge_config: HybridSearchConfig, relevant_docs: Vec<String>) -> Self {
+        Self {
+            inner: WeightedRrf::new(merge_config),
+            relevant_docs,
+        }
+    }
+}
+
+impl MergeStrategy for OracleMerge {
+    fn merge(&self, candidates: &[Candidate]) -> Vec<MergedHit> {
+        let inner_hits = self.inner.merge(candidates);
+        if self.relevant_docs.is_empty() {
+            return inner_hits;
+        }
+        let relevant: HashSet<&str> = self.relevant_docs.iter().map(String::as_str).collect();
+        let inner_max = inner_hits.iter().map(|h| h.score).fold(0.0_f64, f64::max);
+        let mut output: Vec<MergedHit> =
+            Vec::with_capacity(self.relevant_docs.len() + inner_hits.len());
+        // Anchor synthetic scores to `inner_max` so the smallest oracle
+        // score still strictly exceeds every natural hit. The descending
+        // `(len - i) + 1.0` offset keeps relevant_docs[0] highest and
+        // preserves input order under any subsequent sort.
+        let count = self.relevant_docs.len();
+        for (i, doc_id) in self.relevant_docs.iter().enumerate() {
+            #[allow(clippy::cast_precision_loss)]
+            let offset = (count - i) as f64;
+            let score = inner_max + offset;
+            output.push(MergedHit {
+                doc_id: doc_id.clone(),
+                chunk_id: None,
+                score,
+                source_scores: HashMap::new(),
+            });
+        }
+        for hit in inner_hits {
+            if !relevant.contains(hit.doc_id.as_str()) {
+                output.push(hit);
+            }
+        }
+        output
+    }
+}
+
+/// Errors surfaced by [`evaluate_oracle`].
+#[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
+pub enum OracleError {
+    /// Underlying pipeline failure (storage, embed, rerank, sanitize).
+    #[error("oracle pipeline error: {0}")]
+    Pipeline(#[from] PipelineError),
+    /// A query's `relevance_map` referenced a `doc_id` absent from the
+    /// corpus. Surfaced eagerly so the AC 4 gate ("oracle recall@k ≥
+    /// baseline recall@k for every category") cannot pass vacuously when a
+    /// fixture typo silently drops the answer in `apply_reranker`.
+    #[error(
+        "oracle: query {query_id:?} references doc_id {doc_id:?} in relevance_map but the corpus has no such document"
+    )]
+    UnknownRelevantDoc {
+        /// The query whose relevance_map is malformed.
+        query_id: String,
+        /// The doc_id that does not exist in the supplied corpus.
+        doc_id: String,
+    },
+}
+
+/// Run the reference pipeline with a per-query [`OracleMerge`] and the
+/// supplied aggregator + reranker.
+///
+/// Mirrors [`crate::eval::pipeline::evaluate`]'s shape but routes Stage 2
+/// through [`OracleMerge::new`] so every relevant doc lands at rank 0
+/// **before** Stage 3 aggregation and Stage 4 rerank. The downstream stages
+/// run unmodified — measuring the post-retrieval ceiling under the
+/// production rerank/aggregation behaviour rather than the
+/// "everything-is-perfect" upper bound.
+///
+/// # Errors
+///
+/// Returns [`OracleError::UnknownRelevantDoc`] when any query's
+/// `relevance_map` references a `doc_id` outside `corpus`, and
+/// [`OracleError::Pipeline`] for downstream pipeline failures.
+#[allow(clippy::too_many_arguments)]
+pub fn evaluate_oracle<E, R, A>(
+    corpus: &[EvalDocument],
+    queries: &[EvalQuery],
+    embedder: &E,
+    reranker: Option<&R>,
+    aggregator: &A,
+    merge_config: &HybridSearchConfig,
+    normalization: &QueryNormalizationConfig,
+    config: &PipelineConfig,
+) -> Result<Vec<QueryResult>, OracleError>
+where
+    E: Embed,
+    R: Rerank,
+    A: Aggregator,
+{
+    let corpus_ids: HashSet<&str> = corpus.iter().map(|d| d.id.as_str()).collect();
+    for query in queries {
+        for doc_id in query.relevance_map.keys() {
+            if !corpus_ids.contains(doc_id.as_str()) {
+                return Err(OracleError::UnknownRelevantDoc {
+                    query_id: query.id.clone(),
+                    doc_id: doc_id.clone(),
+                });
+            }
+        }
+    }
+
+    let conn = setup_pipeline_connection(corpus, embedder, normalization)?;
+
+    let corpus_index: HashMap<&str, &str> = corpus
+        .iter()
+        .map(|d| (d.id.as_str(), d.body.as_str()))
+        .collect();
+
+    let mut results = Vec::with_capacity(queries.len());
+    for query in queries {
+        let relevant_docs = relevant_doc_ids(query);
+        let oracle = OracleMerge::new(merge_config.clone(), relevant_docs);
+        let started = Instant::now();
+        let ranked_hits = run_single_query(
+            &conn,
+            query,
+            embedder,
+            reranker,
+            aggregator,
+            &oracle,
+            &corpus_index,
+            normalization,
+            config,
+        )?;
+        let latency_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        results.push(QueryResult {
+            query_id: query.id.clone(),
+            ranked_hits,
+            latency_ms,
+        });
+    }
+    Ok(results)
+}
+
+/// Project `query.relevance_map` to the deduplicated list of `doc_id`s
+/// whose grade is ≥ 1, preserving a deterministic ordering across runs.
+///
+/// `HashMap` iteration order is unstable across hashers — sort by `doc_id`
+/// so two captures of the same fixture produce bit-identical baselines.
+fn relevant_doc_ids(query: &EvalQuery) -> Vec<String> {
+    let mut ids: Vec<String> = query
+        .relevance_map
+        .iter()
+        .filter(|(_, grade)| **grade >= 1)
+        .map(|(doc_id, _)| doc_id.clone())
+        .collect();
+    ids.sort();
+    ids
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rurico::retrieval::CandidateSource;
+
+    fn fts_candidate(doc_id: &str, score: f64, rank: usize) -> Candidate {
+        Candidate {
+            source: CandidateSource::Fts,
+            doc_id: doc_id.to_owned(),
+            chunk_id: None,
+            score,
+            rank,
+        }
+    }
+
+    // T-052-101: oracle_merge_injects_single_relevant_doc_at_rank_zero
+    //
+    // Issue #52 AC 1: OracleMerge forces a relevant doc to rank 0 of the
+    // merged output even when the underlying WeightedRrf would have ranked
+    // it lower. The synthetic `score = f64::MAX` keeps the slot fixed under
+    // any post-merge sort.
+    #[test]
+    fn oracle_merge_injects_single_relevant_doc_at_rank_zero() {
+        let candidates = vec![
+            fts_candidate("d1", -0.5, 0),
+            fts_candidate("d2", -0.6, 1),
+            fts_candidate("d3", -0.7, 2),
+        ];
+        let oracle = OracleMerge::new(HybridSearchConfig::default(), vec!["d3".to_owned()]);
+        let merged = oracle.merge(&candidates);
+
+        assert_eq!(
+            merged[0].doc_id, "d3",
+            "AC 1: relevant doc must occupy rank 0; got merged = {merged:?}"
+        );
+        let max_natural_score = merged
+            .iter()
+            .skip(1)
+            .map(|h| h.score)
+            .fold(f64::NEG_INFINITY, f64::max);
+        assert!(
+            merged[0].score > max_natural_score,
+            "AC 1: oracle hit must outscore every natural hit so post-sort keeps it at rank 0; \
+             got oracle.score = {} vs max_natural_score = {max_natural_score}",
+            merged[0].score
+        );
+    }
+
+    // T-052-102: oracle_merge_dedupes_relevant_doc_appearing_in_inner_result
+    //
+    // When a relevant doc is also produced by WeightedRrf, the oracle hit
+    // takes the rank-0 slot and the natural duplicate is dropped — a single
+    // relevant doc must not count twice in downstream metrics.
+    #[test]
+    fn oracle_merge_dedupes_relevant_doc_appearing_in_inner_result() {
+        let candidates = vec![
+            fts_candidate("d1", -0.5, 0),
+            fts_candidate("d2", -0.6, 1),
+            fts_candidate("d3", -0.7, 2),
+        ];
+        let oracle = OracleMerge::new(HybridSearchConfig::default(), vec!["d1".to_owned()]);
+        let merged = oracle.merge(&candidates);
+
+        assert_eq!(merged[0].doc_id, "d1", "rank 0 must be the oracle slot");
+        let d1_count = merged.iter().filter(|h| h.doc_id == "d1").count();
+        assert_eq!(
+            d1_count, 1,
+            "duplicate relevant doc must be dropped from the natural tail; got {d1_count}"
+        );
+    }
+
+    // T-052-103: oracle_merge_preserves_natural_order_for_non_relevant_docs
+    //
+    // The contract carved in the issue body: "配置済み doc 以外の順位は
+    // 元の WeightedRrf 結果を維持する". After dropping the oracle slot,
+    // the remaining hits must appear in the same order WeightedRrf would
+    // have emitted them.
+    #[test]
+    fn oracle_merge_preserves_natural_order_for_non_relevant_docs() {
+        let candidates = vec![
+            fts_candidate("d1", -0.5, 0),
+            fts_candidate("d2", -0.6, 1),
+            fts_candidate("d3", -0.7, 2),
+        ];
+        let baseline = WeightedRrf::new(HybridSearchConfig::default()).merge(&candidates);
+        let oracle = OracleMerge::new(HybridSearchConfig::default(), vec!["d3".to_owned()]);
+        let merged = oracle.merge(&candidates);
+
+        let baseline_non_d3: Vec<&str> = baseline
+            .iter()
+            .filter(|h| h.doc_id != "d3")
+            .map(|h| h.doc_id.as_str())
+            .collect();
+        let oracle_non_d3: Vec<&str> = merged
+            .iter()
+            .filter(|h| h.doc_id != "d3")
+            .map(|h| h.doc_id.as_str())
+            .collect();
+        assert_eq!(
+            baseline_non_d3, oracle_non_d3,
+            "non-relevant docs must keep their natural ordering"
+        );
+    }
+
+    // T-052-104: oracle_merge_emits_parent_granular_hits_with_empty_source_scores
+    //
+    // Every oracle hit is parent-granular (`chunk_id = None`) so Stage 3
+    // aggregators that bucket by `(doc_id, chunk_id)` cannot collapse it
+    // against a sibling chunk. `source_scores` is empty because no real
+    // retriever contributed.
+    #[test]
+    fn oracle_merge_emits_parent_granular_hits_with_empty_source_scores() {
+        let candidates = vec![fts_candidate("d1", -0.5, 0)];
+        let oracle = OracleMerge::new(HybridSearchConfig::default(), vec!["d2".to_owned()]);
+        let merged = oracle.merge(&candidates);
+
+        assert!(
+            merged[0].chunk_id.is_none(),
+            "oracle hit must be parent-granular; got chunk_id = {:?}",
+            merged[0].chunk_id
+        );
+        assert!(
+            merged[0].source_scores.is_empty(),
+            "oracle hit has no contributing retriever — source_scores must be empty; got {:?}",
+            merged[0].source_scores
+        );
+    }
+
+    // T-052-105: oracle_merge_orders_multiple_relevant_docs_by_input_sequence
+    //
+    // When a query has multiple relevant docs, the prepended slots use
+    // strictly descending synthetic scores so the input order survives
+    // through any post-merge sort.
+    #[test]
+    fn oracle_merge_orders_multiple_relevant_docs_by_input_sequence() {
+        let candidates = vec![fts_candidate("d99", -0.5, 0)];
+        let oracle = OracleMerge::new(
+            HybridSearchConfig::default(),
+            vec!["d1".to_owned(), "d2".to_owned(), "d3".to_owned()],
+        );
+        let merged = oracle.merge(&candidates);
+
+        assert_eq!(
+            merged
+                .iter()
+                .take(3)
+                .map(|h| h.doc_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["d1", "d2", "d3"],
+            "multi-relevant order must follow the input sequence"
+        );
+        assert!(
+            merged[0].score > merged[1].score && merged[1].score > merged[2].score,
+            "synthetic scores must be strictly descending; got {} {} {}",
+            merged[0].score,
+            merged[1].score,
+            merged[2].score
+        );
+    }
+
+    // T-052-106: oracle_merge_passthrough_when_no_relevant_docs
+    //
+    // Empty `relevant_docs` short-circuits to the WeightedRrf output
+    // verbatim — guards the `evaluate_oracle` path against a query whose
+    // relevance_map happens to be empty (defensive: such a query would not
+    // contribute to recall@k anyway, but it must not crash the pipeline).
+    #[test]
+    fn oracle_merge_passthrough_when_no_relevant_docs() {
+        let candidates = vec![fts_candidate("d1", -0.5, 0), fts_candidate("d2", -0.6, 1)];
+        let baseline = WeightedRrf::new(HybridSearchConfig::default()).merge(&candidates);
+        let oracle = OracleMerge::new(HybridSearchConfig::default(), Vec::new());
+        let merged = oracle.merge(&candidates);
+
+        assert_eq!(
+            merged, baseline,
+            "empty relevant_docs must short-circuit to WeightedRrf output"
+        );
+    }
+
+    // T-052-107: relevant_doc_ids_filters_by_grade_and_sorts_deterministically
+    //
+    // `relevant_doc_ids` drops grade=0 entries (treated as "not relevant"
+    // by amici metrics) and sorts the surviving ids. Sorting matters
+    // because HashMap iteration order is hasher-dependent — without it the
+    // baseline.json byte content would drift across runs.
+    #[test]
+    fn relevant_doc_ids_filters_by_grade_and_sorts_deterministically() {
+        use crate::eval::fixture::EvalQuery;
+        let mut relevance_map = HashMap::new();
+        relevance_map.insert("z9".to_owned(), 0u8);
+        relevance_map.insert("d2".to_owned(), 1u8);
+        relevance_map.insert("a1".to_owned(), 3u8);
+        let query = EvalQuery {
+            id: "q1".to_owned(),
+            text: "stub".to_owned(),
+            category: "C1".to_owned(),
+            relevance_map,
+            annotation: "stub".to_owned(),
+        };
+        let ids = relevant_doc_ids(&query);
+        assert_eq!(
+            ids,
+            vec!["a1".to_owned(), "d2".to_owned()],
+            "must drop grade=0 and sort ascending"
+        );
+    }
+
+    // T-052-201: evaluate_oracle_rejects_relevance_map_pointing_outside_corpus
+    //
+    // Issue #52 P1 (advisor): if a query's relevance_map names a doc_id
+    // that the corpus lacks, `apply_reranker` would silently drop it via
+    // `filter_map(corpus_index.get(...))`. That would let the AC 4 gate
+    // pass vacuously when a fixture typo dropped the answer. evaluate_oracle
+    // must surface this as a typed error before pipeline setup.
+    #[test]
+    fn evaluate_oracle_rejects_relevance_map_pointing_outside_corpus() {
+        use rurico::embed::MockEmbedder;
+        use rurico::reranker::MockReranker;
+        use rurico::retrieval::IdentityAggregator;
+
+        let corpus = vec![EvalDocument {
+            id: "d1".to_owned(),
+            title: "title".to_owned(),
+            body: "body for d1".to_owned(),
+            category_hint: None,
+            source: "test".to_owned(),
+        }];
+        let mut relevance_map = HashMap::new();
+        relevance_map.insert("d1".to_owned(), 1u8);
+        relevance_map.insert("doc_that_does_not_exist".to_owned(), 1u8);
+        let queries = vec![EvalQuery {
+            id: "q1".to_owned(),
+            text: "body".to_owned(),
+            category: "C1".to_owned(),
+            relevance_map,
+            annotation: "stub".to_owned(),
+        }];
+        let embedder = MockEmbedder::default();
+        let reranker: Option<&MockReranker> = None;
+        let aggregator = IdentityAggregator;
+        let merge_config = HybridSearchConfig::default();
+        let normalization = QueryNormalizationConfig::default();
+        let config = PipelineConfig { k: 5 };
+
+        let result = evaluate_oracle(
+            &corpus,
+            &queries,
+            &embedder,
+            reranker,
+            &aggregator,
+            &merge_config,
+            &normalization,
+            &config,
+        );
+
+        assert!(
+            matches!(
+                result,
+                Err(OracleError::UnknownRelevantDoc { ref query_id, ref doc_id })
+                    if query_id == "q1" && doc_id == "doc_that_does_not_exist"
+            ),
+            "must surface UnknownRelevantDoc {{ query_id=q1, doc_id=doc_that_does_not_exist }}; got: {result:?}"
+        );
+    }
+
+    // T-052-202: evaluate_oracle_places_relevant_doc_at_top_under_mock_pipeline
+    //
+    // End-to-end proof that OracleMerge ↔ pipeline composition surfaces the
+    // relevant doc at rank 0 of `ranked_hits` even when the upstream
+    // retrieval order would have buried it. Uses MockEmbedder so the test
+    // runs in the default cargo lane (no MLX).
+    #[test]
+    fn evaluate_oracle_places_relevant_doc_at_top_under_mock_pipeline() {
+        use rurico::embed::MockEmbedder;
+        use rurico::reranker::MockReranker;
+        use rurico::retrieval::IdentityAggregator;
+
+        let corpus = vec![
+            EvalDocument {
+                id: "d1".to_owned(),
+                title: "title-d1".to_owned(),
+                body: "alpha document about retrieval".to_owned(),
+                category_hint: None,
+                source: "test".to_owned(),
+            },
+            EvalDocument {
+                id: "d2".to_owned(),
+                title: "title-d2".to_owned(),
+                body: "beta document about ranking".to_owned(),
+                category_hint: None,
+                source: "test".to_owned(),
+            },
+            EvalDocument {
+                id: "d3".to_owned(),
+                title: "title-d3".to_owned(),
+                body: "gamma document about indexing".to_owned(),
+                category_hint: None,
+                source: "test".to_owned(),
+            },
+        ];
+        let mut relevance_map = HashMap::new();
+        // d3 is far from "alpha retrieval" linguistically — without
+        // OracleMerge it would not surface at rank 0.
+        relevance_map.insert("d3".to_owned(), 1u8);
+        let queries = vec![EvalQuery {
+            id: "q1".to_owned(),
+            text: "alpha retrieval".to_owned(),
+            category: "C1".to_owned(),
+            relevance_map,
+            annotation: "stub".to_owned(),
+        }];
+        let embedder = MockEmbedder::default();
+        let reranker: Option<&MockReranker> = None;
+        let aggregator = IdentityAggregator;
+        let merge_config = HybridSearchConfig::default();
+        let normalization = QueryNormalizationConfig::default();
+        let config = PipelineConfig { k: 5 };
+
+        let results = evaluate_oracle(
+            &corpus,
+            &queries,
+            &embedder,
+            reranker,
+            &aggregator,
+            &merge_config,
+            &normalization,
+            &config,
+        )
+        .expect("oracle pipeline must succeed under MockEmbedder + no reranker");
+
+        assert_eq!(results.len(), 1, "one query in → one QueryResult out");
+        let top = results[0]
+            .ranked_hits
+            .first()
+            .expect("ranked_hits must be non-empty");
+        assert_eq!(
+            top.doc_id, "d3",
+            "AC 1: oracle path must surface d3 at rank 0; got ranked_hits = {:?}",
+            results[0].ranked_hits
+        );
+    }
+
+    // T-052-203: evaluate_oracle_uses_per_query_relevant_docs
+    //
+    // Two queries with different relevance_maps must each surface their
+    // own relevant doc at rank 0 — proves the per-query OracleMerge
+    // construction (vs. a single shared instance) wires the right
+    // relevant_docs through the pipeline loop.
+    #[test]
+    fn evaluate_oracle_uses_per_query_relevant_docs() {
+        use rurico::embed::MockEmbedder;
+        use rurico::reranker::MockReranker;
+        use rurico::retrieval::IdentityAggregator;
+
+        let corpus = vec![
+            EvalDocument {
+                id: "d1".to_owned(),
+                title: "t1".to_owned(),
+                body: "alpha".to_owned(),
+                category_hint: None,
+                source: "test".to_owned(),
+            },
+            EvalDocument {
+                id: "d2".to_owned(),
+                title: "t2".to_owned(),
+                body: "beta".to_owned(),
+                category_hint: None,
+                source: "test".to_owned(),
+            },
+        ];
+        let queries = vec![
+            EvalQuery {
+                id: "qa".to_owned(),
+                text: "alpha".to_owned(),
+                category: "C1".to_owned(),
+                relevance_map: {
+                    let mut m = HashMap::new();
+                    m.insert("d1".to_owned(), 1u8);
+                    m
+                },
+                annotation: "stub".to_owned(),
+            },
+            EvalQuery {
+                id: "qb".to_owned(),
+                text: "beta".to_owned(),
+                category: "C1".to_owned(),
+                relevance_map: {
+                    let mut m = HashMap::new();
+                    m.insert("d2".to_owned(), 1u8);
+                    m
+                },
+                annotation: "stub".to_owned(),
+            },
+        ];
+        let embedder = MockEmbedder::default();
+        let reranker: Option<&MockReranker> = None;
+        let aggregator = IdentityAggregator;
+        let merge_config = HybridSearchConfig::default();
+        let normalization = QueryNormalizationConfig::default();
+        let config = PipelineConfig { k: 5 };
+
+        let results = evaluate_oracle(
+            &corpus,
+            &queries,
+            &embedder,
+            reranker,
+            &aggregator,
+            &merge_config,
+            &normalization,
+            &config,
+        )
+        .expect("per-query oracle pipeline must succeed");
+
+        assert_eq!(results[0].ranked_hits[0].doc_id, "d1", "qa → d1 at rank 0");
+        assert_eq!(results[1].ranked_hits[0].doc_id, "d2", "qb → d2 at rank 0");
+    }
+}

--- a/src/eval/oracle_pipeline/tests.rs
+++ b/src/eval/oracle_pipeline/tests.rs
@@ -1,0 +1,426 @@
+//! Unit tests for [`crate::eval::oracle_pipeline`].
+//!
+//! Split out of `oracle_pipeline.rs` (per `rules/development/STRUCTURE.md`)
+//! once the test module grew past the file-line ceiling. The module itself
+//! is small; tests dominate.
+
+use std::collections::HashMap;
+
+use rurico::retrieval::{
+    Candidate, CandidateSource, HybridSearchConfig, MergeStrategy, WeightedRrf,
+};
+use rurico::storage::QueryNormalizationConfig;
+
+use super::{OracleError, OracleMerge, evaluate_oracle, relevant_doc_ids};
+use crate::eval::fixture::{EvalDocument, EvalQuery};
+use crate::eval::pipeline::PipelineConfig;
+
+fn fts_candidate(doc_id: &str, score: f64, rank: usize) -> Candidate {
+    Candidate {
+        source: CandidateSource::Fts,
+        doc_id: doc_id.to_owned(),
+        chunk_id: None,
+        score,
+        rank,
+    }
+}
+
+// T-052-101: oracle_merge_injects_single_relevant_doc_at_rank_zero
+//
+// Even when WeightedRrf would have ranked the relevant doc lower, the
+// synthetic score (anchored to inner_max + offset) keeps the slot fixed
+// under any post-merge sort.
+#[test]
+fn oracle_merge_injects_single_relevant_doc_at_rank_zero() {
+    let candidates = vec![
+        fts_candidate("d1", -0.5, 0),
+        fts_candidate("d2", -0.6, 1),
+        fts_candidate("d3", -0.7, 2),
+    ];
+    let oracle = OracleMerge::new(HybridSearchConfig::default(), vec!["d3".to_owned()]);
+    let merged = oracle.merge(&candidates);
+
+    assert_eq!(
+        merged[0].doc_id, "d3",
+        "AC 1: relevant doc must occupy rank 0; got merged = {merged:?}"
+    );
+    let max_natural_score = merged
+        .iter()
+        .skip(1)
+        .map(|h| h.score)
+        .fold(f64::NEG_INFINITY, f64::max);
+    assert!(
+        merged[0].score > max_natural_score,
+        "AC 1: oracle hit must outscore every natural hit so post-sort keeps it at rank 0; \
+         got oracle.score = {} vs max_natural_score = {max_natural_score}",
+        merged[0].score
+    );
+}
+
+// T-052-102: oracle_merge_dedupes_relevant_doc_appearing_in_inner_result
+//
+// When a relevant doc is also produced by WeightedRrf, the oracle hit
+// takes the rank-0 slot and the natural duplicate is dropped — a single
+// relevant doc must not count twice in downstream metrics.
+#[test]
+fn oracle_merge_dedupes_relevant_doc_appearing_in_inner_result() {
+    let candidates = vec![
+        fts_candidate("d1", -0.5, 0),
+        fts_candidate("d2", -0.6, 1),
+        fts_candidate("d3", -0.7, 2),
+    ];
+    let oracle = OracleMerge::new(HybridSearchConfig::default(), vec!["d1".to_owned()]);
+    let merged = oracle.merge(&candidates);
+
+    assert_eq!(merged[0].doc_id, "d1", "rank 0 must be the oracle slot");
+    let d1_count = merged.iter().filter(|h| h.doc_id == "d1").count();
+    assert_eq!(
+        d1_count, 1,
+        "duplicate relevant doc must be dropped from the natural tail; got {d1_count}"
+    );
+}
+
+// T-052-103: oracle_merge_preserves_natural_order_for_non_relevant_docs
+//
+// The contract carved in the issue body: "配置済み doc 以外の順位は
+// 元の WeightedRrf 結果を維持する". After dropping the oracle slot,
+// the remaining hits must appear in the same order WeightedRrf would
+// have emitted them.
+#[test]
+fn oracle_merge_preserves_natural_order_for_non_relevant_docs() {
+    let candidates = vec![
+        fts_candidate("d1", -0.5, 0),
+        fts_candidate("d2", -0.6, 1),
+        fts_candidate("d3", -0.7, 2),
+    ];
+    let baseline = WeightedRrf::new(HybridSearchConfig::default()).merge(&candidates);
+    let oracle = OracleMerge::new(HybridSearchConfig::default(), vec!["d3".to_owned()]);
+    let merged = oracle.merge(&candidates);
+
+    let baseline_non_d3: Vec<&str> = baseline
+        .iter()
+        .filter(|h| h.doc_id != "d3")
+        .map(|h| h.doc_id.as_str())
+        .collect();
+    let oracle_non_d3: Vec<&str> = merged
+        .iter()
+        .filter(|h| h.doc_id != "d3")
+        .map(|h| h.doc_id.as_str())
+        .collect();
+    assert_eq!(
+        baseline_non_d3, oracle_non_d3,
+        "non-relevant docs must keep their natural ordering"
+    );
+}
+
+// T-052-104: oracle_merge_emits_parent_granular_hits_with_empty_source_scores
+//
+// Every oracle hit is parent-granular (`chunk_id = None`) so Stage 3
+// aggregators that bucket by `(doc_id, chunk_id)` cannot collapse it
+// against a sibling chunk. `source_scores` is empty because no real
+// retriever contributed.
+#[test]
+fn oracle_merge_emits_parent_granular_hits_with_empty_source_scores() {
+    let candidates = vec![fts_candidate("d1", -0.5, 0)];
+    let oracle = OracleMerge::new(HybridSearchConfig::default(), vec!["d2".to_owned()]);
+    let merged = oracle.merge(&candidates);
+
+    assert!(
+        merged[0].chunk_id.is_none(),
+        "oracle hit must be parent-granular; got chunk_id = {:?}",
+        merged[0].chunk_id
+    );
+    assert!(
+        merged[0].source_scores.is_empty(),
+        "oracle hit has no contributing retriever — source_scores must be empty; got {:?}",
+        merged[0].source_scores
+    );
+}
+
+// T-052-105: oracle_merge_orders_multiple_relevant_docs_by_input_sequence
+//
+// When a query has multiple relevant docs, the prepended slots use
+// strictly descending synthetic scores so the input order survives
+// through any post-merge sort.
+#[test]
+fn oracle_merge_orders_multiple_relevant_docs_by_input_sequence() {
+    let candidates = vec![fts_candidate("d99", -0.5, 0)];
+    let oracle = OracleMerge::new(
+        HybridSearchConfig::default(),
+        vec!["d1".to_owned(), "d2".to_owned(), "d3".to_owned()],
+    );
+    let merged = oracle.merge(&candidates);
+
+    assert_eq!(
+        merged
+            .iter()
+            .take(3)
+            .map(|h| h.doc_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["d1", "d2", "d3"],
+        "multi-relevant order must follow the input sequence"
+    );
+    assert!(
+        merged[0].score > merged[1].score && merged[1].score > merged[2].score,
+        "synthetic scores must be strictly descending; got {} {} {}",
+        merged[0].score,
+        merged[1].score,
+        merged[2].score
+    );
+}
+
+// T-052-106: oracle_merge_passthrough_when_no_relevant_docs
+//
+// Empty `relevant_docs` short-circuits to the WeightedRrf output
+// verbatim — guards the `evaluate_oracle` path against a query whose
+// relevance_map happens to be empty (defensive: such a query would not
+// contribute to recall@k anyway, but it must not crash the pipeline).
+#[test]
+fn oracle_merge_passthrough_when_no_relevant_docs() {
+    let candidates = vec![fts_candidate("d1", -0.5, 0), fts_candidate("d2", -0.6, 1)];
+    let baseline = WeightedRrf::new(HybridSearchConfig::default()).merge(&candidates);
+    let oracle = OracleMerge::new(HybridSearchConfig::default(), Vec::new());
+    let merged = oracle.merge(&candidates);
+
+    assert_eq!(
+        merged, baseline,
+        "empty relevant_docs must short-circuit to WeightedRrf output"
+    );
+}
+
+// T-052-107: relevant_doc_ids_filters_by_grade_and_sorts_deterministically
+//
+// `relevant_doc_ids` drops grade=0 entries (treated as "not relevant"
+// by amici metrics) and sorts the surviving ids. Sorting matters
+// because HashMap iteration order is hasher-dependent — without it the
+// baseline.json byte content would drift across runs.
+#[test]
+fn relevant_doc_ids_filters_by_grade_and_sorts_deterministically() {
+    let mut relevance_map = HashMap::new();
+    relevance_map.insert("z9".to_owned(), 0u8);
+    relevance_map.insert("d2".to_owned(), 1u8);
+    relevance_map.insert("a1".to_owned(), 3u8);
+    let query = EvalQuery {
+        id: "q1".to_owned(),
+        text: "stub".to_owned(),
+        category: "C1".to_owned(),
+        relevance_map,
+        annotation: "stub".to_owned(),
+    };
+    let ids = relevant_doc_ids(&query);
+    assert_eq!(
+        ids,
+        vec!["a1".to_owned(), "d2".to_owned()],
+        "must drop grade=0 and sort ascending"
+    );
+}
+
+// T-052-201: evaluate_oracle_rejects_relevance_map_pointing_outside_corpus
+//
+// Issue #52 P1 (advisor): if a query's relevance_map names a doc_id
+// that the corpus lacks, `apply_reranker` would silently drop it via
+// `filter_map(corpus_index.get(...))`. That would let the AC 4 gate
+// pass vacuously when a fixture typo dropped the answer. evaluate_oracle
+// must surface this as a typed error before pipeline setup.
+#[test]
+fn evaluate_oracle_rejects_relevance_map_pointing_outside_corpus() {
+    use rurico::embed::MockEmbedder;
+    use rurico::reranker::MockReranker;
+    use rurico::retrieval::IdentityAggregator;
+
+    let corpus = vec![EvalDocument {
+        id: "d1".to_owned(),
+        title: "title".to_owned(),
+        body: "body for d1".to_owned(),
+        category_hint: None,
+        source: "test".to_owned(),
+    }];
+    let mut relevance_map = HashMap::new();
+    relevance_map.insert("d1".to_owned(), 1u8);
+    relevance_map.insert("doc_that_does_not_exist".to_owned(), 1u8);
+    let queries = vec![EvalQuery {
+        id: "q1".to_owned(),
+        text: "body".to_owned(),
+        category: "C1".to_owned(),
+        relevance_map,
+        annotation: "stub".to_owned(),
+    }];
+    let embedder = MockEmbedder::default();
+    let reranker: Option<&MockReranker> = None;
+    let aggregator = IdentityAggregator;
+    let merge_config = HybridSearchConfig::default();
+    let normalization = QueryNormalizationConfig::default();
+    let config = PipelineConfig { k: 5 };
+
+    let result = evaluate_oracle(
+        &corpus,
+        &queries,
+        &embedder,
+        reranker,
+        &aggregator,
+        &merge_config,
+        &normalization,
+        &config,
+    );
+
+    assert!(
+        matches!(
+            result,
+            Err(OracleError::UnknownRelevantDoc { ref query_id, ref doc_id })
+                if query_id == "q1" && doc_id == "doc_that_does_not_exist"
+        ),
+        "must surface UnknownRelevantDoc {{ query_id=q1, doc_id=doc_that_does_not_exist }}; got: {result:?}"
+    );
+}
+
+// T-052-202: evaluate_oracle_places_relevant_doc_at_top_under_mock_pipeline
+//
+// End-to-end proof that OracleMerge ↔ pipeline composition surfaces the
+// relevant doc at rank 0 of `ranked_hits` even when the upstream
+// retrieval order would have buried it. Uses MockEmbedder so the test
+// runs in the default cargo lane (no MLX).
+#[test]
+fn evaluate_oracle_places_relevant_doc_at_top_under_mock_pipeline() {
+    use rurico::embed::MockEmbedder;
+    use rurico::reranker::MockReranker;
+    use rurico::retrieval::IdentityAggregator;
+
+    let corpus = vec![
+        EvalDocument {
+            id: "d1".to_owned(),
+            title: "title-d1".to_owned(),
+            body: "alpha document about retrieval".to_owned(),
+            category_hint: None,
+            source: "test".to_owned(),
+        },
+        EvalDocument {
+            id: "d2".to_owned(),
+            title: "title-d2".to_owned(),
+            body: "beta document about ranking".to_owned(),
+            category_hint: None,
+            source: "test".to_owned(),
+        },
+        EvalDocument {
+            id: "d3".to_owned(),
+            title: "title-d3".to_owned(),
+            body: "gamma document about indexing".to_owned(),
+            category_hint: None,
+            source: "test".to_owned(),
+        },
+    ];
+    let mut relevance_map = HashMap::new();
+    // d3 is far from "alpha retrieval" linguistically — without
+    // OracleMerge it would not surface at rank 0.
+    relevance_map.insert("d3".to_owned(), 1u8);
+    let queries = vec![EvalQuery {
+        id: "q1".to_owned(),
+        text: "alpha retrieval".to_owned(),
+        category: "C1".to_owned(),
+        relevance_map,
+        annotation: "stub".to_owned(),
+    }];
+    let embedder = MockEmbedder::default();
+    let reranker: Option<&MockReranker> = None;
+    let aggregator = IdentityAggregator;
+    let merge_config = HybridSearchConfig::default();
+    let normalization = QueryNormalizationConfig::default();
+    let config = PipelineConfig { k: 5 };
+
+    let results = evaluate_oracle(
+        &corpus,
+        &queries,
+        &embedder,
+        reranker,
+        &aggregator,
+        &merge_config,
+        &normalization,
+        &config,
+    )
+    .expect("oracle pipeline must succeed under MockEmbedder + no reranker");
+
+    assert_eq!(results.len(), 1, "one query in → one QueryResult out");
+    let top = results[0]
+        .ranked_hits
+        .first()
+        .expect("ranked_hits must be non-empty");
+    assert_eq!(
+        top.doc_id, "d3",
+        "AC 1: oracle path must surface d3 at rank 0; got ranked_hits = {:?}",
+        results[0].ranked_hits
+    );
+}
+
+// T-052-203: evaluate_oracle_uses_per_query_relevant_docs
+//
+// Two queries with different relevance_maps must each surface their
+// own relevant doc at rank 0 — proves the per-query OracleMerge
+// construction (vs. a single shared instance) wires the right
+// relevant_docs through the pipeline loop.
+#[test]
+fn evaluate_oracle_uses_per_query_relevant_docs() {
+    use rurico::embed::MockEmbedder;
+    use rurico::reranker::MockReranker;
+    use rurico::retrieval::IdentityAggregator;
+
+    let corpus = vec![
+        EvalDocument {
+            id: "d1".to_owned(),
+            title: "t1".to_owned(),
+            body: "alpha".to_owned(),
+            category_hint: None,
+            source: "test".to_owned(),
+        },
+        EvalDocument {
+            id: "d2".to_owned(),
+            title: "t2".to_owned(),
+            body: "beta".to_owned(),
+            category_hint: None,
+            source: "test".to_owned(),
+        },
+    ];
+    let queries = vec![
+        EvalQuery {
+            id: "qa".to_owned(),
+            text: "alpha".to_owned(),
+            category: "C1".to_owned(),
+            relevance_map: {
+                let mut m = HashMap::new();
+                m.insert("d1".to_owned(), 1u8);
+                m
+            },
+            annotation: "stub".to_owned(),
+        },
+        EvalQuery {
+            id: "qb".to_owned(),
+            text: "beta".to_owned(),
+            category: "C1".to_owned(),
+            relevance_map: {
+                let mut m = HashMap::new();
+                m.insert("d2".to_owned(), 1u8);
+                m
+            },
+            annotation: "stub".to_owned(),
+        },
+    ];
+    let embedder = MockEmbedder::default();
+    let reranker: Option<&MockReranker> = None;
+    let aggregator = IdentityAggregator;
+    let merge_config = HybridSearchConfig::default();
+    let normalization = QueryNormalizationConfig::default();
+    let config = PipelineConfig { k: 5 };
+
+    let results = evaluate_oracle(
+        &corpus,
+        &queries,
+        &embedder,
+        reranker,
+        &aggregator,
+        &merge_config,
+        &normalization,
+        &config,
+    )
+    .expect("per-query oracle pipeline must succeed");
+
+    assert_eq!(results[0].ranked_hits[0].doc_id, "d1", "qa → d1 at rank 0");
+    assert_eq!(results[1].ranked_hits[0].doc_id, "d2", "qb → d2 at rank 0");
+}

--- a/src/eval/pipeline.rs
+++ b/src/eval/pipeline.rs
@@ -141,10 +141,7 @@ where
     R: Rerank,
     A: Aggregator,
 {
-    ensure_sqlite_vec().map_err(PipelineError::SqliteVec)?;
-    let conn = Connection::open_in_memory()?;
-    create_schema(&conn)?;
-    index_corpus(&conn, corpus, embedder, normalization)?;
+    let conn = setup_pipeline_connection(corpus, embedder, normalization)?;
 
     // Build (doc_id → body) lookup once before the query loop. apply_reranker
     // does O(1) hits against this map instead of an O(N) corpus.iter().find()
@@ -180,6 +177,34 @@ where
         });
     }
     Ok(results)
+}
+
+/// Initialise an in-memory SQLite connection, build the eval-harness
+/// schema, and index `corpus` into all three tables.
+///
+/// Centralises the four-step setup (`ensure_sqlite_vec` →
+/// `Connection::open_in_memory` → [`create_schema`] → [`index_corpus`])
+/// so [`evaluate`] and [`crate::eval::oracle_pipeline::evaluate_oracle`]
+/// share a single bring-up path. The returned [`Connection`] is owned by
+/// the caller and dropped (closing the in-memory DB) when the eval run
+/// finishes.
+///
+/// # Errors
+///
+/// Returns [`PipelineError::SqliteVec`] when the `sqlite_vec` extension
+/// fails to register, [`PipelineError::Sqlite`] for SQLite errors during
+/// schema creation, and the [`PipelineError`] variants surfaced by
+/// [`index_corpus`] for embed / chunk-id failures.
+pub(super) fn setup_pipeline_connection<E: Embed>(
+    corpus: &[EvalDocument],
+    embedder: &E,
+    normalization: &QueryNormalizationConfig,
+) -> Result<Connection, PipelineError> {
+    ensure_sqlite_vec().map_err(PipelineError::SqliteVec)?;
+    let conn = Connection::open_in_memory()?;
+    create_schema(&conn)?;
+    index_corpus(&conn, corpus, embedder, normalization)?;
+    Ok(conn)
 }
 
 /// Build the in-memory schema (documents + FTS5 + vec0 + fts5vocab).
@@ -272,8 +297,12 @@ fn index_corpus<E: Embed>(
 
 /// Drive one `EvalQuery` through FTS + vec retrieval, RRF merge, Stage 3
 /// aggregation, and (when supplied) reranker rescoring.
+///
+/// `pub(super)` so [`crate::eval::oracle_pipeline::evaluate_oracle`] can
+/// reuse the per-query stage chain with a different `merge_strategy`
+/// without forking the whole pipeline body.
 #[allow(clippy::too_many_arguments)]
-fn run_single_query<E, R, A, M>(
+pub(super) fn run_single_query<E, R, A, M>(
     conn: &Connection,
     query: &EvalQuery,
     embedder: &E,

--- a/tests/eval_smoke.rs
+++ b/tests/eval_smoke.rs
@@ -198,6 +198,107 @@ fn t017_capture_baseline_writes_required_fields() {
     );
 }
 
+// T-052-001: t052_001_identity_oracle_yields_perfect_metrics
+// Issue #52 AC 5: oracle pipeline against the identity known-answer fixture
+// must keep `recall@1 == 1.0` and `ndcg@10 == 1.0`. Failure here means the
+// OracleMerge wiring or evaluate_oracle flow regressed past the wiring
+// guarantees of the identity fixture.
+#[test]
+#[ignore] // requires ruri-v3-310m cached + MLX (Apple Silicon)
+fn t052_001_identity_oracle_yields_perfect_metrics() {
+    let output = Command::new(env!("CARGO_BIN_EXE_eval_harness"))
+        .args(["evaluate", "kind=identity_oracle"])
+        .output()
+        .expect("spawn eval_harness evaluate kind=identity_oracle");
+    assert_smoke_success(&output);
+
+    let recall_at_1 = parse_metric_field("T-052-001", &output, "recall_at_1");
+    let ndcg_at_10 = parse_metric_field("T-052-001", &output, "ndcg_at_10");
+
+    assert!(
+        (recall_at_1 - 1.0).abs() < f64::EPSILON,
+        "[T-052-001] AC 5 identity_oracle: recall_at_1 must be 1.0, got {recall_at_1}"
+    );
+    assert!(
+        (ndcg_at_10 - 1.0).abs() < f64::EPSILON,
+        "[T-052-001] AC 5 identity_oracle: ndcg_at_10 must be 1.0, got {ndcg_at_10}"
+    );
+}
+
+// T-052-002: t052_002_single_doc_oracle_yields_perfect_metrics
+// Issue #52 AC 5: oracle pipeline against the single_doc known-answer
+// fixture must keep `recall@1 == 1.0` and `mrr == 1.0`.
+#[test]
+#[ignore] // requires ruri-v3-310m cached + MLX (Apple Silicon)
+fn t052_002_single_doc_oracle_yields_perfect_metrics() {
+    let output = Command::new(env!("CARGO_BIN_EXE_eval_harness"))
+        .args(["evaluate", "kind=single_doc_oracle"])
+        .output()
+        .expect("spawn eval_harness evaluate kind=single_doc_oracle");
+    assert_smoke_success(&output);
+
+    let recall_at_1 = parse_metric_field("T-052-002", &output, "recall_at_1");
+    let mrr = parse_metric_field("T-052-002", &output, "mrr");
+
+    assert!(
+        (recall_at_1 - 1.0).abs() < f64::EPSILON,
+        "[T-052-002] AC 5 single_doc_oracle: recall_at_1 must be 1.0, got {recall_at_1}"
+    );
+    assert!(
+        (mrr - 1.0).abs() < f64::EPSILON,
+        "[T-052-002] AC 5 single_doc_oracle: mrr must be 1.0, got {mrr}"
+    );
+}
+
+// T-052-003: t052_003_capture_oracle_writes_oracle_kind_snapshot
+// Issue #52 AC 2: capture-oracle writes a BaselineSnapshot whose `kind`
+// is `Oracle` and whose `captured_with` records the subcommand. Guards
+// against a future refactor stamping the wrong kind discriminator and
+// silently producing a Forward-shaped file under the oracle name.
+#[test]
+#[ignore] // requires ruri-v3-310m cached + MLX (Apple Silicon)
+fn t052_003_capture_oracle_writes_oracle_kind_snapshot() {
+    use amici::eval::baseline::BaselineKind;
+
+    let tempdir = tempfile::tempdir().expect("create tempdir for oracle baseline output");
+    let oracle_path = tempdir.path().join("oracle_baseline.json");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_eval_harness"))
+        .args([
+            "capture-oracle",
+            &format!("output={}", oracle_path.display()),
+        ])
+        .output()
+        .expect("spawn eval_harness capture-oracle");
+    assert_smoke_success(&output);
+
+    assert!(
+        oracle_path.exists(),
+        "[T-052-003] AC 2: capture-oracle must create {} (stderr: {})",
+        oracle_path.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let text = fs::read_to_string(&oracle_path)
+        .unwrap_or_else(|e| panic!("[T-052-003] read {}: {e}", oracle_path.display()));
+    let snapshot: BaselineSnapshot = serde_json::from_str(&text).unwrap_or_else(|e| {
+        panic!(
+            "[T-052-003] AC 2: oracle_baseline.json must deserialise into BaselineSnapshot \
+             ({e}), got: {text}"
+        )
+    });
+    assert_eq!(
+        snapshot.kind,
+        BaselineKind::Oracle,
+        "[T-052-003] AC 2: kind must be Oracle, got {:?}",
+        snapshot.kind
+    );
+    assert_eq!(
+        snapshot.captured_with, "eval_harness capture-oracle",
+        "[T-052-003] AC 2: captured_with must record subcommand, got {:?}",
+        snapshot.captured_with
+    );
+}
+
 // T-019: t019_verify_baseline_passes_against_committed_snapshot
 // FR-017: verify-baseline against the committed baseline.json must exit 0
 //         with stderr containing "verify-baseline: passed".

--- a/tests/fixtures/eval/oracle_baseline.json
+++ b/tests/fixtures/eval/oracle_baseline.json
@@ -1,0 +1,333 @@
+{
+  "schema_version": "1.1",
+  "kind": "oracle",
+  "captured_with": "eval_harness capture-oracle",
+  "timestamp": "epoch:1778206324",
+  "model_id": "cl-nagoya/ruri-v3-310m",
+  "model_revision": "pinned-via-rurico-embed-cache",
+  "mlx_rs_version": "0.25",
+  "fixture_hash": "fnv1a64:88afbfc4e99e0a84",
+  "aggregation": "identity",
+  "merge_config": {
+    "rrf_k": 60.0,
+    "source_weights": {
+      "vector": 1.0,
+      "fts": 1.0
+    }
+  },
+  "normalization": {
+    "nfkc": true,
+    "ascii_lowercase": true,
+    "collapse_whitespace": true
+  },
+  "global": [
+    {
+      "name": "recall@5",
+      "k": 5,
+      "point_estimate": 0.7200396825396826,
+      "ci_lower": 0.6905753968253968,
+      "ci_upper": 0.7512896825396826,
+      "uninformative": false
+    },
+    {
+      "name": "recall@10",
+      "k": 10,
+      "point_estimate": 1.0,
+      "ci_lower": 1.0,
+      "ci_upper": 1.0,
+      "uninformative": false
+    },
+    {
+      "name": "mrr@10",
+      "k": 10,
+      "point_estimate": 1.0,
+      "ci_lower": 1.0,
+      "ci_upper": 1.0,
+      "uninformative": false
+    },
+    {
+      "name": "ndcg@10",
+      "k": 10,
+      "point_estimate": 0.947417468881108,
+      "ci_lower": 0.9380144950499698,
+      "ci_upper": 0.9555539325334218,
+      "uninformative": false
+    }
+  ],
+  "per_category": {
+    "comparative": [
+      {
+        "name": "recall@5",
+        "k": 5,
+        "point_estimate": 0.7,
+        "ci_lower": 0.6095238095238095,
+        "ci_upper": 0.7833333333333333,
+        "uninformative": false
+      },
+      {
+        "name": "recall@10",
+        "k": 10,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "mrr@10",
+        "k": 10,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "ndcg@10",
+        "k": 10,
+        "point_estimate": 0.9570131387426085,
+        "ci_lower": 0.9391914260511297,
+        "ci_upper": 0.9739230629079416,
+        "uninformative": false
+      }
+    ],
+    "conceptual": [
+      {
+        "name": "recall@5",
+        "k": 5,
+        "point_estimate": 0.7031746031746032,
+        "ci_lower": 0.6095238095238096,
+        "ci_upper": 0.7888888888888891,
+        "uninformative": false
+      },
+      {
+        "name": "recall@10",
+        "k": 10,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "mrr@10",
+        "k": 10,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "ndcg@10",
+        "k": 10,
+        "point_estimate": 0.9506746255042603,
+        "ci_lower": 0.9344869648048872,
+        "ci_upper": 0.9662463831054537,
+        "uninformative": false
+      }
+    ],
+    "definitional": [
+      {
+        "name": "recall@5",
+        "k": 5,
+        "point_estimate": 0.676984126984127,
+        "ci_lower": 0.611111111111111,
+        "ci_upper": 0.7412698412698413,
+        "uninformative": false
+      },
+      {
+        "name": "recall@10",
+        "k": 10,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "mrr@10",
+        "k": 10,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "ndcg@10",
+        "k": 10,
+        "point_estimate": 0.9387410192400452,
+        "ci_lower": 0.9173450456161811,
+        "ci_upper": 0.9577831111082179,
+        "uninformative": false
+      }
+    ],
+    "factoid": [
+      {
+        "name": "recall@5",
+        "k": 5,
+        "point_estimate": 0.7658730158730158,
+        "ci_lower": 0.6746031746031746,
+        "ci_upper": 0.8531746031746033,
+        "uninformative": false
+      },
+      {
+        "name": "recall@10",
+        "k": 10,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "mrr@10",
+        "k": 10,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "ndcg@10",
+        "k": 10,
+        "point_estimate": 0.9601781667669697,
+        "ci_lower": 0.9476983053601403,
+        "ci_upper": 0.9716387324248144,
+        "uninformative": false
+      }
+    ],
+    "howto": [
+      {
+        "name": "recall@5",
+        "k": 5,
+        "point_estimate": 0.7031746031746032,
+        "ci_lower": 0.6158730158730158,
+        "ci_upper": 0.7873015873015872,
+        "uninformative": false
+      },
+      {
+        "name": "recall@10",
+        "k": 10,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "mrr@10",
+        "k": 10,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "ndcg@10",
+        "k": 10,
+        "point_estimate": 0.9222885339993571,
+        "ci_lower": 0.8736695192831133,
+        "ci_upper": 0.9633591107584204,
+        "uninformative": false
+      }
+    ],
+    "listing": [
+      {
+        "name": "recall@5",
+        "k": 5,
+        "point_estimate": 0.6404761904761905,
+        "ci_lower": 0.5666666666666667,
+        "ci_upper": 0.7166666666666667,
+        "uninformative": false
+      },
+      {
+        "name": "recall@10",
+        "k": 10,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "mrr@10",
+        "k": 10,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "ndcg@10",
+        "k": 10,
+        "point_estimate": 0.9341278252974499,
+        "ci_lower": 0.9163042519379759,
+        "ci_upper": 0.9530551796723765,
+        "uninformative": false
+      }
+    ],
+    "troubleshooting": [
+      {
+        "name": "recall@5",
+        "k": 5,
+        "point_estimate": 0.6976190476190476,
+        "ci_lower": 0.6333333333333334,
+        "ci_upper": 0.7619047619047619,
+        "uninformative": false
+      },
+      {
+        "name": "recall@10",
+        "k": 10,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "mrr@10",
+        "k": 10,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "ndcg@10",
+        "k": 10,
+        "point_estimate": 0.951523402963173,
+        "ci_lower": 0.9339699548631354,
+        "ci_upper": 0.9676853451726773,
+        "uninformative": false
+      }
+    ],
+    "variant_notation": [
+      {
+        "name": "recall@5",
+        "k": 5,
+        "point_estimate": 0.8730158730158729,
+        "ci_lower": 0.7777777777777776,
+        "ci_upper": 0.9523809523809523,
+        "uninformative": false
+      },
+      {
+        "name": "recall@10",
+        "k": 10,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "mrr@10",
+        "k": 10,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "ndcg@10",
+        "k": 10,
+        "point_estimate": 0.9647930385350004,
+        "ci_lower": 0.9477577061247511,
+        "ci_upper": 0.9802541392294131,
+        "uninformative": false
+      }
+    ]
+  },
+  "latency_p50_ms": 2083.0,
+  "latency_p95_ms": 3103.0
+}


### PR DESCRIPTION
## 概要

- `OracleMerge: MergeStrategy` + `evaluate_oracle` で検索側ボトルネック (CoSearch retrieval ceiling) を定量化。「rerank/aggregation が recall を取りこぼしてる」のか「retrieval が正しい doc を浮上させられてへん」のかを切り分け可能にする。
- `capture-oracle` subcommand + `BaselineKind::Oracle` variant + `just eval-oracle` recipe を追加。
- 初回 `oracle_baseline.json` を `baseline.json` と同 fixture (fixture_hash 一致) で取得済み。gap が解釈可能。

これは **PR1 / 2 の 1 本目**。PR2 で `oracle-gap` (per-metric / per-category diff + AC 4 gate)、ADR 0002 更新、README CLI conventions 更新、`BASELINE_SCHEMA_VERSION` bump を追加する。

## 初回 Oracle Gap

`just eval-oracle` で production fixture (140+ query, fixture_hash `fnv1a64:88afbfc4e99e0a84`) に対して取得:

| Metric    | Forward | Oracle | Gap     |
| --------- | ------- | ------ | ------- |
| recall@5  | 0.6300  | 0.7200 | +9.0pt  |
| recall@10 | 0.7415  | 1.0000 | +25.9pt |
| mrr@10    | 1.0000  | 1.0000 | 0       |
| ndcg@10   | 0.8930  | 0.9474 | +5.4pt  |

recall@10 で +25.9pt が headline 数値 — CoSearch 論文の 7B agent gap (+14.7pt F1) と同等オーダー。Phase 2 で retrieval 改善 (rerank 候補数、クエリ書き換え、学習型 ranker) を優先する判断材料になる。

mrr@10 が両方 1.0 なのは production reranker が retrieval が浮上させた relevant doc を rank 1 に置けてるから (Issue #52 設計メモ通り)。

## AC カバレッジ

- [x] AC 1: `OracleMerge: MergeStrategy` (10 unit tests)
- [x] AC 2: `capture-oracle` で `oracle_baseline.json` 生成 (T-052-003)
- [x] AC 5: known-answer fixture で `recall@1=1.0`, `ndcg@10=1.0` 維持 (T-052-001/002)
- [x] AC 6: oracle wiring test を `tests/eval_smoke.rs` に追加 (T-052-001/002/003)
- [ ] AC 3: `oracle-gap` subcommand → PR2
- [ ] AC 4: per-category recall@k ≥ baseline gate → PR2
- [ ] AC 7: ADR 0002 に Oracle mode セクション追記 → PR2
- [ ] AC 8: README CLI conventions 直後に Oracle mode 使い方追記 → PR2

## 設計メモ

- **Per-query `OracleMerge` 構築**: `MergeStrategy::merge(&self, &[Candidate])` は query identity を持たないから、ループ内で query ごとに新規構築するのが trait の制約に適合。rurico の上流 API 変更不要。
- **Synthetic score を `inner_max` 起点** (`f64::MAX - i` ではない): `f64::MAX` から小整数を引くと精度限界で saturate して同値になる → multi-relevant の順序が silently collapse。テストで検出して修正済み。
- **Pattern A (retrieval-stage Oracle)** を採用 (Pattern B 全段 post-process は不採用)。CoSearch の「retrieval を固定して reasoning を変える」枠組みと一致し、Phase 2 優先度判断に直結。
- **`evaluate_oracle` 入口で `relevance_map` ↔ corpus pre-validation**: `apply_reranker` の silent `filter_map(corpus_index.get(...))` で missing doc を握り潰されると AC 4 gate が vacuously に通る恐れ → typed error で eager に弾く。

## 動作確認

- [x] `cargo test --all-features` — lib 165 + storage 7 + doctest 18 pass、MLX-gated `#[ignore]` smoke 9 件
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Apple Silicon で `just eval-oracle` 実行 → `oracle_baseline.json` 生成 + commit 済み
- [ ] (merge 後) Apple Silicon で `cargo test --features eval-harness -- --ignored t052_001 t052_002 t052_003` 実行して MLX-gated smoke を発火

Refs: #52