### PR TITLE
feat(eval): oracle-gap subcommand と AC 4 gate を追加 (Issue #52 PR2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,34 @@ can write deterministic retry logic.
 > CI pipelines, and parent processes that branch on a specific number must
 > be updated. Announce the change in the CLI's release notes.
 
+### Oracle mode
+
+The eval harness ships an Oracle pipeline that measures how much recall
+the production retrieval is leaving on the table. It works by forcing
+every known-relevant document to rank 0 inside the merge stage, then
+running the rest of the pipeline (aggregation, reranker) unchanged. The
+gap between the normal "forward" baseline and this idealised oracle
+baseline is the search-side improvement headroom.
+
+```sh
+# 1. Capture the oracle baseline (MLX required, Apple Silicon only).
+just eval-oracle
+
+# 2. Compare it with the forward baseline. Read-only, no MLX.
+just eval-oracle-gap
+```
+
+`eval-oracle-gap` emits a markdown report with global and per-category
+gap tables. It exits `1` if any category shows `oracle.recall@k <
+baseline.recall@k` (the oracle path failed to land the relevant doc in
+`top-k` — almost always a wiring regression). Otherwise it exits `0`.
+
+How to read the result: a large positive `recall@k` gap means
+retrieval-side investment (more rerank candidates, query rewriting,
+a learned ranker) has measurable headroom. A near-zero gap means the
+retrieval is already at its ceiling for this fixture, and the next
+quality gain has to come from elsewhere — e.g. extending the fixture.
+
 ## Development
 
 ### Setup

--- a/docs/decisions/0002-evaluation-methodology.md
+++ b/docs/decisions/0002-evaluation-methodology.md
@@ -59,6 +59,29 @@ The reproducibility contract layers two distinct tolerances:
 
 `baseline.json` carries `schema_version`, `kind`, `model_id`, `model_revision`, `mlx_rs_version`, `fixture_hash`, `aggregation`, `merge_config`, `normalization`, and `captured_with` so drift drivers are explicit. `fixture_hash` is FNV-1a 64-bit over `documents.jsonl + queries.jsonl + known_answers.jsonl`.
 
+## Oracle Mode (Issue #52)
+
+The `oracle` baseline kind quantifies the **search-side ceiling**: what the metrics would look like if Stage 2 always placed every relevant doc at rank 0. Pairs with the `forward` baseline to surface the retrieval-side improvement headroom — Phase 2 priority signal directly aligned with CoSearch (arXiv:2604.17555).
+
+| Aspect | Forward | Oracle |
+| --- | --- | --- |
+| Stage 2 (merge) | `WeightedRrf` | `OracleMerge` (forces relevant doc to rank 0) |
+| Stage 3 (aggregator) | unchanged | unchanged |
+| Stage 4 (rerank) | unchanged | unchanged |
+| Captures | `eval_harness capture-baseline` | `eval_harness capture-oracle` |
+
+**Pattern A vs B**: amici uses **Pattern A** (retrieval-stage Oracle only). Stage 3 aggregation and Stage 4 rerank run against the idealised retrieval, so the gap is interpretable as "improvement available by rebuilding retrieval, holding rerank/aggregation fixed". Pattern B (post-process injection that overrides the final ranking) measures the full pipeline ceiling but cannot tell apart retrieval gain from rerank gain — out of scope for the Phase 2 decision this ADR supports.
+
+**Capture cadence**: rerun `just eval-oracle` whenever the production fixture is reauthored (so `fixture_hash` rolls forward) or rurico's retrieval primitives ship a behaviour change (FTS tokenizer / sqlite-vec ANN / RRF). Skip on rurico bumps that touch only embed or rerank — Stage 2 is unchanged so the oracle gap stays comparable.
+
+**AC 4 gate** (`eval_harness oracle-gap`): for every per-category bucket, `oracle.recall@k ≥ baseline.recall@k`. The gate covers `recall@k` only; `mrr@k` and `ndcg@k` involve reranker score comparisons that can legitimately let a relevant doc slide inside `top-k` after the oracle replaces a stronger natural hit, so flagging those as violations would be a false positive. The gate exits `EXIT_REGRESSION` (1) so CI catches a wiring regression where the oracle inject failed to land in `top-k`.
+
+**What Oracle does NOT measure**:
+
+- Rerank ceiling — the production reranker still scores oracle-injected hits; if the reranker mis-ranks them, the metric reflects that.
+- Aggregation ceiling — Stage 3 aggregators (Identity / MaxChunk / Dedupe / TopKAverage) run unchanged. A bug in aggregation would be visible in both Forward and Oracle and not in the gap.
+- End-to-end product quality — the gap is bounded by metrics that are themselves bounded by the fixture's relevance judgments. A query whose `relevance_map` is sparse or noisy biases the gap downward.
+
 ## Reassessment Triggers
 
 (Inherited from rurico ADR 0003 §Reassessment Triggers — handled in this location going forward.)

--- a/justfile
+++ b/justfile
@@ -50,6 +50,14 @@ eval-oracle:
       capture-oracle aggregation=identity \
       output=tests/fixtures/eval/oracle_baseline.json
 
+# Compare committed baseline.json with oracle_baseline.json (Issue #52)
+# Emits markdown gap report + AC 4 gate (exit 1 on per-category recall regression).
+# Read-only — no MLX required, runs on any platform.
+eval-oracle-gap:
+    cargo run --bin eval_harness --features eval-harness --release -- \
+      oracle-gap baseline=tests/fixtures/eval/baseline.json \
+      oracle=tests/fixtures/eval/oracle_baseline.json
+
 # Capture a variant baseline to /tmp (agg = identity / max-chunk / dedupe / topk-average)
 eval-baseline-variant agg:
     cargo run --bin eval_harness --features eval-harness --release -- \

--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -493,9 +493,20 @@ impl MetricSpec {
     }
 }
 
