### PR TITLE
feat(eval): annotation framework 基盤を追加 (Issue #53 PR-A)

### DIFF
--- a/docs/decisions/0004-annotation-framework.md
+++ b/docs/decisions/0004-annotation-framework.md
@@ -1,0 +1,98 @@
+# Annotation Framework Foundation
+
+- Status: proposed
+- Deciders: thkt
+- Date: 2026-05-08
+- Confidence: medium — provenance envelope の必要性は ADR-0002 `BaselineSnapshot` 既存パターンで実証済。`eval::annotation` module path での既存 `EvalQuery.annotation` field との共存は T-001 readability test で検証可能。一方 Phase 1.5 Collaborative mode 着手時に model_id / mlx_rs_version 追加で `ANNOTATION_SCHEMA_VERSION` bump が必要となる migration debt は存在し、その時点で envelope 設計の再評価余地が残る。
+
+## Context and Problem Statement
+
+amici の `tests/fixtures/eval/queries.jsonl` は ADR-0002 fixture 規約に基づき 168 queries × 8 categories で運用されている。新カテゴリ追加・relevance map 拡張・annotation 文字列の手書きは継続して手作業で行われ、誰が・いつ・どの session で書いたかの provenance trail を残す手段がない。
+
+ADR-0001 は amici の charter を「shared model-loading + CLI utilities」、ADR-0002 は「end-to-end retrieval-quality governance」と定義したが、いずれも authoring tool (queries.jsonl 拡張支援 subcommand 群) を含まない。Issue #53 で計画中の `annotate` / `annotation-stats` / `annotation-export` subcommand を charter 不変のまま追加すると charter creep となり、ADR の説明可能性 (contributor が `docs/decisions/` を読んだだけで charter scope を判断できる) が劣化する。
+
+加えて、authoring tool が emit する session metadata は capture metadata (`BaselineSnapshot.schema_version` 等) と同様に schema-version envelope discipline を持たないと、後続 phase での field 追加 (model_id, mlx_rs_version 等) で silent drift が発生する。
+
+## Decision Drivers
+
+- charter clarity: authoring tool が ADR で説明可能な状態を維持し、新規 contributor が charter scope を `docs/decisions/` から判断できる
+- provenance discipline: queries.jsonl 拡張に session-level provenance (annotator id / session id / fixture hash) を attach する型基盤を public API として提供
+- envelope discipline: `ANNOTATION_SCHEMA_VERSION` 定数を canonical reference として固定し、schema version mismatch を runtime で typed error として検出可能にする (`oracle_gap.rs::OracleGapError::SchemaVersionMismatch` precedent)
+- naming collision avoidance: 既存 `EvalQuery.annotation: String` field (`src/eval/fixture.rs:34-36`、`REQUIRED_QUERY_FIELDS:132`) と命名衝突せず両者を同一 test scope 内で参照可能にする
+- 168 行 queries.jsonl の breaking change を避ける: 既存 fixture を rename / migration 不要のまま foundation を land する
+
+## Considered Options
+
+### Option 1: Annotation-tailored envelope + module path namespacing (chosen)
+
+- Good: `eval::annotation::Session` / `eval::annotation::Entry` という module path で既存 `EvalQuery.annotation` field との衝突を解消、168 行の queries.jsonl rename / migration 不要
+- Good: `ANNOTATION_SCHEMA_VERSION` を `BASELINE_SCHEMA_VERSION` (現 1.2) と独立に進化させられる、Phase 1.5 Collaborative mode で `model_id` / `mlx_rs_version` 追加時に baseline 側を bump せずに済む
+- Good: ADR-0002 既存 envelope (`BaselineSnapshot`) precedent を踏襲した形で `Provenance` 型に schema_version / captured_with / fixture hash 等を持たせる
+- Bad: capture envelope と authoring envelope の 2 envelope を維持するコスト。Phase 1.5 Collaborative mode で「authoring metadata と capture metadata を symmetric に揃えたい」という contributor 要望が出た場合、本 ADR の方針再評価が必要
+
+### Option 2: BaselineSnapshot mirror + BaselineKind::Annotation variant
+
+- Good: 1 envelope に統一、provenance schema が capture / annotation で symmetric
+- Bad: `BASELINE_SCHEMA_VERSION` (現 1.2) を 1.3 へ bump 必要 → committed `baseline.json` fixture (T-021 で deserialise 検証中) も同時更新、Phase 1 sub-PR-A の scope を超える
+- Bad: `BaselineKind::Annotation` の body shape が `BaselineSnapshot` (metrics + per_category 必須) と乖離、variant 追加時に shape divergence → optional field の serde default 設計が必要
+
+### Option 3: rename existing `EvalQuery.annotation` field
+
+- Good: 命名衝突なし、`Entry.annotation` という flat 命名が可能
+- Bad: 168 行の queries.jsonl migration が必要 (各行の JSON key rename + fixture_hash 再計算 → `BASELINE_SCHEMA_VERSION` coordinate bump も波及)
+- Bad: 既存 fixture file format の breaking change、ADR-0002 で凍結された `tests/fixtures/eval/` 規約から逸脱
+
+## Decision Outcome
+
+Option 1 を採用する。
+
+1. **`eval::annotation` module 新設** — `src/eval/annotation.rs` に `Session`, `Entry`, `BlockMode`, `Provenance`, `AnnotationError`, `ANNOTATION_SCHEMA_VERSION` を pub export。tests は `src/eval/annotation/tests.rs` に分離 (LANG.md `sub.rs` + `sub/child.rs` 規約)。
+
+2. **`ANNOTATION_SCHEMA_VERSION = "1.0"`** — `BASELINE_SCHEMA_VERSION` (現 1.2) と独立。`Provenance.schema_version` が canonical 値と不一致のとき `AnnotationError::SchemaVersionMismatch { got, expected }` を返す。
+
+3. **Phase 1 で意図的に欠落させる field** — `Provenance` から `model_id` と `mlx_rs_version` を Phase 1 では除外。Phase 1.5 Collaborative mode (model-assisted relevance suggestion) 着手時に追加し、`ANNOTATION_SCHEMA_VERSION` を 1.0 → 1.1 へ bump する。
+
+| Attribute | Phase 1 で欠落させる根拠 | 追加トリガと schema version bump |
+| --------- | ------------------------ | ---------------------------------- |
+| `model_id` | Phase 1 sub-PR-A は Block mode (手動 judgment、model 未関与) のみを foundation として扱う。`Provenance` に未使用 field を持たせると schema 欄外フィールドとして空文字列流通し、下流 consumer が「省略 OK」と誤解する | Phase 1.5 Collaborative mode (model-assisted suggestion) → `ANNOTATION_SCHEMA_VERSION` 1.0 → 1.1 bump で `Provenance.model_id: String` 追加 |
+| `mlx_rs_version` | 同上、Block mode は ML runtime 未関与 | Phase 1.5 Collaborative mode → 同じ 1.0 → 1.1 bump で `Provenance.mlx_rs_version: String` 同時追加 |
+
+4. **`AnnotationError` は `thiserror` + `#[non_exhaustive]`** — `BaselineError` / `FixtureError` / `OracleGapError` 既存 precedent を踏襲。variant 追加を非破壊で許可する forward-compatible 設計。
+
+5. **Status: proposed で land し、PR-B / PR-C 着地後に accepted promote** — ADR-0003 precedent に従う。先行 PR-A で foundation を land、PR-B (annotate subcommand) / PR-C (annotation-stats / annotation-export) 着地時点で本 ADR を accepted へ promote する。
+
+### Positive Consequences
+
+- queries.jsonl 拡張に provenance trail (annotator id / session id / fixture hash) を attach する型基盤が public API として確立する
+- charter scope が `docs/decisions/0004-*.md` を介して contributor に説明可能になる、authoring tool の charter creep が解消する
+- schema-version envelope discipline が runtime check として enforce される (`SchemaVersionMismatch` typed error)
+- 既存 `EvalQuery.annotation` field と 168 行 queries.jsonl は touch せず、breaking change を Phase 1 sub-PR-A から排除
+
+### Negative Consequences
+
+- capture envelope (`BaselineSnapshot`) と authoring envelope (`Session`) の 2 envelope を維持。Phase 1.5 Collaborative mode で symmetric 化を求められた場合、本 ADR の方針再評価が必要となる migration debt
+- Phase 1.5 で `model_id` / `mlx_rs_version` 追加時に `ANNOTATION_SCHEMA_VERSION` bump が必須、その時点で committed annotation session fixture (もし存在すれば) も同時更新
+
+## Reassessment Triggers
+
+- Phase 1.5 Collaborative mode 着手時に「Annotation-tailored envelope を維持」「`BaselineSnapshot` mirror に migrate」両 option の比較判断。本 ADR §Decision Outcome 第 3 項の table が判断 anchor
+- T-001 (naming collision readability) が PASS していても、実運用で `EvalQuery.annotation` と `eval::annotation::Entry` の混同による不具合が報告された場合 → §Considered Options Option 3 (rename existing field) を再評価
+- contributor 数が増え authoring tool の使用頻度が baseline capture と同等以上になり、capture / authoring envelope の symmetric 化要望が複数 contributor から出た場合 → Option 2 (`BaselineSnapshot` mirror + `BaselineKind::Annotation`) を再評価
+- `ANNOTATION_SCHEMA_VERSION` の bump 頻度が `BASELINE_SCHEMA_VERSION` を超える状態が継続した場合 → 2 envelope 維持の正当性 (独立進化) が機能している証左、本 ADR の方針継続を強化
+
+## References
+
+- ADR-0001 (amici extraction)
+- ADR-0002 (eval governance methodology, `BaselineSnapshot` envelope precedent)
+- ADR-0003 (Status: proposed precedent, schema version bump pattern via Issue #61 / #62)
+- amici Issue #53 (this ADR's deliverable — annotation framework Phase 1)
+- amici Issue #61 (`Hit@1` / `Hit@3` metrics — PR-B blocking)
+- amici Issue #62 (first-search replay subcommand — PR-C blocking)
+- `src/eval/baseline.rs` (`BASELINE_SCHEMA_VERSION` envelope precedent)
+- `src/eval/oracle_gap.rs` (`OracleGapError::SchemaVersionMismatch` typed error precedent)
+- `src/eval/fixture.rs:34-36` (existing `EvalQuery.annotation` field that motivates module-path namespacing)
+
+## Downstream consumers (this ADR を前提として動く後続)
+
+- amici Issue #53 PR-B — `annotate` subcommand (Block mode TTY shell + Session 永続化、本 ADR Phase 1 完了 + Issue #61 完了後に着手)
+- amici Issue #53 PR-C — `annotation-stats` / `annotation-export` subcommand (Session 統計 + queries.jsonl 形式への export、本 ADR Phase 1 完了 + Issue #62 完了後に着手)

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -6,6 +6,7 @@
 //! run. Feature-gated behind `eval-harness`; default `amici` builds skip
 //! the module.
 
+pub mod annotation;
 pub mod baseline;
 pub mod fixture;
 pub mod metrics;

--- a/src/eval/annotation.rs
+++ b/src/eval/annotation.rs
@@ -1,0 +1,137 @@
+//! Annotation framework foundation (Issue #53 Phase 1 sub-PR-A).
+//!
+//! Public types underpinning the offline annotation authoring tool whose
+//! subcommand wiring lands in sub-PR-B (after #61 / #62). Phase 1
+//! deliberately omits `model_id` and `mlx_rs_version` from
+//! [`Provenance`] — those attach in Phase 1.5 Collaborative mode and
+//! trigger an [`ANNOTATION_SCHEMA_VERSION`] bump per ADR-0004.
+//!
+//! The envelope is annotation-tailored (does not mirror
+//! [`crate::eval::baseline::BaselineSnapshot`]) so authoring metadata
+//! evolves independently of capture metadata. Migration triggers and
+//! intentionally-omitted fields are documented in
+//! `docs/decisions/0004-annotation-framework.md`.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Canonical schema-version label stamped onto every emitted
+/// [`Provenance`] envelope. Bump when the envelope shape changes.
+///
+/// Version log:
+/// - `1.0`: initial Phase 1 envelope. Block-mode authoring only;
+///   `model_id` and `mlx_rs_version` are intentionally absent — see
+///   `docs/decisions/0004-annotation-framework.md` §Decision Outcome
+///   for the migration trigger that bumps to `1.1`.
+pub const ANNOTATION_SCHEMA_VERSION: &str = "1.0";
+
+/// Authoring strategy discriminator. Exactly one Phase 1 variant
+/// (`Standard`) per FR-006; `Highlight` and `Collaborative` modes attach
+/// in Phase 1.5+ and trigger an [`ANNOTATION_SCHEMA_VERSION`] bump.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BlockMode {
+    /// Standard block-mode authoring: relevance grades are filled in
+    /// without model assistance.
+    Standard,
+}
+
+/// Per-session authoring metadata captured alongside annotation
+/// records. Phase 1 omits `model_id` / `mlx_rs_version` per ADR-0004.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Provenance {
+    /// Envelope schema label. See [`ANNOTATION_SCHEMA_VERSION`].
+    pub schema_version: String,
+    /// Subcommand or context label that produced this session.
+    pub captured_with: String,
+    /// Capture-time label in `epoch:N` form. Avoids pulling `chrono`
+    /// in just for an ISO-8601 timestamp; mirrors
+    /// [`crate::eval::baseline::BaselineSnapshot::timestamp`].
+    pub timestamp: String,
+    /// Annotator identity (e.g. `thkt`, GitHub handle, OAuth subject).
+    pub annotator_id: String,
+    /// Stable session identifier used to deduplicate / correlate
+    /// records across runs.
+    pub session_id: String,
+    /// Content hash over `queries.jsonl` at session start. Mirrors
+    /// `BaselineSnapshot.fixture_hash` so authoring can be replayed
+    /// against the exact fixture state it was authored against.
+    pub queries_jsonl_hash: String,
+}
+
+/// Single annotation record. Carries graded relevance per `doc_id`
+/// plus a free-form rationale note.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Entry {
+    /// Stable identifier (typically mirrors a query / record id).
+    pub id: String,
+    /// Surface text being annotated.
+    pub text: String,
+    /// One of the seven semantic category labels (FR-006 of ADR-0002).
+    pub category: String,
+    /// Maps `doc_id` to graded relevance in `{0, 1, 2, 3}`.
+    pub relevance_map: HashMap<String, u8>,
+    /// Free-form rationale note for the relevance judgment. Distinct
+    /// from [`crate::eval::fixture::EvalQuery::annotation`] to avoid
+    /// identifier collision in shared `use` scope (FR-005).
+    pub annotation_note: String,
+    /// Authoring strategy used (FR-006).
+    pub mode: BlockMode,
+}
+
+/// One annotation session. Pairs [`Provenance`] with the ordered list of
+/// records authored under it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Session {
+    /// Capture metadata for this session.
+    pub provenance: Provenance,
+    /// Authored records in capture order.
+    pub entries: Vec<Entry>,
+}
+
+impl Session {
+    /// Verify [`Provenance::schema_version`] equals
+    /// [`ANNOTATION_SCHEMA_VERSION`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnnotationError::SchemaVersionMismatch`] when the
+    /// labels disagree, carrying both observed and expected labels so
+    /// downstream consumers can render an actionable diff.
+    pub fn validate_schema_version(&self) -> Result<(), AnnotationError> {
+        if self.provenance.schema_version != ANNOTATION_SCHEMA_VERSION {
+            return Err(AnnotationError::SchemaVersionMismatch {
+                got: self.provenance.schema_version.clone(),
+                expected: ANNOTATION_SCHEMA_VERSION.to_owned(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Errors surfaced by annotation framework operations.
+#[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
+pub enum AnnotationError {
+    /// `Provenance.schema_version` did not equal
+    /// [`ANNOTATION_SCHEMA_VERSION`] at validation time.
+    #[error("annotation schema version mismatch (got {got:?}, expected {expected:?})")]
+    SchemaVersionMismatch {
+        /// Observed label carried by the provenance under inspection.
+        got: String,
+        /// Canonical label expected at validation.
+        expected: String,
+    },
+    /// Annotation session contains zero entries.
+    #[error("annotation session is empty")]
+    EmptySession,
+    /// JSON serialisation / deserialisation failure. Wraps the
+    /// underlying `serde_json::Error` and preserves the source chain
+    /// via `#[from]`.
+    #[error("annotation serialise error: {0}")]
+    Serialise(#[from] serde_json::Error),
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/eval/annotation.rs
+++ b/src/eval/annotation.rs
@@ -12,7 +12,7 @@
 //! intentionally-omitted fields are documented in
 //! `docs/decisions/0004-annotation-framework.md`.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
@@ -70,8 +70,10 @@ pub struct Entry {
     pub text: String,
     /// One of the seven semantic category labels (FR-006 of ADR-0002).
     pub category: String,
-    /// Maps `doc_id` to graded relevance in `{0, 1, 2, 3}`.
-    pub relevance_map: HashMap<String, u8>,
+    /// Maps `doc_id` to graded relevance in `{0, 1, 2, 3}`. `BTreeMap`
+    /// guarantees deterministic JSON key order so an unchanged
+    /// [`Session`] re-emits byte-identical output across runs.
+    pub relevance_map: BTreeMap<String, u8>,
     /// Free-form rationale note for the relevance judgment. Distinct
     /// from [`crate::eval::fixture::EvalQuery::annotation`] to avoid
     /// identifier collision in shared `use` scope (FR-005).
@@ -126,9 +128,7 @@ pub enum AnnotationError {
     /// Annotation session contains zero entries.
     #[error("annotation session is empty")]
     EmptySession,
-    /// JSON serialisation / deserialisation failure. Wraps the
-    /// underlying `serde_json::Error` and preserves the source chain
-    /// via `#[from]`.
+    /// JSON serialisation / deserialisation failure.
     #[error("annotation serialise error: {0}")]
     Serialise(#[from] serde_json::Error),
 }

--- a/src/eval/annotation/tests.rs
+++ b/src/eval/annotation/tests.rs
@@ -1,0 +1,161 @@
+//! Unit tests for [`crate::eval::annotation`] (Issue #53 sub-PR-A).
+//!
+//! Maps to spec Test Scenarios T-001..T-004 in
+//! `docs/spec/2026-05-08-issue-53-annotation-foundation/spec.md`. The
+//! Spec's Skip rationale (FR-V002 Serialise wrapper) explicitly defers
+//! that case to the implicit serde path coverage from T-002.
+
+use std::collections::HashMap;
+
+use super::*;
+use crate::eval::fixture::EvalQuery;
+
+/// Build a stub [`Provenance`] carrying the given `schema_version`. All
+/// other fields take literal stub values that the test under exercise
+/// does not inspect.
+///
+/// Mirrors the `snapshot` helper pattern in
+/// `src/eval/oracle_gap/tests.rs` — centralises the 6-field literal so
+/// T-002 / T-003 / T-004 read as one-liners.
+fn make_provenance(schema_version: &str) -> Provenance {
+    Provenance {
+        schema_version: schema_version.to_owned(),
+        captured_with: "annotation-tests".to_owned(),
+        timestamp: "epoch:0".to_owned(),
+        annotator_id: "test-annotator".to_owned(),
+        session_id: "test-session-0".to_owned(),
+        queries_jsonl_hash: "fnv1a64:0".to_owned(),
+    }
+}
+
+/// Build a stub [`Entry`] with a single relevance grade and the supplied
+/// annotation note text. `mode` is fixed to [`BlockMode::Standard`] (the
+/// only Phase 1 variant per FR-006).
+fn make_entry(id: &str, annotation_note: &str) -> Entry {
+    let mut relevance_map = HashMap::new();
+    relevance_map.insert("d1".to_owned(), 2u8);
+    Entry {
+        id: id.to_owned(),
+        text: "stub entry text".to_owned(),
+        category: "C1".to_owned(),
+        relevance_map,
+        annotation_note: annotation_note.to_owned(),
+        mode: BlockMode::Standard,
+    }
+}
+
+/// Build a one-entry [`Session`] with provenance carrying
+/// `schema_version`. Used by T-002 / T-003 / T-004.
+fn make_session(schema_version: &str) -> Session {
+    Session {
+        provenance: make_provenance(schema_version),
+        entries: vec![make_entry("q1", "block-mode judgment")],
+    }
+}
+
+// T-001: eval_query_annotation_and_entry_annotation_note_coexist
+// FR-005: EvalQuery.annotation and Entry.annotation_note coexist in
+//         shared scope without rename or shadowing.
+#[test]
+fn eval_query_annotation_and_entry_annotation_note_coexist() {
+    let mut relevance_map = HashMap::new();
+    relevance_map.insert("d1".to_owned(), 1u8);
+    let query = EvalQuery {
+        id: "q1".to_owned(),
+        text: "alpha".to_owned(),
+        category: "C1".to_owned(),
+        relevance_map,
+        annotation: "existing relevance note".to_owned(),
+    };
+    let entry = make_entry("q1", "new block-mode judgment");
+
+    assert_eq!(
+        query.annotation, "existing relevance note",
+        "EvalQuery.annotation must preserve the existing relevance-rationale field semantics; \
+         got: {:?}",
+        query.annotation
+    );
+    assert_eq!(
+        entry.annotation_note, "new block-mode judgment",
+        "Entry.annotation_note must be readable alongside EvalQuery.annotation without rename; \
+         got: {:?}",
+        entry.annotation_note
+    );
+}
+
+// T-002: session_round_trips_through_serde_json
+// FR-003: Session encodes via serde_json and decodes back to a
+//         PartialEq-equal value (pins envelope shape against silent
+//         field rename/drop).
+#[test]
+fn session_round_trips_through_serde_json() {
+    let original = make_session(ANNOTATION_SCHEMA_VERSION);
+
+    let json = serde_json::to_string(&original).expect("serialise Session to JSON");
+    let parsed: Session = serde_json::from_str(&json).expect("deserialise Session from JSON");
+
+    assert_eq!(
+        parsed, original,
+        "Session must round-trip through serde_json under PartialEq; \
+         original={original:?}, parsed={parsed:?}"
+    );
+}
+
+// T-003: validate_schema_version_rejects_mismatched_label
+// FR-V001: Session::validate_schema_version returns
+//          AnnotationError::SchemaVersionMismatch { got, expected }
+//          when provenance schema_version != ANNOTATION_SCHEMA_VERSION.
+#[test]
+fn validate_schema_version_rejects_mismatched_label() {
+    let session = make_session("0.9");
+
+    let result = session.validate_schema_version();
+
+    assert!(
+        matches!(
+            &result,
+            Err(AnnotationError::SchemaVersionMismatch { got, expected })
+                if got == "0.9" && expected == "1.0"
+        ),
+        "FR-V001: schema_version \"0.9\" must yield SchemaVersionMismatch \
+         {{ got: \"0.9\", expected: \"1.0\" }}; got: {result:?}"
+    );
+}
+
+// T-004: pub_items_compile_with_canonical_constant_and_block_mode_variant
+// FR-001 / FR-002 / FR-006: 6 pub items reachable via `use super::*`;
+//          ANNOTATION_SCHEMA_VERSION == "1.0"; BlockMode::Standard
+//          reachable on Entry.mode; one AnnotationError variant
+//          matches!-pattern.
+#[test]
+fn pub_items_compile_with_canonical_constant_and_block_mode_variant() {
+    assert_eq!(
+        ANNOTATION_SCHEMA_VERSION, "1.0",
+        "FR-002: ANNOTATION_SCHEMA_VERSION must equal \"1.0\"; got: {ANNOTATION_SCHEMA_VERSION:?}"
+    );
+
+    let session = make_session(ANNOTATION_SCHEMA_VERSION);
+
+    assert_eq!(
+        session.provenance.schema_version, ANNOTATION_SCHEMA_VERSION,
+        "Provenance built from ANNOTATION_SCHEMA_VERSION must round-trip the constant value"
+    );
+    assert_eq!(
+        session.entries.len(),
+        1,
+        "make_session must produce exactly one entry for the FR-006 reachability check"
+    );
+    assert!(
+        matches!(session.entries[0].mode, BlockMode::Standard),
+        "FR-006: Entry.mode must be reachable as BlockMode::Standard; \
+         got: {:?}",
+        session.entries[0].mode
+    );
+
+    let err: AnnotationError = AnnotationError::EmptySession;
+    assert!(
+        matches!(err, AnnotationError::EmptySession),
+        "FR-001: AnnotationError::EmptySession variant must be reachable via matches!; \
+         got: {err:?}"
+    );
+}

--- a/src/eval/annotation/tests.rs
+++ b/src/eval/annotation/tests.rs
@@ -5,7 +5,7 @@
 //! Spec's Skip rationale (FR-V002 Serialise wrapper) explicitly defers
 //! that case to the implicit serde path coverage from T-002.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use super::*;
 use crate::eval::fixture::EvalQuery;
@@ -13,10 +13,6 @@ use crate::eval::fixture::EvalQuery;
 /// Build a stub [`Provenance`] carrying the given `schema_version`. All
 /// other fields take literal stub values that the test under exercise
 /// does not inspect.
-///
-/// Mirrors the `snapshot` helper pattern in
-/// `src/eval/oracle_gap/tests.rs` — centralises the 6-field literal so
-/// T-002 / T-003 / T-004 read as one-liners.
 fn make_provenance(schema_version: &str) -> Provenance {
     Provenance {
         schema_version: schema_version.to_owned(),
@@ -32,7 +28,7 @@ fn make_provenance(schema_version: &str) -> Provenance {
 /// annotation note text. `mode` is fixed to [`BlockMode::Standard`] (the
 /// only Phase 1 variant per FR-006).
 fn make_entry(id: &str, annotation_note: &str) -> Entry {
-    let mut relevance_map = HashMap::new();
+    let mut relevance_map = BTreeMap::new();
     relevance_map.insert("d1".to_owned(), 2u8);
     Entry {
         id: id.to_owned(),
@@ -45,7 +41,7 @@ fn make_entry(id: &str, annotation_note: &str) -> Entry {
 }
 
 /// Build a one-entry [`Session`] with provenance carrying
-/// `schema_version`. Used by T-002 / T-003 / T-004.
+/// `schema_version`.
 fn make_session(schema_version: &str) -> Session {
     Session {
         provenance: make_provenance(schema_version),
@@ -71,15 +67,11 @@ fn eval_query_annotation_and_entry_annotation_note_coexist() {
 
     assert_eq!(
         query.annotation, "existing relevance note",
-        "EvalQuery.annotation must preserve the existing relevance-rationale field semantics; \
-         got: {:?}",
-        query.annotation
+        "EvalQuery.annotation must preserve the existing relevance-rationale field semantics"
     );
     assert_eq!(
         entry.annotation_note, "new block-mode judgment",
-        "Entry.annotation_note must be readable alongside EvalQuery.annotation without rename; \
-         got: {:?}",
-        entry.annotation_note
+        "Entry.annotation_note must be readable alongside EvalQuery.annotation without rename"
     );
 }
 
@@ -96,8 +88,7 @@ fn session_round_trips_through_serde_json() {
 
     assert_eq!(
         parsed, original,
-        "Session must round-trip through serde_json under PartialEq; \
-         original={original:?}, parsed={parsed:?}"
+        "Session must round-trip through serde_json under PartialEq"
     );
 }
 
@@ -122,36 +113,35 @@ fn validate_schema_version_rejects_mismatched_label() {
     );
 }
 
-// T-004: pub_items_compile_with_canonical_constant_and_block_mode_variant
-// FR-001 / FR-002 / FR-006: 6 pub items reachable via `use super::*`;
-//          ANNOTATION_SCHEMA_VERSION == "1.0"; BlockMode::Standard
-//          reachable on Entry.mode; one AnnotationError variant
-//          matches!-pattern.
+// T-004a: annotation_schema_version_constant_equals_1_0
+// FR-002: ANNOTATION_SCHEMA_VERSION pub const equals "1.0".
 #[test]
-fn pub_items_compile_with_canonical_constant_and_block_mode_variant() {
+fn annotation_schema_version_constant_equals_1_0() {
     assert_eq!(
         ANNOTATION_SCHEMA_VERSION, "1.0",
-        "FR-002: ANNOTATION_SCHEMA_VERSION must equal \"1.0\"; got: {ANNOTATION_SCHEMA_VERSION:?}"
+        "FR-002: ANNOTATION_SCHEMA_VERSION must equal \"1.0\""
     );
+}
 
+// T-004b: entry_mode_is_reachable_as_block_mode_standard
+// FR-006: BlockMode::Standard is reachable as the sole Phase 1
+//         authoring strategy variant via `matches!`.
+#[test]
+fn entry_mode_is_reachable_as_block_mode_standard() {
     let session = make_session(ANNOTATION_SCHEMA_VERSION);
-
-    assert_eq!(
-        session.provenance.schema_version, ANNOTATION_SCHEMA_VERSION,
-        "Provenance built from ANNOTATION_SCHEMA_VERSION must round-trip the constant value"
-    );
-    assert_eq!(
-        session.entries.len(),
-        1,
-        "make_session must produce exactly one entry for the FR-006 reachability check"
-    );
     assert!(
         matches!(session.entries[0].mode, BlockMode::Standard),
         "FR-006: Entry.mode must be reachable as BlockMode::Standard; \
          got: {:?}",
         session.entries[0].mode
     );
+}
 
+// T-004c: annotation_error_empty_session_variant_is_reachable
+// FR-001: AnnotationError pub-exports the EmptySession variant
+//         reachable via `matches!`.
+#[test]
+fn annotation_error_empty_session_variant_is_reachable() {
     let err: AnnotationError = AnnotationError::EmptySession;
     assert!(
         matches!(err, AnnotationError::EmptySession),


### PR DESCRIPTION
## 概要

Issue #53 Phase 1 sub-PR-A — `eval::annotation` モジュール foundation + ADR-0004 (Status: proposed)。後続 sub-PR-B (`annotate` subcommand) / sub-PR-C (`annotation-stats` / `annotation-export`) は #61 / #62 の land 後に follow-up で着手。

| 項目 | 内容 |
| ---- | ---- |
| 新規 pub items | `Session` / `Entry` / `BlockMode` / `Provenance` / `AnnotationError` / `ANNOTATION_SCHEMA_VERSION` |
| 新規 ADR | `docs/decisions/0004-annotation-framework.md` (Status: proposed) |
| Phase 1 意図欠落 field | `model_id`, `mlx_rs_version` (Phase 1.5 Collaborative mode で追加 → 1.0 → 1.1 bump) |
| 既存 fixture への破壊的変更 | なし (168 queries.jsonl rename 回避 — module path で命名衝突解消) |

## 決定要因 (ADR-0004)

- charter clarity: authoring tool が ADR で説明可能、charter creep 防止
- provenance discipline: queries.jsonl 拡張に session-level provenance を attach する型基盤を public API として提供
- envelope discipline: `ANNOTATION_SCHEMA_VERSION` mismatch を runtime で typed error として検出
- naming collision avoidance: 既存 `EvalQuery.annotation: String` field と module path namespacing で共存 (T-001 readability test で実証)

## Issue #53 description との関係

Issue 本文は AIANO (arXiv:2602.04579) 前提で書かれているが、本 sub-PR-A の ADR-0004 Decision Drivers は **AIANO / arXiv:2602.04579 / ADR-0021 を引用しない** 設計に意図的に変更 (NFR-004)。理由:

- arXiv:2602.04579 は 2026-02-04 公開、本 PR 起草時点の verifiability path が立たず post-cutoff
- ADR-0021 は amici に存在しない参照
- amici-internal precedent (`oracle_pipeline.rs`、ADR-0001/0002/0003、`BaselineSnapshot` envelope) のみで rationale を独立構築

Issue 本文の「Phase 1 受け入れ基準」のうち本 sub-PR-A は型 foundation + ADR のみを land。`annotate` / `annotation-stats` / `annotation-export` subcommand は sub-PR-B / sub-PR-C で。

## テスト計画

| Test | FR | 種別 |
| ---- | -- | ---- |
| `eval_query_annotation_and_entry_annotation_note_coexist` (T-001) | FR-005 | unit |
| `session_round_trips_through_serde_json` (T-002) | FR-003 | unit |
| `validate_schema_version_rejects_mismatched_label` (T-003) | FR-V001 | unit |
| `annotation_schema_version_constant_equals_1_0` (T-004a) | FR-002 | unit |
| `entry_mode_is_reachable_as_block_mode_standard` (T-004b) | FR-006 | unit |
| `annotation_error_empty_session_variant_is_reachable` (T-004c) | FR-001 | unit |

- [x] `cargo build --workspace --features eval-harness` exit 0
- [x] `cargo test --workspace --features eval-harness --lib` 182 passed
- [x] `cargo clippy --features eval-harness -p amici --lib --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo doc --no-deps -p amici --features eval-harness` で 6 pub items rendered (`constant.ANNOTATION_SCHEMA_VERSION.html` / `enum.AnnotationError.html` / `enum.BlockMode.html` / `struct.Entry.html` / `struct.Provenance.html` / `struct.Session.html`)

## スコープ外 (sub-PR-B / PR-C 以降)

- `annotate` / `annotation-stats` / `annotation-export` subcommand 本体
- `Highlight` / `Collaborative` mode 実装 (Phase 1.5+、`ANNOTATION_SCHEMA_VERSION` bump 伴う)
- `EvalQuery.annotation` field rename + queries.jsonl migration (ADR-0004 §Considered Options Option 3 で reject)
- `BaselineSnapshot` mirror + `BaselineKind::Annotation` variant (ADR-0004 §Considered Options Option 2 で reject)
- 新規 external deps (`clap` / `dialoguer` / `strsim`) 追加
- bias monitoring / NASA-TLX / IRR (Phase 2 範疇)
- `RelevanceGrade` newtype validation (CodeRabbit 提案、follow-up で T-NNN 起こして対応)

## レビュー履歴

`/think` (codebase exploration + DA + 3 envelope options 比較) → spec.md / sow.md 起草 → reviewer-spec NotReady → P0/P1/P2 fix → self-confirm Ready → `/code` で TDD RGRC + reviewer-readability (P2 × 2 fix) + evaluator-test (1.00/0.00/0.00/0.75/1.00) → `/polish` (simplify-readability 3 fix + Codex P2 fix + enhancer-code 2 cleanup)。CodeRabbit major (RelevanceGrade newtype) は /polish triage rule で skip、follow-up に記録。

## 参考

- Issue #53 (本 PR の deliverable Phase 1 sub-PR-A)
- ADR-0001 (amici extraction)
- ADR-0002 (eval governance methodology, BaselineSnapshot envelope precedent)
- ADR-0003 (Status: proposed precedent, Issue #61 / #62 dependency chain)
- Issue #61 (`Hit@1` / `Hit@3` metrics — sub-PR-B blocking)
- Issue #62 (first-search replay subcommand — sub-PR-C blocking)