### PR TITLE
feat(eval): Hit@1 / Hit@3 メトリクスを追加 (Issue #61)

### DIFF
--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -38,7 +38,9 @@ use amici::eval::baseline::{
 use amici::eval::fixture::{
     EvalDocument, EvalQuery, load_documents, load_known_answers, load_queries,
 };
-use amici::eval::metrics::{MetricResult, bootstrap_ci, mrr_at_k, ndcg_at_k, recall_at_k};
+use amici::eval::metrics::{
+    MetricResult, bootstrap_ci, hit_at_k, mrr_at_k, ndcg_at_k, recall_at_k,
+};
 use amici::eval::oracle_gap::{compute_gap, format_markdown};
 use amici::eval::oracle_pipeline::{OracleError, evaluate_oracle};
 use amici::eval::pipeline::{PipelineConfig, PipelineError, QueryResult, evaluate as run_pipeline};
@@ -423,11 +425,15 @@ fn parse_normalization_from_kvs(
 /// Anchors the contract that misspelled metric names cannot silently slip
 /// past the tolerance gate: `build_global_metrics` iterates `MetricSpec::ALL`,
 /// the JSON `name` field is derived from [`MetricSpec::name`], and
-/// `verify-baseline` resolves the committed name back through
-/// [`MetricSpec::from_name`] to look up its tolerance. Per-metric tolerance
-/// bounds (FR-017) come from [`MetricSpec::tolerance`].
+/// `verify-baseline` iterates the same `ALL` slice — comparing each spec's
+/// committed point estimate against the current run — so a stale baseline
+/// missing newer metrics is rejected as a regeneration prompt rather than
+/// silently skipping the gate. Per-metric tolerance bounds (FR-017) come
+/// from [`MetricSpec::tolerance`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MetricSpec {
+    HitAt1,
+    HitAt3,
     RecallAt5,
     RecallAt10,
     MrrAt10,
@@ -435,9 +441,11 @@ enum MetricSpec {
 }
 
 impl MetricSpec {
-    /// All specs in canonical emission order. `BaselineSnapshot.global` is
-    /// produced by mapping over this slice.
+    /// All specs in canonical emission order (ADR-0003 importance order).
+    /// `BaselineSnapshot.global` is produced by mapping over this slice.
     const ALL: &'static [Self] = &[
+        Self::HitAt1,
+        Self::HitAt3,
         Self::RecallAt5,
         Self::RecallAt10,
         Self::MrrAt10,
@@ -447,6 +455,8 @@ impl MetricSpec {
     /// JSON-serialised metric label as it appears in `MetricResult.name`.
     const fn name(self) -> &'static str {
         match self {
+            Self::HitAt1 => "hit@1",
+            Self::HitAt3 => "hit@3",
             Self::RecallAt5 => "recall@5",
             Self::RecallAt10 => "recall@10",
             Self::MrrAt10 => "mrr@10",
@@ -456,6 +466,8 @@ impl MetricSpec {
 
     const fn k(self) -> usize {
         match self {
+            Self::HitAt1 => 1,
+            Self::HitAt3 => 3,
             Self::RecallAt5 => 5,
             Self::RecallAt10 | Self::MrrAt10 | Self::NdcgAt10 => 10,
         }
@@ -463,6 +475,7 @@ impl MetricSpec {
 
     fn metric_fn(self) -> MetricFn {
         match self {
+            Self::HitAt1 | Self::HitAt3 => hit_at_k,
             Self::RecallAt5 | Self::RecallAt10 => recall_at_k,
             Self::MrrAt10 => mrr_at_k,
             Self::NdcgAt10 => ndcg_at_k,
@@ -471,23 +484,25 @@ impl MetricSpec {
 
     /// Per-metric drift tolerance for `verify-baseline` (FR-017).
     ///
-    /// Cross-process MLX reranker forward exhibits f32 non-determinism that
-    /// propagates to score-sensitive metrics. Embedder forward is bit-identical
-    /// (proven by `mlx_smoke verify-fixture`); the bound below absorbs the
-    /// reranker-side noise. See ADR 0003 § Reproducibility.
-    ///
-    /// Bounds set to ≥ 2× empirically observed max drift (N=10 + historical
-    /// session max), keeping >1% regression detectable while accepting
-    /// non-determinism inherent to Apple Silicon Metal f32 ops.
+    /// Bounds absorb cross-process MLX reranker f32 non-determinism on
+    /// Apple Silicon Metal. Set to ≥ 2× empirically observed max drift
+    /// (N=10 + historical session max), with floor `1e-3`. `HitAt1` /
+    /// `HitAt3` floor applies because the current fixture's `mrr@10 = 1.0`
+    /// ceiling pins both metrics at 1.0; recalibrate once the ceiling
+    /// lifts. See ADR-0003 § Reproducibility.
     const fn tolerance(self) -> f64 {
         match self {
+            Self::HitAt1 | Self::HitAt3 => 1e-3,
             Self::RecallAt5 => 1e-2,
             Self::RecallAt10 | Self::MrrAt10 | Self::NdcgAt10 => 1e-3,
         }
     }
 
-    /// Inverse of [`name()`]; returns `None` for unknown labels (e.g. a
-    /// committed baseline produced by an older harness version).
+    /// Inverse of [`Self::name`]; returns `None` for unknown labels.
+    /// Test-only — `verify-baseline` iterates `MetricSpec::ALL` directly
+    /// to defeat stale-baseline blind spots, so production code does not
+    /// need `from_name`.
+    #[cfg(test)]
     fn from_name(name: &str) -> Option<Self> {
         Self::ALL.iter().copied().find(|s| s.name() == name)
     }
@@ -1079,34 +1094,43 @@ fn run_verify_baseline_with<E: Embed, R: Rerank>(
         }
     };
     let current_global = build_global_metrics(&results, &queries);
-    let by_name: HashMap<&str, &MetricResult> = current_global
+    let by_name_current: HashMap<&str, &MetricResult> = current_global
+        .iter()
+        .map(|m| (m.name.as_str(), m))
+        .collect();
+    let by_name_committed: HashMap<&str, &MetricResult> = committed
+        .global
         .iter()
         .map(|m| (m.name.as_str(), m))
         .collect();
 
-    for committed_m in &committed.global {
-        let Some(current_m) = by_name.get(committed_m.name.as_str()) else {
+    // Iterate `MetricSpec::ALL` (the current harness contract) so a stale
+    // baseline that pre-dates a metric addition cannot silently skip the
+    // newly added gate. Every known spec must be present in both committed
+    // and current runs; missing committed entry signals a stale snapshot
+    // and is rejected as a regeneration prompt.
+    for spec in MetricSpec::ALL {
+        let name = spec.name();
+        let Some(current_m) = by_name_current.get(name) else {
             eprintln!(
-                "verify-baseline: failed — committed metric {} missing in current run",
-                committed_m.name
-            );
-            return ExitCode::from(EXIT_REGRESSION);
-        };
-        let Some(spec) = MetricSpec::from_name(&committed_m.name) else {
-            eprintln!(
-                "verify-baseline: failed — committed metric name {:?} is not a known MetricSpec; \
-                 baseline.json may have been produced by a newer harness version",
-                committed_m.name
+                "verify-baseline: failed — current metric {name} missing from harness output"
             );
             return ExitCode::from(EXIT_INFRA);
+        };
+        let Some(committed_m) = by_name_committed.get(name) else {
+            eprintln!(
+                "verify-baseline: failed — committed baseline lacks {name}; \
+                 regenerate via capture-baseline (likely produced by an older harness version)"
+            );
+            return ExitCode::from(EXIT_REGRESSION);
         };
         let diff = (committed_m.point_estimate - current_m.point_estimate).abs();
         let tol = spec.tolerance();
         if diff > tol {
             eprintln!(
-                "verify-baseline: failed — {} drifted by {diff:.6} > {tol:.6} \
+                "verify-baseline: failed — {name} drifted by {diff:.6} > {tol:.6} \
                  (committed {:.6} vs current {:.6})",
-                committed_m.name, committed_m.point_estimate, current_m.point_estimate
+                committed_m.point_estimate, current_m.point_estimate
             );
             return ExitCode::from(EXIT_REGRESSION);
         }
@@ -1655,5 +1679,67 @@ mod tests {
         // others stay at default
         assert!((parsed.rrf_k - 60.0).abs() < f64::EPSILON);
         assert!((parsed.source_weights[&CandidateSource::Vector] - 1.0).abs() < f64::EPSILON);
+    }
+
+    // T-061-010: `MetricSpec::ALL` leads with HitAt1 / HitAt3.
+    #[test]
+    fn metric_spec_all_starts_with_hit_variants_in_order() {
+        assert_eq!(
+            MetricSpec::ALL[0],
+            MetricSpec::HitAt1,
+            "MetricSpec::ALL[0] must be HitAt1 so baseline.json global[0] is hit@1"
+        );
+        assert_eq!(
+            MetricSpec::ALL[1],
+            MetricSpec::HitAt3,
+            "MetricSpec::ALL[1] must be HitAt3 so baseline.json global[1] is hit@3"
+        );
+    }
+
+    // T-061-011: HitAt{1,3}.k() returns the cutoff encoded in the variant name.
+    #[test]
+    fn metric_spec_hit_variants_report_correct_k() {
+        assert_eq!(
+            MetricSpec::HitAt1.k(),
+            1,
+            "HitAt1.k() must be 1 to dispatch hit_at_k against the top-1 window"
+        );
+        assert_eq!(
+            MetricSpec::HitAt3.k(),
+            3,
+            "HitAt3.k() must be 3 to dispatch hit_at_k against the top-3 window"
+        );
+    }
+
+    // T-061-012: from_name("hit@{1,3}") resolves to HitAt{1,3}.
+    #[test]
+    fn metric_spec_from_name_resolves_hit_labels() {
+        assert_eq!(
+            MetricSpec::from_name("hit@1"),
+            Some(MetricSpec::HitAt1),
+            "from_name(\"hit@1\") must resolve to HitAt1 so verify-baseline can look up tolerance"
+        );
+        assert_eq!(
+            MetricSpec::from_name("hit@3"),
+            Some(MetricSpec::HitAt3),
+            "from_name(\"hit@3\") must resolve to HitAt3 so verify-baseline can look up tolerance"
+        );
+    }
+
+    // T-061-013: HitAt1.metric_fn() dispatches to hit_at_k.
+    //
+    // Grade-0 input is the discriminator: hit_at_k returns 0.0, while a wrong
+    // dispatch to recall_at_k would also return 0.0 only by coincidence (empty
+    // relevance set), so this case anchors the dispatch contract specifically.
+    #[test]
+    fn metric_spec_hit1_metric_fn_dispatches_to_hit_at_k() {
+        let ranked: &[&str] = &["d1"];
+        let relevance: HashMap<String, u8> = HashMap::from([("d1".to_owned(), 0u8)]);
+        let dispatch = MetricSpec::HitAt1.metric_fn();
+        let result = dispatch(ranked, &relevance, 1);
+        assert!(
+            result.abs() < f64::EPSILON,
+            "HitAt1.metric_fn() on grade-0 input must yield 0.0; got {result}"
+        );
     }
 }

--- a/src/eval/metrics.rs
+++ b/src/eval/metrics.rs
@@ -103,6 +103,22 @@ pub fn ndcg_at_k(ranked: &[&str], relevance: &HashMap<String, u8>, k: usize) -> 
     if idcg == 0.0 { 0.0 } else { dcg / idcg }
 }
 
+/// Hit@k with binary relevance threshold rel ≥ 1.
+///
+/// Returns `1.0` when at least one document id in the top-k window of
+/// `ranked` has a relevance grade `≥ 1`, otherwise `0.0`. Hit@k is binary
+/// at the per-query level; see ADR-0003 for the agentic-search sensitivity
+/// rationale that motivates it.
+#[must_use]
+pub fn hit_at_k(ranked: &[&str], relevance: &HashMap<String, u8>, k: usize) -> f64 {
+    for id in ranked.iter().take(k) {
+        if relevance.get(*id).is_some_and(|&g| g >= 1) {
+            return 1.0;
+        }
+    }
+    0.0
+}
+
 /// Bootstrap 95% CI for an arbitrary metric.
 ///
 /// Returns `(point_estimate, ci_lower, ci_upper)`. The point estimate is
@@ -285,6 +301,120 @@ mod tests {
             (upper_a - upper_b).abs() < f64::EPSILON,
             "FR-004 / NFR-002: ci_upper must be bit-identical across runs with seed=42 \
              (got {upper_a} vs {upper_b})"
+        );
+    }
+
+    // T-061-001: hit_at_k_top_1_relevant_returns_one
+    // Hit@k: ranked = ["d1", "d2"], relevance = {"d1": 1}, k = 1 → 1.0
+    // Perspective: Equivalence (relevant doc inside top-k window).
+    #[test]
+    fn hit_at_k_top_1_relevant_returns_one() {
+        let ranked = ranked(&["d1", "d2"]);
+        let rel = relevance(&[("d1", 1)]);
+
+        let result = hit_at_k(&ranked, &rel, 1);
+
+        assert!(
+            (result - 1.0).abs() < f64::EPSILON,
+            "relevant doc at rank 1 within k=1 → Hit@k must be 1.0, got: {result}"
+        );
+    }
+
+    // T-061-002: hit_at_k_relevant_at_rank_two_within_k_returns_one
+    // Hit@k: ranked = ["d2", "d1"], relevance = {"d1": 1}, k = 2 → 1.0
+    // Perspective: Boundary (relevant doc at the last position inside k).
+    #[test]
+    fn hit_at_k_relevant_at_rank_two_within_k_returns_one() {
+        let ranked = ranked(&["d2", "d1"]);
+        let rel = relevance(&[("d1", 1)]);
+
+        let result = hit_at_k(&ranked, &rel, 2);
+
+        assert!(
+            (result - 1.0).abs() < f64::EPSILON,
+            "relevant doc at rank 2 within k=2 → Hit@k must be 1.0, got: {result}"
+        );
+    }
+
+    // T-061-003: hit_at_k_empty_ranked_returns_zero
+    // Hit@k: ranked = [], relevance = {"d1": 1}, k = 5 → 0.0 (no panic)
+    // Perspective: Boundary / Error (empty ranked slice must not panic).
+    #[test]
+    fn hit_at_k_empty_ranked_returns_zero() {
+        let ranked: Vec<&str> = ranked(&[]);
+        let rel = relevance(&[("d1", 1)]);
+
+        let result = hit_at_k(&ranked, &rel, 5);
+
+        assert!(
+            result.abs() < f64::EPSILON,
+            "empty ranked slice → Hit@k must be 0.0, got: {result}"
+        );
+    }
+
+    // T-061-004: hit_at_k_no_relevant_in_top_k_returns_zero
+    // Hit@k: ranked = ["d2", "d3"], relevance = {"d1": 1}, k = 2 → 0.0
+    // Perspective: Branch (top-k disjoint from relevant set).
+    #[test]
+    fn hit_at_k_no_relevant_in_top_k_returns_zero() {
+        let ranked = ranked(&["d2", "d3"]);
+        let rel = relevance(&[("d1", 1)]);
+
+        let result = hit_at_k(&ranked, &rel, 2);
+
+        assert!(
+            result.abs() < f64::EPSILON,
+            "top-k window disjoint from relevant set → Hit@k must be 0.0, got: {result}"
+        );
+    }
+
+    // T-061-005: hit_at_k_k_greater_than_n_returns_one
+    // Hit@k: ranked = ["d1"], relevance = {"d1": 1}, k = 10 → 1.0 (no panic)
+    // Perspective: Boundary (k > N must clamp to ranked.len() without panic).
+    #[test]
+    fn hit_at_k_k_greater_than_n_returns_one() {
+        let ranked = ranked(&["d1"]);
+        let rel = relevance(&[("d1", 1)]);
+
+        let result = hit_at_k(&ranked, &rel, 10);
+
+        assert!(
+            (result - 1.0).abs() < f64::EPSILON,
+            "k=10 exceeds ranked.len()=1 but relevant doc present → Hit@k must be 1.0, got: {result}"
+        );
+    }
+
+    // T-061-006: hit_at_k_grade_zero_treated_as_irrelevant_returns_zero
+    // Hit@k: ranked = ["d1"], relevance = {"d1": 0}, k = 1 → 0.0
+    // Perspective: Boundary / Condition (grade < 1 must not count as a hit;
+    // mirrors the rel ≥ 1 threshold used by recall_at_k / mrr_at_k).
+    #[test]
+    fn hit_at_k_grade_zero_treated_as_irrelevant_returns_zero() {
+        let ranked = ranked(&["d1"]);
+        let rel = relevance(&[("d1", 0)]);
+
+        let result = hit_at_k(&ranked, &rel, 1);
+
+        assert!(
+            result.abs() < f64::EPSILON,
+            "grade 0 is below the rel ≥ 1 threshold → Hit@k must be 0.0, got: {result}"
+        );
+    }
+
+    // T-061-007: hit_at_k_grade_three_counts_as_hit_returns_one
+    // Hit@k: ranked = ["d1"], relevance = {"d1": 3}, k = 1 → 1.0
+    // Perspective: Boundary / Condition (highest graded relevance still
+    // satisfies the binary rel ≥ 1 threshold).
+    #[test]
+    fn hit_at_k_grade_three_counts_as_hit_returns_one() {
+        let ranked = ranked(&["d1"]);
+        let rel = relevance(&[("d1", 3)]);
+
+        let result = hit_at_k(&ranked, &rel, 1);
+
+        assert!(
+            (result - 1.0).abs() < f64::EPSILON,
+            "grade 3 satisfies rel ≥ 1 → Hit@k must be 1.0, got: {result}"
         );
     }
 }

--- a/tests/fixtures/eval/baseline.json
+++ b/tests/fixtures/eval/baseline.json
@@ -2,7 +2,7 @@
   "schema_version": "1.2",
   "kind": "forward",
   "captured_with": "eval_harness capture-baseline",
-  "timestamp": "epoch:1777265610",
+  "timestamp": "epoch:1778271132",
   "model_id": "cl-nagoya/ruri-v3-310m",
   "model_revision": "pinned-via-rurico-embed-cache",
   "mlx_rs_version": "0.25",
@@ -21,6 +21,22 @@
     "collapse_whitespace": true
   },
   "global": [
+    {
+      "name": "hit@1",
+      "k": 1,
+      "point_estimate": 1.0,
+      "ci_lower": 1.0,
+      "ci_upper": 1.0,
+      "uninformative": false
+    },
+    {
+      "name": "hit@3",
+      "k": 3,
+      "point_estimate": 1.0,
+      "ci_lower": 1.0,
+      "ci_upper": 1.0,
+      "uninformative": false
+    },
     {
       "name": "recall@5",
       "k": 5,
@@ -48,14 +64,30 @@
     {
       "name": "ndcg@10",
       "k": 10,
-      "point_estimate": 0.8929930705316574,
-      "ci_lower": 0.8761522102123755,
-      "ci_upper": 0.9062809356005043,
+      "point_estimate": 0.8928607038824461,
+      "ci_lower": 0.8760706740195523,
+      "ci_upper": 0.9061898299921332,
       "uninformative": false
     }
   ],
   "per_category": {
     "comparative": [
+      {
+        "name": "hit@1",
+        "k": 1,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "hit@3",
+        "k": 3,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
       {
         "name": "recall@5",
         "k": 5,
@@ -83,13 +115,29 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.8983317922434706,
-        "ci_lower": 0.8563901996271307,
-        "ci_upper": 0.9325460147776281,
+        "point_estimate": 0.8984764101286741,
+        "ci_lower": 0.8566214344863141,
+        "ci_upper": 0.9326326317516082,
         "uninformative": false
       }
     ],
     "conceptual": [
+      {
+        "name": "hit@1",
+        "k": 1,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "hit@3",
+        "k": 3,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
       {
         "name": "recall@5",
         "k": 5,
@@ -125,6 +173,22 @@
     ],
     "definitional": [
       {
+        "name": "hit@1",
+        "k": 1,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "hit@3",
+        "k": 3,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
         "name": "recall@5",
         "k": 5,
         "point_estimate": 0.5801587301587302,
@@ -151,13 +215,29 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.8884103087687821,
-        "ci_lower": 0.8511654643804011,
-        "ci_upper": 0.9240010568777395,
+        "point_estimate": 0.888622743495643,
+        "ci_lower": 0.8513983569293486,
+        "ci_upper": 0.9244259263314611,
         "uninformative": false
       }
     ],
     "factoid": [
+      {
+        "name": "hit@1",
+        "k": 1,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "hit@3",
+        "k": 3,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
       {
         "name": "recall@5",
         "k": 5,
@@ -185,13 +265,29 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.9185756327347544,
-        "ci_lower": 0.8939517700954362,
-        "ci_upper": 0.941254666473713,
+        "point_estimate": 0.9184890157607745,
+        "ci_lower": 0.8938651531214562,
+        "ci_upper": 0.9411464664154108,
         "uninformative": false
       }
     ],
     "howto": [
+      {
+        "name": "hit@1",
+        "k": 1,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "hit@3",
+        "k": 3,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
       {
         "name": "recall@5",
         "k": 5,
@@ -219,13 +315,29 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.8508233540703584,
-        "ci_lower": 0.7646722904276082,
-        "ci_upper": 0.9174426666621226,
+        "point_estimate": 0.8512482235240798,
+        "ci_lower": 0.7654535080777085,
+        "ci_upper": 0.9174612382258907,
         "uninformative": false
       }
     ],
     "listing": [
+      {
+        "name": "hit@1",
+        "k": 1,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "hit@3",
+        "k": 3,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
       {
         "name": "recall@5",
         "k": 5,
@@ -253,13 +365,29 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.8744565124001691,
-        "ci_lower": 0.8442136605507112,
-        "ci_upper": 0.9032185061447183,
+        "point_estimate": 0.8751847344116845,
+        "ci_lower": 0.8449418825622268,
+        "ci_upper": 0.9039817945359538,
         "uninformative": false
       }
     ],
     "troubleshooting": [
+      {
+        "name": "hit@1",
+        "k": 1,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "hit@3",
+        "k": 3,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
       {
         "name": "recall@5",
         "k": 5,
@@ -287,13 +415,29 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.906720822112825,
-        "ci_lower": 0.8718830780638507,
-        "ci_upper": 0.939301680065366,
+        "point_estimate": 0.9042383618158111,
+        "ci_lower": 0.8691657670447677,
+        "ci_upper": 0.9372754866066317,
         "uninformative": false
       }
     ],
     "variant_notation": [
+      {
+        "name": "hit@1",
+        "k": 1,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "hit@3",
+        "k": 3,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
       {
         "name": "recall@5",
         "k": 5,
@@ -328,6 +472,6 @@
       }
     ]
   },
-  "latency_p50_ms": 516.0,
-  "latency_p95_ms": 650.0
+  "latency_p50_ms": 1593.0,
+  "latency_p95_ms": 1956.0
 }

--- a/tests/fixtures/eval/oracle_baseline.json
+++ b/tests/fixtures/eval/oracle_baseline.json
@@ -2,7 +2,7 @@
   "schema_version": "1.2",
   "kind": "oracle",
   "captured_with": "eval_harness capture-oracle",
-  "timestamp": "epoch:1778206324",
+  "timestamp": "epoch:1778271389",
   "model_id": "cl-nagoya/ruri-v3-310m",
   "model_revision": "pinned-via-rurico-embed-cache",
   "mlx_rs_version": "0.25",
@@ -11,8 +11,8 @@
   "merge_config": {
     "rrf_k": 60.0,
     "source_weights": {
-      "vector": 1.0,
-      "fts": 1.0
+      "fts": 1.0,
+      "vector": 1.0
     }
   },
   "normalization": {
@@ -22,11 +22,27 @@
   },
   "global": [
     {
+      "name": "hit@1",
+      "k": 1,
+      "point_estimate": 1.0,
+      "ci_lower": 1.0,
+      "ci_upper": 1.0,
+      "uninformative": false
+    },
+    {
+      "name": "hit@3",
+      "k": 3,
+      "point_estimate": 1.0,
+      "ci_lower": 1.0,
+      "ci_upper": 1.0,
+      "uninformative": false
+    },
+    {
       "name": "recall@5",
       "k": 5,
-      "point_estimate": 0.7200396825396826,
-      "ci_lower": 0.6905753968253968,
-      "ci_upper": 0.7512896825396826,
+      "point_estimate": 0.7185515873015874,
+      "ci_lower": 0.6878968253968254,
+      "ci_upper": 0.7495039682539681,
       "uninformative": false
     },
     {
@@ -48,14 +64,30 @@
     {
       "name": "ndcg@10",
       "k": 10,
-      "point_estimate": 0.947417468881108,
-      "ci_lower": 0.9380144950499698,
-      "ci_upper": 0.9555539325334218,
+      "point_estimate": 0.9475268057575891,
+      "ci_lower": 0.9377598165614695,
+      "ci_upper": 0.9555558053772821,
       "uninformative": false
     }
   ],
   "per_category": {
     "comparative": [
+      {
+        "name": "hit@1",
+        "k": 1,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "hit@3",
+        "k": 3,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
       {
         "name": "recall@5",
         "k": 5,
@@ -83,13 +115,29 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.9570131387426085,
-        "ci_lower": 0.9391914260511297,
-        "ci_upper": 0.9739230629079416,
+        "point_estimate": 0.9569265217686284,
+        "ci_lower": 0.9391914260511298,
+        "ci_upper": 0.9736789700043081,
         "uninformative": false
       }
     ],
     "conceptual": [
+      {
+        "name": "hit@1",
+        "k": 1,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "hit@3",
+        "k": 3,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
       {
         "name": "recall@5",
         "k": 5,
@@ -117,19 +165,35 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.9506746255042603,
-        "ci_lower": 0.9344869648048872,
+        "point_estimate": 0.9505880085302805,
+        "ci_lower": 0.9343798876650027,
         "ci_upper": 0.9662463831054537,
         "uninformative": false
       }
     ],
     "definitional": [
       {
+        "name": "hit@1",
+        "k": 1,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "hit@3",
+        "k": 3,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
         "name": "recall@5",
         "k": 5,
-        "point_estimate": 0.676984126984127,
-        "ci_lower": 0.611111111111111,
-        "ci_upper": 0.7412698412698413,
+        "point_estimate": 0.665079365079365,
+        "ci_lower": 0.5976190476190476,
+        "ci_upper": 0.7317460317460318,
         "uninformative": false
       },
       {
@@ -151,13 +215,29 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.9387410192400452,
-        "ci_lower": 0.9173450456161811,
-        "ci_upper": 0.9577831111082179,
+        "point_estimate": 0.9385225697523962,
+        "ci_lower": 0.9168675056567677,
+        "ci_upper": 0.9578637210311838,
         "uninformative": false
       }
     ],
     "factoid": [
+      {
+        "name": "hit@1",
+        "k": 1,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "hit@3",
+        "k": 3,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
       {
         "name": "recall@5",
         "k": 5,
@@ -193,6 +273,22 @@
     ],
     "howto": [
       {
+        "name": "hit@1",
+        "k": 1,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "hit@3",
+        "k": 3,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
         "name": "recall@5",
         "k": 5,
         "point_estimate": 0.7031746031746032,
@@ -219,13 +315,29 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.9222885339993571,
-        "ci_lower": 0.8736695192831133,
-        "ci_upper": 0.9633591107584204,
+        "point_estimate": 0.9222622532390031,
+        "ci_lower": 0.8735235642004637,
+        "ci_upper": 0.9631790103705432,
         "uninformative": false
       }
     ],
     "listing": [
+      {
+        "name": "hit@1",
+        "k": 1,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "hit@3",
+        "k": 3,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
       {
         "name": "recall@5",
         "k": 5,
@@ -253,13 +365,29 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.9341278252974499,
-        "ci_lower": 0.9163042519379759,
-        "ci_upper": 0.9530551796723765,
+        "point_estimate": 0.932948166458314,
+        "ci_lower": 0.9150871653619601,
+        "ci_upper": 0.9518346130876413,
         "uninformative": false
       }
     ],
     "troubleshooting": [
+      {
+        "name": "hit@1",
+        "k": 1,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "hit@3",
+        "k": 3,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
       {
         "name": "recall@5",
         "k": 5,
@@ -287,13 +415,29 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.951523402963173,
-        "ci_lower": 0.9339699548631354,
-        "ci_upper": 0.9676853451726773,
+        "point_estimate": 0.9514431171772477,
+        "ci_lower": 0.9338896690772103,
+        "ci_upper": 0.9676585548569386,
         "uninformative": false
       }
     ],
     "variant_notation": [
+      {
+        "name": "hit@1",
+        "k": 1,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
+      {
+        "name": "hit@3",
+        "k": 3,
+        "point_estimate": 1.0,
+        "ci_lower": 1.0,
+        "ci_upper": 1.0,
+        "uninformative": false
+      },
       {
         "name": "recall@5",
         "k": 5,
@@ -321,13 +465,13 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.9647930385350004,
-        "ci_lower": 0.9477577061247511,
-        "ci_upper": 0.9802541392294131,
+        "point_estimate": 0.9673456423678749,
+        "ci_lower": 0.949941847757764,
+        "ci_upper": 0.9813843255296133,
         "uninformative": false
       }
     ]
   },
-  "latency_p50_ms": 2083.0,
-  "latency_p95_ms": 3103.0
+  "latency_p50_ms": 1735.0,
+  "latency_p95_ms": 1975.0
 }


### PR DESCRIPTION
## 概要

amici crate の eval-harness に Hit@k メトリクス (Hit@1 / Hit@3) を追加し、ADR-0003 (`pgr-style first-search offline retrieval benchmark`) の deliverable Issue #61 を land。downstream (yomu#163 / sae#107) の definitions-first / src-tier ranking 効果測定を可能にする。

Closes #61。

## 決定要因

| 要因 | 採用 | 根拠 |
|------|------|------|
| `hit_at_k` 関数 配置 | `src/eval/metrics.rs` pub fn (独立) | `mrr_at_k` と同型 early-return loop、`MetricFn` 型整合、test 独立 |
| `MetricSpec` 命名 | `HitAt1` / `HitAt3` (`<Metric>At<K>` 規約) | 既存 `RecallAt5` / `MrrAt10` etc と consistency |
| `MetricSpec::ALL` 順序 | **先頭追加** (`[HitAt1, HitAt3, RecallAt5, ...]`) | ADR-0003 signal-importance 順、JSON 出力先頭に first-result quality を配置 |
| tolerance 値 | `1e-3` (BR-002 floor) | Phase 2 N=10 empirical measurement で drift_max = 0.0 観測 (fixture ceiling) |
| `verify-baseline` iteration | `MetricSpec::ALL` (committed.global ではなく) | stale baseline で新 metric silently skip される soundness gap を closure |
| `BASELINE_SCHEMA_VERSION` | 1.2 維持 | Issue #62 範疇、本 issue で bump せず name-based 解決で互換維持 |

## テスト計画

- `cargo test --workspace --features eval-harness --lib`: 189 PASS / 0 fail (+7 hit_at_k tests T-061-001..007)
- `cargo test --workspace --features eval-harness --bins`: 11 PASS / 0 fail (+4 MetricSpec tests T-061-010..013)
- `cargo test --workspace --features eval-harness --doc`: 18 PASS / 0 fail
- `cargo clippy --workspace --features eval-harness --all-targets -- -D warnings`: clean
- Phase 2 empirical measurement: N=10 capture-baseline / fixture `tests/fixtures/eval/` (168 query × 8 category) で hit@1 / hit@3 全 run = 1.0、drift_max = 0.0 確認
- Phase 3 verify-baseline integration: committed baseline で exit 0、`jq '.global[0].point_estimate += 0.05'` 人為改変で exit 1 + stderr に `hit@1 drifted by 0.050000 > 0.001000 ...`

## スコープ外

- `replay-first-search` subcommand (Issue #62 範疇、本 issue dependent)
- `BaselineKind::FirstSearchReplay` variant 追加 (Issue #62)
- `BASELINE_SCHEMA_VERSION` 1.2 → 1.3 bump (Issue #62)
- `per_category` Hit@k 用 `UNINFORMATIVE_HALF_WIDTH` 閾値分離 (Reassessment Trigger 後)
- downstream rev pin bump (yomu / sae / recall 各リポで対応)
- ADR-0003 を `proposed` → `accepted` promote (本 PR + #62 land 後)

## レビュー履歴

`/polish` (`/code` 完了直後) で以下を適用済:

- **Codex P2**: `verify-baseline` を `MetricSpec::ALL` iterate に refactor (stale baseline soundness)
- **REUSE-001**: `Hit1` / `Hit3` → `HitAt1` / `HitAt3` rename
- **CQ-001..005**: tolerance / ALL / hit_at_k doc trim、test header 単行 cite 化、MetricSpec leak 除去
- **enhancer-code**: T-061-013 を grade-0 input に変更で discriminator 強化
- skip 済: CodeRabbit major (latency 3x = committed vs regenerated drift で false positive) / EFF-001 (`parent_dedup_ranked` per spec、pre-existing pattern) / Gemini (gemini-2.5-pro quota exhausted)

## 重要な発見

amici fixture (`tests/fixtures/eval/queries.jsonl` 168 query) は `mrr@10 = 1.0` の特性 — 全 query で first relevant doc が rank 1 にある。Hit@k は本 fixture で **ceiling = 1.0** に張り付き、empirical drift_max = 0.0。本 fixture 自体での Hit@k regression 検出感度は限定的だが、`MetricSpec::HitAt1.tolerance() = 1e-3` constant は downstream consumer (yomu / sae の独自 ranking 改変経由の verify-baseline 呼び出し) で reference として load-bearing に機能。ADR-0003 §Reassessment Triggers 第 4 項 ("Hit@k と Recall@k 同順序") に部分的に該当、削除判断は yomu#163 / sae#107 観測委ね。

## 参考

- Issue #61: https://github.com/thkt/amici/issues/61
- ADR-0003: docs/decisions/0003-add-pgr-style-first-search-offline-retrieval-benchmark.md
- pgr 記事: https://entire.io/blog/improving-agentic-search-in-coding-agents (2026-05-06)
- Phase 2 measurement details: `.claude/workspace/planning/2026-05-09-issue-61-hit-metrics/spec.md` §Phase 2 Measurement