+/// Modes that load MLX models and would crash under the Codex seatbelt
+/// sandbox. `exit_if_seatbelt` fires for these only — read-only modes
+/// like `oracle-gap` and `compare-baselines` parse committed JSON and
+/// have no MLX dependency, so they should run inside the sandbox.
+const MLX_DEPENDENT_MODES: &[&str] = &[
+    "evaluate",
+    "capture-baseline",
+    "capture-reverse-baseline",
+    "capture-oracle",
+    "verify-baseline",
+];
+
 fn main() -> ExitCode {
     rurico::handle_probe_if_needed();
-    exit_if_seatbelt(env!("CARGO_BIN_NAME"));
 
     let args: Vec<String> = env::args().skip(1).collect();
     let Some(mode) = args.first() else {
@@ -505,6 +516,9 @@ fn main() -> ExitCode {
         );
         return ExitCode::from(EXIT_USAGE);
     };
+    if MLX_DEPENDENT_MODES.contains(&mode.as_str()) {
+        exit_if_seatbelt(env!("CARGO_BIN_NAME"));
+    }
     let kvs: HashMap<String, String> = args[1..]
         .iter()
         .filter_map(|s| s.split_once('=').map(|(k, v)| (k.to_owned(), v.to_owned())))

--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -11,6 +11,7 @@
 //! eval_harness capture-baseline output=<path>
 //! eval_harness capture-reverse-baseline output=<path>
 //! eval_harness capture-oracle output=<path>
+//! eval_harness oracle-gap baseline=<path> oracle=<path>
 //! eval_harness verify-baseline baseline=<path>
 //! ```
 //!
@@ -38,6 +39,7 @@ use amici::eval::fixture::{
     EvalDocument, EvalQuery, load_documents, load_known_answers, load_queries,
 };
 use amici::eval::metrics::{MetricResult, bootstrap_ci, mrr_at_k, ndcg_at_k, recall_at_k};
+use amici::eval::oracle_gap::{compute_gap, format_markdown};
 use amici::eval::oracle_pipeline::{OracleError, evaluate_oracle};
 use amici::eval::pipeline::{PipelineConfig, PipelineError, QueryResult, evaluate as run_pipeline};
 use rurico::embed::Embed;
@@ -499,7 +501,7 @@ fn main() -> ExitCode {
     let Some(mode) = args.first() else {
         eprintln!(
             "usage: eval_harness <evaluate|capture-baseline|capture-reverse-baseline|\
-             capture-oracle|verify-baseline|compare-baselines> [key=value...]"
+             capture-oracle|oracle-gap|verify-baseline|compare-baselines> [key=value...]"
         );
         return ExitCode::from(EXIT_USAGE);
     };
@@ -513,6 +515,7 @@ fn main() -> ExitCode {
         "capture-baseline" => run_capture_baseline(&kvs),
         "capture-reverse-baseline" => run_capture_reverse_baseline(&kvs),
         "capture-oracle" => run_capture_oracle(&kvs),
+        "oracle-gap" => run_oracle_gap(&kvs),
         "verify-baseline" => run_verify_baseline(&kvs),
         "compare-baselines" => run_compare_baselines(&kvs),
         other => {
@@ -1331,6 +1334,73 @@ fn run_compare_baselines(kvs: &HashMap<String, String>) -> ExitCode {
     }
     print_comparison_table(&snapshots);
     ExitCode::SUCCESS
+}
+
+/// `oracle-gap baseline=<path> oracle=<path>` — read a Forward baseline
+/// and an Oracle baseline (Issue #52), emit a markdown gap report on
+/// stdout, and exit `EXIT_REGRESSION` if AC 4 is violated (any category
+/// where `oracle.recall@k < baseline.recall@k`).
+fn run_oracle_gap(kvs: &HashMap<String, String>) -> ExitCode {
+    let Some(baseline_raw) = kvs.get("baseline") else {
+        eprintln!("oracle-gap: baseline= argument required");
+        return ExitCode::from(EXIT_USAGE);
+    };
+    let Some(oracle_raw) = kvs.get("oracle") else {
+        eprintln!("oracle-gap: oracle= argument required");
+        return ExitCode::from(EXIT_USAGE);
+    };
+    let baseline_path = match validate_baseline_path(baseline_raw) {
+        Ok(p) => p,
+        Err(msg) => {
+            eprintln!("oracle-gap: baseline= {msg}");
+            return ExitCode::from(EXIT_USAGE);
+        }
+    };
+    let oracle_path = match validate_baseline_path(oracle_raw) {
+        Ok(p) => p,
+        Err(msg) => {
+            eprintln!("oracle-gap: oracle= {msg}");
+            return ExitCode::from(EXIT_USAGE);
+        }
+    };
+    let baseline_snapshot = match read_snapshot(&baseline_path) {
+        Ok(s) => s,
+        Err(msg) => {
+            eprintln!("oracle-gap: baseline= {msg}");
+            return ExitCode::from(EXIT_INFRA);
+        }
+    };
+    let oracle_snapshot = match read_snapshot(&oracle_path) {
+        Ok(s) => s,
+        Err(msg) => {
+            eprintln!("oracle-gap: oracle= {msg}");
+            return ExitCode::from(EXIT_INFRA);
+        }
+    };
+    let gap = match compute_gap(&baseline_snapshot, &oracle_snapshot) {
+        Ok(g) => g,
+        Err(e) => {
+            eprintln!("oracle-gap: {e}");
+            return ExitCode::from(EXIT_INFRA);
+        }
+    };
+    println!("{}", format_markdown(&gap));
+    if gap.ac4_violations.is_empty() {
+        ExitCode::SUCCESS
+    } else {
+        eprintln!(
+            "oracle-gap: AC 4 violated by {} per-category recall regression(s)",
+            gap.ac4_violations.len()
+        );
+        ExitCode::from(EXIT_REGRESSION)
+    }
+}
+
+/// Read a `BaselineSnapshot` from `path` as JSON. Centralised so
+/// `oracle-gap` reads both files through the same parse/error path.
+fn read_snapshot(path: &Path) -> Result<BaselineSnapshot, String> {
+    let text = fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    serde_json::from_str(&text).map_err(|e| format!("parse {}: {e}", path.display()))
 }
 
 /// Format `snapshots` as a markdown comparison table on stdout.

--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -991,17 +991,10 @@ fn run_verify_baseline(kvs: &HashMap<String, String>) -> ExitCode {
     };
     // Read and parse the committed baseline before paying the multi-second
     // model-load cost — a malformed file fails fast.
-    let json = match fs::read_to_string(&baseline_path) {
+    let committed: BaselineSnapshot = match read_snapshot(&baseline_path) {
         Ok(s) => s,
-        Err(e) => {
-            eprintln!("verify-baseline: read failed: {e}");
-            return ExitCode::from(EXIT_INFRA);
-        }
-    };
-    let committed: BaselineSnapshot = match serde_json::from_str(&json) {
-        Ok(s) => s,
-        Err(e) => {
-            eprintln!("verify-baseline: parse failed: {e}");
+        Err(msg) => {
+            eprintln!("verify-baseline: {msg}");
             return ExitCode::from(EXIT_INFRA);
         }
     };
@@ -1309,17 +1302,10 @@ fn run_compare_baselines(kvs: &HashMap<String, String>) -> ExitCode {
     }
     let mut snapshots: Vec<(String, BaselineSnapshot)> = Vec::with_capacity(paths.len());
     for path in &paths {
-        let text = match fs::read_to_string(path) {
-            Ok(t) => t,
-            Err(e) => {
-                eprintln!("compare-baselines: failed to read {path}: {e}");
-                return ExitCode::from(EXIT_INFRA);
-            }
-        };
-        let snapshot: BaselineSnapshot = match serde_json::from_str(&text) {
+        let snapshot: BaselineSnapshot = match read_snapshot(Path::new(path)) {
             Ok(s) => s,
-            Err(e) => {
-                eprintln!("compare-baselines: failed to parse {path}: {e}");
+            Err(msg) => {
+                eprintln!("compare-baselines: {msg}");
                 return ExitCode::from(EXIT_INFRA);
             }
         };
@@ -1341,59 +1327,64 @@ fn run_compare_baselines(kvs: &HashMap<String, String>) -> ExitCode {
 /// stdout, and exit `EXIT_REGRESSION` if AC 4 is violated (any category
 /// where `oracle.recall@k < baseline.recall@k`).
 fn run_oracle_gap(kvs: &HashMap<String, String>) -> ExitCode {
-    let Some(baseline_raw) = kvs.get("baseline") else {
-        eprintln!("oracle-gap: baseline= argument required");
-        return ExitCode::from(EXIT_USAGE);
-    };
-    let Some(oracle_raw) = kvs.get("oracle") else {
-        eprintln!("oracle-gap: oracle= argument required");
-        return ExitCode::from(EXIT_USAGE);
-    };
-    let baseline_path = match validate_baseline_path(baseline_raw) {
-        Ok(p) => p,
-        Err(msg) => {
-            eprintln!("oracle-gap: baseline= {msg}");
-            return ExitCode::from(EXIT_USAGE);
+    match run_oracle_gap_inner(kvs) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err((code, msg)) => {
+            eprintln!("oracle-gap: {msg}");
+            ExitCode::from(code)
         }
-    };
-    let oracle_path = match validate_baseline_path(oracle_raw) {
-        Ok(p) => p,
-        Err(msg) => {
-            eprintln!("oracle-gap: oracle= {msg}");
-            return ExitCode::from(EXIT_USAGE);
-        }
-    };
-    let baseline_snapshot = match read_snapshot(&baseline_path) {
-        Ok(s) => s,
-        Err(msg) => {
-            eprintln!("oracle-gap: baseline= {msg}");
-            return ExitCode::from(EXIT_INFRA);
-        }
-    };
-    let oracle_snapshot = match read_snapshot(&oracle_path) {
-        Ok(s) => s,
-        Err(msg) => {
-            eprintln!("oracle-gap: oracle= {msg}");
-            return ExitCode::from(EXIT_INFRA);
-        }
-    };
-    let gap = match compute_gap(&baseline_snapshot, &oracle_snapshot) {
-        Ok(g) => g,
-        Err(e) => {
-            eprintln!("oracle-gap: {e}");
-            return ExitCode::from(EXIT_INFRA);
-        }
-    };
+    }
+}
+
+/// Happy-path body for [`run_oracle_gap`]. Each error carries its exit
+/// code so the outer wrapper never has to map back from the message.
+fn run_oracle_gap_inner(kvs: &HashMap<String, String>) -> Result<(), (u8, String)> {
+    let baseline_raw = kvs
+        .get("baseline")
+        .ok_or((EXIT_USAGE, "baseline= argument required".to_owned()))?;
+    let oracle_raw = kvs
+        .get("oracle")
+        .ok_or((EXIT_USAGE, "oracle= argument required".to_owned()))?;
+    let baseline_path =
+        validate_baseline_path(baseline_raw).map_err(|m| (EXIT_USAGE, format!("baseline= {m}")))?;
+    let oracle_path =
+        validate_baseline_path(oracle_raw).map_err(|m| (EXIT_USAGE, format!("oracle= {m}")))?;
+    let baseline_snapshot =
+        read_snapshot(&baseline_path).map_err(|m| (EXIT_INFRA, format!("baseline= {m}")))?;
+    let oracle_snapshot =
+        read_snapshot(&oracle_path).map_err(|m| (EXIT_INFRA, format!("oracle= {m}")))?;
+    enforce_current_schema(&baseline_snapshot, "baseline")?;
+    enforce_current_schema(&oracle_snapshot, "oracle")?;
+    let gap = compute_gap(&baseline_snapshot, &oracle_snapshot)
+        .map_err(|e| (EXIT_INFRA, format!("{e}")))?;
     println!("{}", format_markdown(&gap));
     if gap.ac4_violations.is_empty() {
-        ExitCode::SUCCESS
+        Ok(())
     } else {
-        eprintln!(
-            "oracle-gap: AC 4 violated by {} per-category recall regression(s)",
-            gap.ac4_violations.len()
-        );
-        ExitCode::from(EXIT_REGRESSION)
+        Err((
+            EXIT_REGRESSION,
+            format!(
+                "AC 4 violated by {} per-category recall regression(s)",
+                gap.ac4_violations.len()
+            ),
+        ))
     }
+}
+
+/// Reject snapshots whose `schema_version` does not match the current
+/// harness, so a stale committed file cannot drift past a schema bump.
+fn enforce_current_schema(snapshot: &BaselineSnapshot, label: &str) -> Result<(), (u8, String)> {
+    if snapshot.schema_version == BASELINE_SCHEMA_VERSION {
+        return Ok(());
+    }
+    Err((
+        EXIT_INFRA,
+        format!(
+            "{label} schema_version {:?} does not match harness {:?}; \
+             regenerate the snapshot before comparing",
+            snapshot.schema_version, BASELINE_SCHEMA_VERSION
+        ),
+    ))
 }
 
 /// Read a `BaselineSnapshot` from `path` as JSON. Centralised so

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -9,5 +9,6 @@
 pub mod baseline;
 pub mod fixture;
 pub mod metrics;
+pub mod oracle_gap;
 pub mod oracle_pipeline;
 pub mod pipeline;

--- a/src/eval/baseline.rs
+++ b/src/eval/baseline.rs
@@ -36,7 +36,13 @@ pub const UNINFORMATIVE_HALF_WIDTH: f64 = 0.10;
 ///   baseline.json files would surface as confusing per-metric drift
 ///   under the new fusion; the version bump turns that into a clean
 ///   "regenerate the baseline before verifying" exit instead.
-pub const BASELINE_SCHEMA_VERSION: &str = "1.1";
+/// - `1.2`: Oracle baseline kind (Issue #52). [`BaselineKind`] gained an
+///   `Oracle` variant; older harnesses cannot deserialise an
+///   `oracle_baseline.json` (variant unknown to their enum), but
+///   Forward and Reverse files round-trip unchanged. The bump lets
+///   `oracle-gap` refuse to compare snapshots produced under different
+///   semantic versions.
+pub const BASELINE_SCHEMA_VERSION: &str = "1.2";
 
 /// Discriminator distinguishing forward (`capture-baseline`) from reverse
 /// (`capture-reverse-baseline`) and oracle (`capture-oracle`) baseline files.

--- a/src/eval/oracle_gap.rs
+++ b/src/eval/oracle_gap.rs
@@ -17,6 +17,12 @@ use std::collections::BTreeMap;
 use crate::eval::baseline::{BaselineKind, BaselineSnapshot};
 use crate::eval::metrics::MetricResult;
 
+/// Prefix on every metric name that the AC 4 gate covers.
+///
+/// Single source of truth so a typo (`"recall_"`) cannot silently
+/// disable the gate.
+const RECALL_METRIC_PREFIX: &str = "recall@";
+
 /// Errors surfaced by [`compute_gap`].
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
@@ -73,11 +79,11 @@ pub struct MetricGap {
 /// doc at rank 0.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Ac4Violation {
-    /// Category label that triggered the violation (or `"<global>"` when
-    /// the global metric itself regressed).
+    /// Per-category label that triggered the violation. The global
+    /// aggregate is reported in [`OracleGap::global`] but not gated.
     pub category: String,
     /// Metric label that regressed (e.g. `recall@5`).
-    pub metric_name: String,
+    pub name: String,
     /// `k` cutoff carried by the metric.
     pub k: usize,
     /// Forward point estimate.
@@ -186,10 +192,10 @@ fn detect_ac4_violations(per_category: &BTreeMap<String, Vec<MetricGap>>) -> Vec
     let mut violations = Vec::new();
     for (category, gaps) in per_category {
         for gap in gaps {
-            if gap.name.starts_with("recall@") && gap.diff < 0.0 {
+            if gap.name.starts_with(RECALL_METRIC_PREFIX) && gap.diff < 0.0 {
                 violations.push(Ac4Violation {
                     category: category.clone(),
-                    metric_name: gap.name.clone(),
+                    name: gap.name.clone(),
                     k: gap.k,
                     baseline_point: gap.baseline_point,
                     oracle_point: gap.oracle_point,
@@ -222,7 +228,7 @@ pub fn format_markdown(gap: &OracleGap) -> String {
                 "- `{category}` `{name}`: oracle {oracle:.4} < baseline {baseline:.4} \
                  (diff {diff:+.4})\n",
                 category = v.category,
-                name = v.metric_name,
+                name = v.name,
                 oracle = v.oracle_point,
                 baseline = v.baseline_point,
                 diff = v.oracle_point - v.baseline_point,

--- a/src/eval/oracle_gap.rs
+++ b/src/eval/oracle_gap.rs
@@ -54,6 +54,49 @@ pub enum OracleGapError {
         /// Oracle snapshot fixture content hash.
         oracle: String,
     },
+    /// The two snapshots were captured under different pipeline knobs
+    /// (`aggregation`, `merge_config`, `normalization`, or model
+    /// identity). The gap would no longer measure the oracle under the
+    /// same downstream stack — AC 4 could swing on a config typo.
+    #[error(
+        "oracle-gap: {field} mismatch — \
+         baseline and oracle were captured under different pipeline configs \
+         (baseline={baseline:?}, oracle={oracle:?})"
+    )]
+    PipelineConfigMismatch {
+        /// Snapshot field that disagreed (`aggregation`, `merge_config`,
+        /// `normalization`, `model_id`, or `model_revision`).
+        field: &'static str,
+        /// Forward snapshot value (debug-formatted).
+        baseline: String,
+        /// Oracle snapshot value (debug-formatted).
+        oracle: String,
+    },
+    /// A category present on the baseline is absent from the oracle.
+    /// AC 4 would silently skip that bucket and PASS vacuously.
+    #[error(
+        "oracle-gap: oracle snapshot is missing per-category bucket {category:?} \
+         that baseline reports — regenerate before comparing"
+    )]
+    MissingOracleCategory {
+        /// Category label that exists on the baseline but not the oracle.
+        category: String,
+    },
+    /// A metric present on the baseline is absent from the oracle for a
+    /// given bucket (global or per-category). AC 4 would silently skip
+    /// that metric.
+    #[error(
+        "oracle-gap: oracle snapshot is missing metric {metric:?}@{k} in {scope} — \
+         regenerate before comparing"
+    )]
+    MissingOracleMetric {
+        /// Scope label (`"<global>"` or category name).
+        scope: String,
+        /// Metric label that exists on the baseline but not the oracle.
+        metric: String,
+        /// `k` cutoff carried by the missing metric.
+        k: usize,
+    },
 }
 
 /// Per-metric difference between Forward and Oracle.
@@ -98,9 +141,11 @@ pub struct Ac4Violation {
 pub struct OracleGap {
     /// Per-metric diff over the global aggregation.
     pub global: Vec<MetricGap>,
-    /// Per-category diff. Categories that appear on only one side are
-    /// dropped silently; the [`OracleGapError::FixtureHashMismatch`]
-    /// guard already rejects such inputs upstream.
+    /// Per-category diff. Every baseline category must have an oracle
+    /// counterpart with the same metric set; mismatches surface as
+    /// [`OracleGapError::MissingOracleCategory`] /
+    /// [`OracleGapError::MissingOracleMetric`] so AC 4 cannot PASS
+    /// vacuously on a partially-edited snapshot.
     pub per_category: BTreeMap<String, Vec<MetricGap>>,
     /// AC 4 violations detected across the per-category breakdown.
     /// `recall@k` is the only metric subject to the gate (the issue body
@@ -140,14 +185,18 @@ pub fn compute_gap(
             oracle: oracle.fixture_hash.clone(),
         });
     }
+    enforce_pipeline_config_match(baseline, oracle)?;
 
-    let global = diff_metric_lists(&baseline.global, &oracle.global);
+    let global = diff_metric_lists(&baseline.global, &oracle.global, "<global>")?;
     let mut per_category: BTreeMap<String, Vec<MetricGap>> = BTreeMap::new();
     for (category, baseline_metrics) in &baseline.per_category {
-        if let Some(oracle_metrics) = oracle.per_category.get(category) {
-            let gap = diff_metric_lists(baseline_metrics, oracle_metrics);
-            per_category.insert(category.clone(), gap);
-        }
+        let oracle_metrics = oracle.per_category.get(category).ok_or_else(|| {
+            OracleGapError::MissingOracleCategory {
+                category: category.clone(),
+            }
+        })?;
+        let gap = diff_metric_lists(baseline_metrics, oracle_metrics, category)?;
+        per_category.insert(category.clone(), gap);
     }
     let ac4_violations = detect_ac4_violations(&per_category);
     Ok(OracleGap {
@@ -157,25 +206,84 @@ pub fn compute_gap(
     })
 }
 
-/// Compute per-metric `MetricGap` for two metric lists keyed by `name`.
+/// Reject snapshots whose pipeline knobs disagree.
 ///
-/// Metrics present on only one side are dropped — `compute_gap` already
-/// guarantees the snapshots come from the same fixture under the same
-/// schema, so missing metrics here would mean a corrupted file.
-fn diff_metric_lists(baseline: &[MetricResult], oracle: &[MetricResult]) -> Vec<MetricGap> {
+/// `aggregation`, `merge_config`, `normalization`, `model_id`, and
+/// `model_revision` define the downstream stack. A gap captured under
+/// mismatched knobs no longer measures "retrieval ceiling under the
+/// same rerank/aggregation" — AC 4 could swing on a config typo.
+fn enforce_pipeline_config_match(
+    baseline: &BaselineSnapshot,
+    oracle: &BaselineSnapshot,
+) -> Result<(), OracleGapError> {
+    if baseline.aggregation != oracle.aggregation {
+        return Err(OracleGapError::PipelineConfigMismatch {
+            field: "aggregation",
+            baseline: baseline.aggregation.clone(),
+            oracle: oracle.aggregation.clone(),
+        });
+    }
+    if baseline.merge_config != oracle.merge_config {
+        return Err(OracleGapError::PipelineConfigMismatch {
+            field: "merge_config",
+            baseline: format!("{:?}", baseline.merge_config),
+            oracle: format!("{:?}", oracle.merge_config),
+        });
+    }
+    if baseline.normalization != oracle.normalization {
+        return Err(OracleGapError::PipelineConfigMismatch {
+            field: "normalization",
+            baseline: format!("{:?}", baseline.normalization),
+            oracle: format!("{:?}", oracle.normalization),
+        });
+    }
+    if baseline.model_id != oracle.model_id {
+        return Err(OracleGapError::PipelineConfigMismatch {
+            field: "model_id",
+            baseline: baseline.model_id.clone(),
+            oracle: oracle.model_id.clone(),
+        });
+    }
+    if baseline.model_revision != oracle.model_revision {
+        return Err(OracleGapError::PipelineConfigMismatch {
+            field: "model_revision",
+            baseline: baseline.model_revision.clone(),
+            oracle: oracle.model_revision.clone(),
+        });
+    }
+    Ok(())
+}
+
+/// Compute per-metric `MetricGap` for two metric lists keyed by
+/// `(name, k)`.
+///
+/// Returns [`OracleGapError::MissingOracleMetric`] when a baseline metric
+/// has no oracle counterpart in the same `scope` — silently dropping it
+/// would let AC 4 PASS vacuously on a partially-edited oracle snapshot.
+fn diff_metric_lists(
+    baseline: &[MetricResult],
+    oracle: &[MetricResult],
+    scope: &str,
+) -> Result<Vec<MetricGap>, OracleGapError> {
     let mut out = Vec::with_capacity(baseline.len());
     for b in baseline {
-        if let Some(o) = oracle.iter().find(|o| o.name == b.name && o.k == b.k) {
-            out.push(MetricGap {
-                name: b.name.clone(),
+        let o = oracle
+            .iter()
+            .find(|o| o.name == b.name && o.k == b.k)
+            .ok_or_else(|| OracleGapError::MissingOracleMetric {
+                scope: scope.to_owned(),
+                metric: b.name.clone(),
                 k: b.k,
-                baseline_point: b.point_estimate,
-                oracle_point: o.point_estimate,
-                diff: o.point_estimate - b.point_estimate,
-            });
-        }
+            })?;
+        out.push(MetricGap {
+            name: b.name.clone(),
+            k: b.k,
+            baseline_point: b.point_estimate,
+            oracle_point: o.point_estimate,
+            diff: o.point_estimate - b.point_estimate,
+        });
     }
-    out
+    Ok(out)
 }
 
 /// Scan the per-category gap for `recall@k` regressions and emit one

--- a/src/eval/oracle_gap.rs
+++ b/src/eval/oracle_gap.rs
@@ -1,0 +1,247 @@
+//! Oracle gap report (Issue #52 PR2 / AC 3, AC 4).
+//!
+//! Compares a Forward baseline (`capture-baseline` output) against an
+//! Oracle baseline (`capture-oracle` output) captured from the same
+//! fixture. Quantifies the search-side bottleneck: how much recall the
+//! production retrieval is leaving on the table relative to a perfect
+//! top-rank inject — the Phase 2 priority signal.
+//!
+//! AC 4: for every query category, `oracle.recall@k` must be at least
+//! `baseline.recall@k`. A violation means the oracle inject failed to
+//! land in `top-k` for some query in the category — almost certainly a
+//! wiring regression (the inject is supposed to dominate Stage 2's RRF
+//! score). The harness exits `EXIT_REGRESSION` so CI catches it.
+
+use std::collections::BTreeMap;
+
+use crate::eval::baseline::{BaselineKind, BaselineSnapshot};
+use crate::eval::metrics::MetricResult;
+
+/// Errors surfaced by [`compute_gap`].
+#[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
+pub enum OracleGapError {
+    /// `baseline=<path>` did not point at a `kind=forward` snapshot.
+    #[error("oracle-gap: baseline kind {0:?} is not Forward; pass capture-baseline output")]
+    BaselineNotForward(BaselineKind),
+    /// `oracle=<path>` did not point at a `kind=oracle` snapshot.
+    #[error("oracle-gap: oracle kind {0:?} is not Oracle; pass capture-oracle output")]
+    OracleNotOracle(BaselineKind),
+    /// The two snapshots were captured under different schema versions.
+    /// Comparing them would silently mix metric definitions.
+    #[error("oracle-gap: schema_version mismatch (baseline={baseline:?}, oracle={oracle:?})")]
+    SchemaVersionMismatch {
+        /// Forward snapshot version label.
+        baseline: String,
+        /// Oracle snapshot version label.
+        oracle: String,
+    },
+    /// The two snapshots were captured against different fixtures.
+    /// Comparing the gap would mix populations.
+    #[error(
+        "oracle-gap: fixture_hash mismatch — comparing different fixtures \
+         (baseline={baseline:?}, oracle={oracle:?})"
+    )]
+    FixtureHashMismatch {
+        /// Forward snapshot fixture content hash.
+        baseline: String,
+        /// Oracle snapshot fixture content hash.
+        oracle: String,
+    },
+}
+
+/// Per-metric difference between Forward and Oracle.
+///
+/// `diff` is `oracle_point - baseline_point`; positive means the
+/// retrieval ceiling sits above the production result for that metric.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MetricGap {
+    /// Metric label (e.g. `recall@5`, `mrr@10`).
+    pub name: String,
+    /// `k` cutoff carried by the metric.
+    pub k: usize,
+    /// Forward `point_estimate`.
+    pub baseline_point: f64,
+    /// Oracle `point_estimate`.
+    pub oracle_point: f64,
+    /// `oracle_point - baseline_point`.
+    pub diff: f64,
+}
+
+/// Single AC 4 violation: an oracle metric ranked below its baseline
+/// counterpart, despite the oracle pipeline force-injecting the relevant
+/// doc at rank 0.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Ac4Violation {
+    /// Category label that triggered the violation (or `"<global>"` when
+    /// the global metric itself regressed).
+    pub category: String,
+    /// Metric label that regressed (e.g. `recall@5`).
+    pub metric_name: String,
+    /// `k` cutoff carried by the metric.
+    pub k: usize,
+    /// Forward point estimate.
+    pub baseline_point: f64,
+    /// Oracle point estimate.
+    pub oracle_point: f64,
+}
+
+/// Combined gap report consumed by [`format_markdown`] and the
+/// `oracle-gap` subcommand exit code.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OracleGap {
+    /// Per-metric diff over the global aggregation.
+    pub global: Vec<MetricGap>,
+    /// Per-category diff. Categories that appear on only one side are
+    /// dropped silently; the [`OracleGapError::FixtureHashMismatch`]
+    /// guard already rejects such inputs upstream.
+    pub per_category: BTreeMap<String, Vec<MetricGap>>,
+    /// AC 4 violations detected across the per-category breakdown.
+    /// `recall@k` is the only metric subject to the gate (the issue body
+    /// pins the AC to recall); `mrr` and `ndcg` are reported but not
+    /// gated since the production reranker can promote a relevant doc
+    /// past the oracle inject when both land in the top-k tie.
+    pub ac4_violations: Vec<Ac4Violation>,
+}
+
+/// Compute the gap between `baseline` (`kind=Forward`) and `oracle`
+/// (`kind=Oracle`).
+///
+/// # Errors
+///
+/// Returns [`OracleGapError`] when the inputs disagree on `kind`,
+/// `schema_version`, or `fixture_hash`. Each rejection prevents a
+/// silently-incorrect comparison.
+pub fn compute_gap(
+    baseline: &BaselineSnapshot,
+    oracle: &BaselineSnapshot,
+) -> Result<OracleGap, OracleGapError> {
+    if baseline.kind != BaselineKind::Forward {
+        return Err(OracleGapError::BaselineNotForward(baseline.kind));
+    }
+    if oracle.kind != BaselineKind::Oracle {
+        return Err(OracleGapError::OracleNotOracle(oracle.kind));
+    }
+    if baseline.schema_version != oracle.schema_version {
+        return Err(OracleGapError::SchemaVersionMismatch {
+            baseline: baseline.schema_version.clone(),
+            oracle: oracle.schema_version.clone(),
+        });
+    }
+    if baseline.fixture_hash != oracle.fixture_hash {
+        return Err(OracleGapError::FixtureHashMismatch {
+            baseline: baseline.fixture_hash.clone(),
+            oracle: oracle.fixture_hash.clone(),
+        });
+    }
+
+    let global = diff_metric_lists(&baseline.global, &oracle.global);
+    let mut per_category: BTreeMap<String, Vec<MetricGap>> = BTreeMap::new();
+    for (category, baseline_metrics) in &baseline.per_category {
+        if let Some(oracle_metrics) = oracle.per_category.get(category) {
+            let gap = diff_metric_lists(baseline_metrics, oracle_metrics);
+            per_category.insert(category.clone(), gap);
+        }
+    }
+    let ac4_violations = detect_ac4_violations(&per_category);
+    Ok(OracleGap {
+        global,
+        per_category,
+        ac4_violations,
+    })
+}
+
+/// Compute per-metric `MetricGap` for two metric lists keyed by `name`.
+///
+/// Metrics present on only one side are dropped — `compute_gap` already
+/// guarantees the snapshots come from the same fixture under the same
+/// schema, so missing metrics here would mean a corrupted file.
+fn diff_metric_lists(baseline: &[MetricResult], oracle: &[MetricResult]) -> Vec<MetricGap> {
+    let mut out = Vec::with_capacity(baseline.len());
+    for b in baseline {
+        if let Some(o) = oracle.iter().find(|o| o.name == b.name && o.k == b.k) {
+            out.push(MetricGap {
+                name: b.name.clone(),
+                k: b.k,
+                baseline_point: b.point_estimate,
+                oracle_point: o.point_estimate,
+                diff: o.point_estimate - b.point_estimate,
+            });
+        }
+    }
+    out
+}
+
+/// Scan the per-category gap for `recall@k` regressions and emit one
+/// [`Ac4Violation`] per offending (category, metric) pair.
+///
+/// The AC 4 gate covers **recall metrics only** because the oracle
+/// inject specifically targets recall: forcing the relevant doc into
+/// `top-k` cannot reduce the retrieval recall, so any regression
+/// signals a wiring bug. `mrr` and `ndcg` involve reranker score
+/// comparisons that can legitimately cause a relevant doc to slide
+/// inside `top-k` after the oracle replaces a stronger natural hit;
+/// reporting those as violations would be a false positive.
+fn detect_ac4_violations(per_category: &BTreeMap<String, Vec<MetricGap>>) -> Vec<Ac4Violation> {
+    let mut violations = Vec::new();
+    for (category, gaps) in per_category {
+        for gap in gaps {
+            if gap.name.starts_with("recall@") && gap.diff < 0.0 {
+                violations.push(Ac4Violation {
+                    category: category.clone(),
+                    metric_name: gap.name.clone(),
+                    k: gap.k,
+                    baseline_point: gap.baseline_point,
+                    oracle_point: gap.oracle_point,
+                });
+            }
+        }
+    }
+    violations
+}
+
+/// Render an [`OracleGap`] as a markdown report suitable for stdout
+/// inside a PR description or `oracle-gap` subcommand output.
+#[must_use]
+pub fn format_markdown(gap: &OracleGap) -> String {
+    let mut out = String::new();
+    out.push_str("# Oracle Gap\n\n## Global\n\n");
+    write_metric_table(&mut out, &gap.global);
+    out.push_str("\n## Per-category\n");
+    for (category, gaps) in &gap.per_category {
+        out.push_str(&format!("\n### {category}\n\n"));
+        write_metric_table(&mut out, gaps);
+    }
+    out.push_str("\n## AC 4 (per-category recall@k ≥ baseline)\n\n");
+    if gap.ac4_violations.is_empty() {
+        out.push_str("PASS: every category satisfies oracle.recall@k ≥ baseline.recall@k.\n");
+    } else {
+        out.push_str("FAIL — the oracle inject regressed recall in the following slots:\n\n");
+        for v in &gap.ac4_violations {
+            out.push_str(&format!(
+                "- `{category}` `{name}`: oracle {oracle:.4} < baseline {baseline:.4} \
+                 (diff {diff:+.4})\n",
+                category = v.category,
+                name = v.metric_name,
+                oracle = v.oracle_point,
+                baseline = v.baseline_point,
+                diff = v.oracle_point - v.baseline_point,
+            ));
+        }
+    }
+    out
+}
+
+fn write_metric_table(buf: &mut String, gaps: &[MetricGap]) {
+    buf.push_str("| Metric | Forward | Oracle | Gap |\n");
+    buf.push_str("| --- | --- | --- | --- |\n");
+    for g in gaps {
+        buf.push_str(&format!(
+            "| {} | {:.4} | {:.4} | {:+.4} |\n",
+            g.name, g.baseline_point, g.oracle_point, g.diff,
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/eval/oracle_gap/tests.rs
+++ b/src/eval/oracle_gap/tests.rs
@@ -1,0 +1,264 @@
+//! Unit tests for [`crate::eval::oracle_gap`].
+
+use std::collections::BTreeMap;
+
+use rurico::retrieval::HybridSearchConfig;
+use rurico::storage::pre_phase_5_disabled;
+
+use super::{
+    Ac4Violation, MetricGap, OracleGapError, compute_gap, detect_ac4_violations, format_markdown,
+};
+use crate::eval::baseline::{BASELINE_SCHEMA_VERSION, BaselineKind, BaselineSnapshot};
+use crate::eval::metrics::MetricResult;
+
+/// Build a stub `MetricResult` for the given metric label and point estimate.
+/// CI bounds are degenerate (zero width); they are not exercised by the
+/// gap diff itself.
+fn metric(name: &str, k: usize, point: f64) -> MetricResult {
+    MetricResult {
+        name: name.to_owned(),
+        k,
+        point_estimate: point,
+        ci_lower: point,
+        ci_upper: point,
+        uninformative: false,
+    }
+}
+
+/// Build a `BaselineSnapshot` shell with the provided `kind` /
+/// `fixture_hash` / metric lists. Other provenance fields take stub
+/// values that the gap computation does not inspect.
+fn snapshot(
+    kind: BaselineKind,
+    fixture_hash: &str,
+    global: Vec<MetricResult>,
+    per_category: BTreeMap<String, Vec<MetricResult>>,
+) -> BaselineSnapshot {
+    BaselineSnapshot {
+        schema_version: BASELINE_SCHEMA_VERSION.to_owned(),
+        kind,
+        captured_with: "test".to_owned(),
+        timestamp: "epoch:0".to_owned(),
+        model_id: "test/model".to_owned(),
+        model_revision: "rev".to_owned(),
+        mlx_rs_version: "0.0.0".to_owned(),
+        fixture_hash: fixture_hash.to_owned(),
+        aggregation: "identity".to_owned(),
+        merge_config: HybridSearchConfig::default(),
+        normalization: pre_phase_5_disabled(),
+        global,
+        per_category,
+        latency_p50_ms: 0.0,
+        latency_p95_ms: 0.0,
+    }
+}
+
+// T-052-401: compute_gap_rejects_baseline_with_non_forward_kind
+#[test]
+fn compute_gap_rejects_baseline_with_non_forward_kind() {
+    let baseline = snapshot(BaselineKind::Reverse, "fnv1a64:0", vec![], BTreeMap::new());
+    let oracle = snapshot(BaselineKind::Oracle, "fnv1a64:0", vec![], BTreeMap::new());
+    let result = compute_gap(&baseline, &oracle);
+    assert!(
+        matches!(
+            result,
+            Err(OracleGapError::BaselineNotForward(BaselineKind::Reverse))
+        ),
+        "must reject non-Forward baseline kind; got: {result:?}"
+    );
+}
+
+// T-052-402: compute_gap_rejects_oracle_with_non_oracle_kind
+#[test]
+fn compute_gap_rejects_oracle_with_non_oracle_kind() {
+    let baseline = snapshot(BaselineKind::Forward, "fnv1a64:0", vec![], BTreeMap::new());
+    let oracle = snapshot(BaselineKind::Forward, "fnv1a64:0", vec![], BTreeMap::new());
+    let result = compute_gap(&baseline, &oracle);
+    assert!(
+        matches!(
+            result,
+            Err(OracleGapError::OracleNotOracle(BaselineKind::Forward))
+        ),
+        "must reject non-Oracle oracle kind; got: {result:?}"
+    );
+}
+
+// T-052-403: compute_gap_rejects_fixture_hash_mismatch
+//
+// Two snapshots from different fixtures must not be compared — the
+// per-query populations differ and the gap would be meaningless.
+#[test]
+fn compute_gap_rejects_fixture_hash_mismatch() {
+    let baseline = snapshot(
+        BaselineKind::Forward,
+        "fnv1a64:aaaa",
+        vec![],
+        BTreeMap::new(),
+    );
+    let oracle = snapshot(
+        BaselineKind::Oracle,
+        "fnv1a64:bbbb",
+        vec![],
+        BTreeMap::new(),
+    );
+    let result = compute_gap(&baseline, &oracle);
+    assert!(
+        matches!(
+            result,
+            Err(OracleGapError::FixtureHashMismatch { ref baseline, ref oracle })
+                if baseline == "fnv1a64:aaaa" && oracle == "fnv1a64:bbbb"
+        ),
+        "must reject differing fixture_hash; got: {result:?}"
+    );
+}
+
+// T-052-404: compute_gap_emits_per_metric_diff_against_matching_fixture
+#[test]
+fn compute_gap_emits_per_metric_diff_against_matching_fixture() {
+    let baseline = snapshot(
+        BaselineKind::Forward,
+        "fnv1a64:0",
+        vec![
+            metric("recall@5", 5, 0.6300),
+            metric("recall@10", 10, 0.7415),
+        ],
+        BTreeMap::new(),
+    );
+    let oracle = snapshot(
+        BaselineKind::Oracle,
+        "fnv1a64:0",
+        vec![
+            metric("recall@5", 5, 0.7200),
+            metric("recall@10", 10, 1.0000),
+        ],
+        BTreeMap::new(),
+    );
+    let gap = compute_gap(&baseline, &oracle).expect("matching kinds + fixture must succeed");
+    assert_eq!(gap.global.len(), 2);
+    assert!(
+        (gap.global[0].diff - 0.09).abs() < 1e-9,
+        "recall@5 diff = +9.0pt"
+    );
+    assert!(
+        (gap.global[1].diff - 0.2585).abs() < 1e-9,
+        "recall@10 diff = +25.85pt"
+    );
+}
+
+// T-052-405: detect_ac4_violations_flags_recall_regression_per_category
+//
+// AC 4: oracle.recall@k must be >= baseline.recall@k for every
+// category. A negative diff signals a wiring bug.
+#[test]
+fn detect_ac4_violations_flags_recall_regression_per_category() {
+    let mut per_category: BTreeMap<String, Vec<MetricGap>> = BTreeMap::new();
+    per_category.insert(
+        "troubleshooting".to_owned(),
+        vec![
+            MetricGap {
+                name: "recall@5".to_owned(),
+                k: 5,
+                baseline_point: 0.7,
+                oracle_point: 0.65,
+                diff: -0.05,
+            },
+            MetricGap {
+                name: "ndcg@10".to_owned(),
+                k: 10,
+                baseline_point: 0.9,
+                oracle_point: 0.85,
+                diff: -0.05,
+            },
+        ],
+    );
+    let violations = detect_ac4_violations(&per_category);
+    assert_eq!(
+        violations,
+        vec![Ac4Violation {
+            category: "troubleshooting".to_owned(),
+            metric_name: "recall@5".to_owned(),
+            k: 5,
+            baseline_point: 0.7,
+            oracle_point: 0.65,
+        }],
+        "AC 4 covers recall metrics only; ndcg regression must not be flagged"
+    );
+}
+
+// T-052-406: detect_ac4_violations_returns_empty_when_recall_holds
+#[test]
+fn detect_ac4_violations_returns_empty_when_recall_holds() {
+    let mut per_category: BTreeMap<String, Vec<MetricGap>> = BTreeMap::new();
+    per_category.insert(
+        "listing".to_owned(),
+        vec![MetricGap {
+            name: "recall@5".to_owned(),
+            k: 5,
+            baseline_point: 0.5,
+            oracle_point: 0.7,
+            diff: 0.2,
+        }],
+    );
+    assert!(detect_ac4_violations(&per_category).is_empty());
+}
+
+// T-052-407: format_markdown_includes_global_per_category_and_pass_banner
+#[test]
+fn format_markdown_includes_global_per_category_and_pass_banner() {
+    let baseline = snapshot(
+        BaselineKind::Forward,
+        "fnv1a64:0",
+        vec![metric("recall@5", 5, 0.6)],
+        {
+            let mut m = BTreeMap::new();
+            m.insert("listing".to_owned(), vec![metric("recall@5", 5, 0.5)]);
+            m
+        },
+    );
+    let oracle = snapshot(
+        BaselineKind::Oracle,
+        "fnv1a64:0",
+        vec![metric("recall@5", 5, 0.7)],
+        {
+            let mut m = BTreeMap::new();
+            m.insert("listing".to_owned(), vec![metric("recall@5", 5, 0.6)]);
+            m
+        },
+    );
+    let gap = compute_gap(&baseline, &oracle).expect("compute_gap must succeed");
+    let md = format_markdown(&gap);
+    assert!(md.contains("# Oracle Gap"), "must contain top-level header");
+    assert!(md.contains("## Global"), "must contain global section");
+    assert!(
+        md.contains("## Per-category"),
+        "must contain per-category section"
+    );
+    assert!(md.contains("### listing"), "must list each category");
+    assert!(
+        md.contains("PASS"),
+        "AC 4 must report PASS when no recall regressions; got: {md}"
+    );
+}
+
+// T-052-408: format_markdown_lists_violations_under_fail_banner
+#[test]
+fn format_markdown_lists_violations_under_fail_banner() {
+    let baseline = snapshot(BaselineKind::Forward, "fnv1a64:0", vec![], {
+        let mut m = BTreeMap::new();
+        m.insert("listing".to_owned(), vec![metric("recall@5", 5, 0.7)]);
+        m
+    });
+    let oracle = snapshot(BaselineKind::Oracle, "fnv1a64:0", vec![], {
+        let mut m = BTreeMap::new();
+        m.insert("listing".to_owned(), vec![metric("recall@5", 5, 0.65)]);
+        m
+    });
+    let gap = compute_gap(&baseline, &oracle).expect("compute_gap must succeed");
+    let md = format_markdown(&gap);
+    assert!(
+        md.contains("FAIL"),
+        "AC 4 must report FAIL with a regression"
+    );
+    assert!(md.contains("listing"), "must name the offending category");
+    assert!(md.contains("recall@5"), "must name the offending metric");
+}

--- a/src/eval/oracle_gap/tests.rs
+++ b/src/eval/oracle_gap/tests.rs
@@ -176,7 +176,7 @@ fn detect_ac4_violations_flags_recall_regression_per_category() {
         violations,
         vec![Ac4Violation {
             category: "troubleshooting".to_owned(),
-            metric_name: "recall@5".to_owned(),
+            name: "recall@5".to_owned(),
             k: 5,
             baseline_point: 0.7,
             oracle_point: 0.65,

--- a/src/eval/oracle_gap/tests.rs
+++ b/src/eval/oracle_gap/tests.rs
@@ -112,6 +112,93 @@ fn compute_gap_rejects_fixture_hash_mismatch() {
     );
 }
 
+// T-052-409: compute_gap_rejects_mismatched_aggregation
+//
+// AC 4 must not swing on a config typo: a forward captured under
+// `identity` and an oracle captured under `dedupe` measure different
+// downstream stacks, so the gap is meaningless.
+#[test]
+fn compute_gap_rejects_mismatched_aggregation() {
+    let mut baseline = snapshot(BaselineKind::Forward, "fnv1a64:0", vec![], BTreeMap::new());
+    let mut oracle = snapshot(BaselineKind::Oracle, "fnv1a64:0", vec![], BTreeMap::new());
+    baseline.aggregation = "identity".to_owned();
+    oracle.aggregation = "dedupe".to_owned();
+    let result = compute_gap(&baseline, &oracle);
+    assert!(
+        matches!(
+            result,
+            Err(OracleGapError::PipelineConfigMismatch {
+                field: "aggregation",
+                ..
+            })
+        ),
+        "must reject mismatched aggregation; got: {result:?}"
+    );
+}
+
+// T-052-410: compute_gap_rejects_missing_oracle_category
+//
+// A category present on baseline but absent on oracle must surface as
+// a typed error — silent drop would let AC 4 PASS without checking the
+// missing bucket.
+#[test]
+fn compute_gap_rejects_missing_oracle_category() {
+    let baseline_per_cat = {
+        let mut m = BTreeMap::new();
+        m.insert("listing".to_owned(), vec![metric("recall@5", 5, 0.6)]);
+        m.insert(
+            "troubleshooting".to_owned(),
+            vec![metric("recall@5", 5, 0.7)],
+        );
+        m
+    };
+    let oracle_per_cat = {
+        let mut m = BTreeMap::new();
+        m.insert("listing".to_owned(), vec![metric("recall@5", 5, 0.7)]);
+        m
+    };
+    let baseline = snapshot(BaselineKind::Forward, "fnv1a64:0", vec![], baseline_per_cat);
+    let oracle = snapshot(BaselineKind::Oracle, "fnv1a64:0", vec![], oracle_per_cat);
+    let result = compute_gap(&baseline, &oracle);
+    assert!(
+        matches!(
+            result,
+            Err(OracleGapError::MissingOracleCategory { ref category })
+                if category == "troubleshooting"
+        ),
+        "must reject missing oracle category; got: {result:?}"
+    );
+}
+
+// T-052-411: compute_gap_rejects_missing_oracle_metric_within_category
+#[test]
+fn compute_gap_rejects_missing_oracle_metric_within_category() {
+    let baseline_per_cat = {
+        let mut m = BTreeMap::new();
+        m.insert(
+            "listing".to_owned(),
+            vec![metric("recall@5", 5, 0.6), metric("ndcg@10", 10, 0.85)],
+        );
+        m
+    };
+    let oracle_per_cat = {
+        let mut m = BTreeMap::new();
+        m.insert("listing".to_owned(), vec![metric("recall@5", 5, 0.7)]);
+        m
+    };
+    let baseline = snapshot(BaselineKind::Forward, "fnv1a64:0", vec![], baseline_per_cat);
+    let oracle = snapshot(BaselineKind::Oracle, "fnv1a64:0", vec![], oracle_per_cat);
+    let result = compute_gap(&baseline, &oracle);
+    assert!(
+        matches!(
+            result,
+            Err(OracleGapError::MissingOracleMetric { ref scope, ref metric, k: 10 })
+                if scope == "listing" && metric == "ndcg@10"
+        ),
+        "must reject missing oracle metric within category; got: {result:?}"
+    );
+}
+
 // T-052-404: compute_gap_emits_per_metric_diff_against_matching_fixture
 #[test]
 fn compute_gap_emits_per_metric_diff_against_matching_fixture() {

--- a/tests/eval_smoke.rs
+++ b/tests/eval_smoke.rs
@@ -24,6 +24,38 @@ const REVERSE_BASELINE_PATH: &str = "tests/fixtures/eval/reverse_baseline.json";
 /// Path to the committed full baseline. T-019 verifies against this file.
 const BASELINE_PATH: &str = "tests/fixtures/eval/baseline.json";
 
+/// Path to the committed oracle baseline (Issue #52). T-052-004 compares
+/// it against [`BASELINE_PATH`] via the `oracle-gap` subcommand.
+const ORACLE_BASELINE_PATH: &str = "tests/fixtures/eval/oracle_baseline.json";
+
+// T-052-004: t052_004_oracle_gap_passes_against_committed_fixtures
+// Issue #52 AC 3 + AC 4: `oracle-gap` against the committed baseline.json
+// and oracle_baseline.json must exit 0 (no per-category recall regression)
+// and emit the markdown gap report on stdout. Read-only; no MLX required,
+// so this runs in the default cargo test lane (no #[ignore]).
+#[test]
+fn t052_004_oracle_gap_passes_against_committed_fixtures() {
+    let output = Command::new(env!("CARGO_BIN_EXE_eval_harness"))
+        .args([
+            "oracle-gap",
+            &format!("baseline={BASELINE_PATH}"),
+            &format!("oracle={ORACLE_BASELINE_PATH}"),
+        ])
+        .output()
+        .expect("spawn eval_harness oracle-gap");
+    assert_smoke_success(&output);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("# Oracle Gap"),
+        "[T-052-004] AC 3: stdout must contain `# Oracle Gap` header, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("PASS"),
+        "[T-052-004] AC 4: committed fixtures must pass the AC 4 gate, got: {stdout}"
+    );
+}
+
 // T-013: t013_identity_fixture_perfect_metrics
 // FR-011: identity_ranker fixture must yield nDCG@10 == 1.0 ∧ Recall@1 == 1.0.
 #[test]

--- a/tests/fixtures/eval/baseline.json
+++ b/tests/fixtures/eval/baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.1",
+  "schema_version": "1.2",
   "kind": "forward",
   "captured_with": "eval_harness capture-baseline",
   "timestamp": "epoch:1777265610",

--- a/tests/fixtures/eval/oracle_baseline.json
+++ b/tests/fixtures/eval/oracle_baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.1",
+  "schema_version": "1.2",
   "kind": "oracle",
   "captured_with": "eval_harness capture-oracle",
   "timestamp": "epoch:1778206324",

--- a/tests/fixtures/eval/reverse_baseline.json
+++ b/tests/fixtures/eval/reverse_baseline.json
@@ -3,5 +3,5 @@
   "k": 10,
   "kind": "reverse",
   "observed_lower_bound": 0.47909084298136606,
-  "schema_version": "1.1"
+  "schema_version": "1.2"
 }


### PR DESCRIPTION
## 概要

Issue #52 の残り AC を全部閉じる PR2。Forward baseline と Oracle baseline (PR1 で追加) の差分を runnable な gate として表に出す。

- `oracle-gap` subcommand: per-metric / per-category diff の markdown レポート + AC 4 gate (per-category recall regression で `EXIT_REGRESSION` 1)
- `BASELINE_SCHEMA_VERSION` 1.1 → 1.2 (Oracle variant 互換性 note)
- ADR 0002 に Oracle Mode セクション追記
- README CLI conventions 直後に Oracle mode 使い方追記
- `tests/eval_smoke.rs` T-052-004 (default-lane smoke、MLX 不要)

## 初回 gap (commit fixture)

`fixture_hash: fnv1a64:88afbfc4e99e0a84` にて:

| Metric    | Forward | Oracle | Gap     |
| --------- | ------- | ------ | ------- |
| recall@5  | 0.6300  | 0.7200 | +9.0pt  |
| recall@10 | 0.7415  | 1.0000 | +25.9pt |
| mrr@10    | 1.0000  | 1.0000 | 0       |
| ndcg@10   | 0.8930  | 0.9474 | +5.4pt  |

AC 4 PASS — 全 5 category で `oracle.recall@k ≥ baseline.recall@k`。

## AC カバレッジ (Issue #52)

- [x] AC 1: `OracleMerge: MergeStrategy` (PR1)
- [x] AC 2: `capture-oracle` で `oracle_baseline.json` 生成 (PR1)
- [x] AC 3: `oracle-gap` で per-metric / per-category 差分表示
- [x] AC 4: 全 query category で oracle recall@k ≥ baseline recall@k (gate, exit 1 on regression)
- [x] AC 5: known-answer fixture で oracle 経路でも `recall@1=1.0`, `ndcg@10=1.0` 維持 (PR1)
- [x] AC 6: oracle wiring test を `tests/eval_smoke.rs` に追加 (PR1 + PR2)
- [x] AC 7: ADR 0002 に Oracle mode セクション追記
- [x] AC 8: README CLI conventions 直後に Oracle mode 使い方追記

## 設計メモ

- **AC 4 は recall metrics 限定**: oracle inject は retrieval ceiling を測るのが目的。`mrr` / `ndcg` は reranker score の比較を含むから、oracle が natural top hit を replace する際に relevant doc が top-k 内で前後することがあり、これを違反扱いにすると false positive。issue 本文も "全 query category で oracle の `recall@k ≥`" と recall 限定なのと整合。
- **Pure function 設計**: `compute_gap` は `(BaselineSnapshot, BaselineSnapshot) → Result<OracleGap, _>` の純関数。IO は `eval_harness::run_oracle_gap` 側に分離してテスト容易性を保つ。
- **Schema 互換性 guard**: `compute_gap` は kind / schema_version (両者一致) / fixture_hash の食い違いを reject。さらに `enforce_current_schema` で `schema_version == BASELINE_SCHEMA_VERSION` も check (CodeRabbit 指摘) — 古い 1.1 file を today の 1.2 harness で誤って比較しないようにする。

## 動作確認

- [x] `cargo test --all-features` — lib 173 + storage 7 + smoke 1 (T-052-004 default-lane) + doctest 18 pass、MLX-gated `#[ignore]` smoke 9 件
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `just eval-oracle-gap` 手動実行 → AC 4 PASS 確認、markdown 出力確認
- [x] `/polish` 通し (Phase 1: simplify + Codex + CodeRabbit + Gemini / Phase 2: enhancer-code)

Closes #52