### PR TITLE
feat(eval): replay-first-search モードと FirstSearchReplay baseline kind 追加 (#62)

### DIFF
--- a/docs/decisions/0003-add-pgr-style-first-search-offline-retrieval-benchmark.md
+++ b/docs/decisions/0003-add-pgr-style-first-search-offline-retrieval-benchmark.md
@@ -55,7 +55,7 @@ Option 1 を採用する。
 
 1. **`Hit@k` メトリクス追加** — `src/eval/metrics.rs` に `hit_at_k()` 関数を追加。`MetricSpec` enum に `Hit1`, `Hit3` variant を追加。`MetricSpec::tolerance` に Hit@k 用の許容値を設定。Bootstrap CI (95%, n=1000, seed=42) で算出。実装は Issue #61。
 
-2. **`replay-first-search` サブコマンド追加** — `src/bin/eval_harness.rs` に新サブコマンドを追加。各 query について Stage 1 (FTS+Vec) + Stage 2 (RRF merge) のみ実行、Stage 3 (aggregation) / Stage 4 (rerank) / Stage 5 (final) は skip。出力は `QueryResult.ranked_hits[0..k]` のみ。実装は Issue #62。
+2. **`replay-first-search` サブコマンド追加** — `src/bin/eval_harness.rs` に新サブコマンドを追加。各 query について Stage 1 (FTS+Vec) + Stage 2 (RRF merge) を実行し、Stage 3 minimum として `MaxChunkAggregator` を適用 (parent-level rollup)、ranking-aware aggregator (`IdentityAggregator` 等) と Stage 4 (rerank) / Stage 5 (final) は skip。chunk-level retrieval 下では Stage 1+2 の出力が `(doc_id, chunk_id)` granularity で混在するため、parent rollup 無しで top-k を切ると Hit@3 が実質「同一 parent の異 chunk 3 件」を返し pgr 記事の "top-k unique docs に relevant が含まれるか" 意味論が壊れる。replay 出力は parent-granular な `QueryResult.ranked_hits[0..k]` (全 entry で `chunk_id == None`、`doc_id` unique) で固定。実装は Issue #62。
 
 3. **Baseline schema 更新** — `BaselineKind` enum に `FirstSearchReplay` variant を追加。`BASELINE_SCHEMA_VERSION` を 1.2 → 1.3 に bump。既存の `Forward` / `Reverse` / `Oracle` baseline には影響なし。
 
@@ -65,7 +65,7 @@ Option 1 を採用する。
 
 - yomu / sae の ranking 実験が complete し、Hit@k で有意な変化 (pgr 記事の +8 pt クラス) が観測されない場合 → benchmark 設計の見直し (fixture multiplicity / first-search 定義の精度)
 - pgr 記事の手法を超えるベンチマークが業界標準化された場合 (例: fully agentic loop benchmark の reproducibility 解決) → Option 3 を再評価
-- replay モードでの実行が forward baseline 比 2-5x の高速化に届かない場合 → Stage 3-5 の skip 漏れ調査
+- replay モードでの実行が forward baseline 比 2-5x の高速化に届かない場合 → Stage 4-5 の skip 漏れ調査 (Stage 3 は MaxChunkAggregator 必須なので skip 対象は Stage 4 / Stage 5 のみ)
 - Hit@k と Recall@k / MRR@k が常に一致した順序で動く場合 → Hit@k の独立な情報量がないと判断、削除を検討
 
 ## References

--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -43,7 +43,10 @@ use amici::eval::metrics::{
 };
 use amici::eval::oracle_gap::{compute_gap, format_markdown};
 use amici::eval::oracle_pipeline::{OracleError, evaluate_oracle};
-use amici::eval::pipeline::{PipelineConfig, PipelineError, QueryResult, evaluate as run_pipeline};
+use amici::eval::pipeline::{
+    PipelineConfig, PipelineError, QueryResult, evaluate as run_pipeline,
+    evaluate_first_search_replay,
+};
 use rurico::embed::Embed;
 use rurico::reranker::Rerank;
 use rurico::retrieval::{
@@ -517,6 +520,7 @@ const MLX_DEPENDENT_MODES: &[&str] = &[
     "capture-baseline",
     "capture-reverse-baseline",
     "capture-oracle",
+    "replay-first-search",
     "verify-baseline",
 ];
 
@@ -527,7 +531,8 @@ fn main() -> ExitCode {
     let Some(mode) = args.first() else {
         eprintln!(
             "usage: eval_harness <evaluate|capture-baseline|capture-reverse-baseline|\
-             capture-oracle|oracle-gap|verify-baseline|compare-baselines> [key=value...]"
+             capture-oracle|replay-first-search|oracle-gap|verify-baseline|compare-baselines> \
+             [key=value...]"
         );
         return ExitCode::from(EXIT_USAGE);
     };
@@ -544,6 +549,7 @@ fn main() -> ExitCode {
         "capture-baseline" => run_capture_baseline(&kvs),
         "capture-reverse-baseline" => run_capture_reverse_baseline(&kvs),
         "capture-oracle" => run_capture_oracle(&kvs),
+        "replay-first-search" => run_replay_first_search(&kvs),
         "oracle-gap" => run_oracle_gap(&kvs),
         "verify-baseline" => run_verify_baseline(&kvs),
         "compare-baselines" => run_compare_baselines(&kvs),
@@ -1003,6 +1009,199 @@ fn run_capture_oracle_with<E: Embed, R: Rerank>(
     ExitCode::SUCCESS
 }
 
+/// `replay-first-search output=<path> [rrf_k=N] [fts_weight=W] [vector_weight=W]
+/// [normalization=...]` — Run Stage 1+2 + parent rollup
+/// (`MaxChunkAggregator`) only, skipping Stage 4 (rerank) and Stage 5
+/// (final). Writes a `BaselineSnapshot` with `kind=FirstSearchReplay`
+/// (Issue #62 / ADR-0003 第 2 deliverable). Records the agentic-search
+/// "first-result quality" indicator so downstream consumers can isolate
+/// ranking-strategy sensitivity from aggregator / reranker effects.
+fn run_replay_first_search(kvs: &HashMap<String, String>) -> ExitCode {
+    let Some(output_path_raw) = kvs.get("output") else {
+        eprintln!("replay-first-search: output= argument required");
+        return ExitCode::from(EXIT_USAGE);
+    };
+    let output_path = match validate_output_path(output_path_raw) {
+        Ok(p) => p,
+        Err(msg) => {
+            eprintln!("replay-first-search: {msg}");
+            return ExitCode::from(EXIT_USAGE);
+        }
+    };
+    let merge_config = match parse_merge_config_from_kvs(kvs) {
+        Ok(c) => c,
+        Err(msg) => {
+            eprintln!("replay-first-search: {msg}");
+            return ExitCode::from(EXIT_USAGE);
+        }
+    };
+    let normalization = match parse_normalization_from_kvs(kvs) {
+        Ok(c) => c,
+        Err(msg) => {
+            eprintln!("replay-first-search: {msg}");
+            return ExitCode::from(EXIT_USAGE);
+        }
+    };
+    let ctx = match production_context() {
+        Ok(c) => c,
+        Err(msg) => {
+            eprintln!("replay-first-search: {msg}");
+            return ExitCode::from(EXIT_INFRA);
+        }
+    };
+    log_run_context(&ctx, "replay-first-search", None, Some(&output_path));
+    run_replay_first_search_with(&ctx, &output_path, &merge_config, &normalization)
+}
+
+fn run_replay_first_search_with<E: Embed, R: Rerank>(
+    ctx: &EvalContext<E, R>,
+    output_path: &Path,
+    merge_config: &HybridSearchConfig,
+    normalization: &QueryNormalizationConfig,
+) -> ExitCode {
+    let (corpus, queries) = match load_fixture_for_kind(&ctx.fixture_dir, "full") {
+        Ok(v) => v,
+        Err(msg) => {
+            eprintln!("replay-first-search: {msg}");
+            return ExitCode::from(EXIT_INFRA);
+        }
+    };
+    let fixture_hash = match hash_fixture_dir(&ctx.fixture_dir) {
+        Ok(h) => h,
+        Err(msg) => {
+            eprintln!("replay-first-search: {msg}");
+            return ExitCode::from(EXIT_INFRA);
+        }
+    };
+    let config = PipelineConfig { k: PIPELINE_K };
+    let results = match evaluate_first_search_replay(
+        &corpus,
+        &queries,
+        &ctx.embedder,
+        merge_config,
+        normalization,
+        &config,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("replay-first-search: pipeline failed: {e}");
+            return ExitCode::from(EXIT_INFRA);
+        }
+    };
+
+    let snapshot = build_first_search_replay_snapshot(
+        &results,
+        &queries,
+        fixture_hash,
+        (ctx.timestamp)(),
+        merge_config,
+        normalization,
+    );
+
+    if let Err(e) = write_json(&snapshot, output_path) {
+        eprintln!("replay-first-search: write failed: {e}");
+        return ExitCode::from(EXIT_INFRA);
+    }
+    eprintln!("replay-first-search: wrote {}", output_path.display());
+    ExitCode::SUCCESS
+}
+
+/// Build a `BaselineSnapshot` with `kind=FirstSearchReplay` from
+/// pipeline `results` and run-context provenance fields. Pure builder
+/// (no IO) so the snapshot envelope is unit-testable without a real
+/// MLX-backed fixture run.
+fn build_first_search_replay_snapshot(
+    results: &[QueryResult],
+    queries: &[EvalQuery],
+    fixture_hash: String,
+    timestamp: String,
+    merge_config: &HybridSearchConfig,
+    normalization: &QueryNormalizationConfig,
+) -> BaselineSnapshot {
+    let global = build_global_metrics(results, queries);
+    let per_category = build_per_category_metrics(results, queries);
+    let (latency_p50_ms, latency_p95_ms) = compute_latency_percentiles(results);
+    BaselineSnapshot {
+        schema_version: BASELINE_SCHEMA_VERSION.to_owned(),
+        kind: BaselineKind::FirstSearchReplay,
+        captured_with: "eval_harness replay-first-search".to_owned(),
+        timestamp,
+        model_id: embed::ModelId::default().repo_id().to_owned(),
+        model_revision: RURI_V3_310M_REVISION.to_owned(),
+        mlx_rs_version: MLX_RS_VERSION.to_owned(),
+        fixture_hash,
+        // BR-003: replay runs Stage 3 = MaxChunkAggregator only — no
+        // ranking-aware aggregator is invoked, so "none" is the marker.
+        aggregation: "none".to_owned(),
+        merge_config: merge_config.clone(),
+        normalization: *normalization,
+        global,
+        per_category,
+        latency_p50_ms,
+        latency_p95_ms,
+    }
+}
+
+/// Parse a `kind=<...>` CLI argument into [`BaselineKind`].
+///
+/// Routes through serde so the wire-format mapping has a single source of
+/// truth (`#[serde(rename_all = "snake_case")]` on `BaselineKind`); a new
+/// variant gains the CLI mapping automatically without a coordinated edit.
+/// Used by `verify-baseline` to compare a user-provided expected kind
+/// against the committed baseline file's `kind` field (FR-024 / AC-7).
+fn parse_baseline_kind(s: &str) -> Result<BaselineKind, String> {
+    serde_json::from_str::<BaselineKind>(&format!("\"{s}\"")).map_err(|e| {
+        format!(
+            "unknown kind {s:?}: {e}; expected one of: forward, reverse, oracle, first_search_replay"
+        )
+    })
+}
+
+/// Validate the committed baseline envelope (schema_version + kind) before
+/// any pipeline dispatch. Centralises FR-023 (schema mismatch →
+/// `EXIT_REGRESSION`), FR-024 (kind mismatch via `kind=` argument →
+/// `EXIT_REGRESSION`), and Reverse rejection (`EXIT_INFRA`) so the checks
+/// are unit-testable independently of the MLX-loading `production_context`.
+fn validate_committed_baseline_envelope(
+    committed: &BaselineSnapshot,
+    kvs: &HashMap<String, String>,
+) -> Result<(), u8> {
+    if committed.schema_version != BASELINE_SCHEMA_VERSION {
+        eprintln!(
+            "verify-baseline: failed — committed schema_version {:?} does not match harness {:?}; \
+             regenerate via {{capture-baseline | capture-oracle | replay-first-search}} \
+             before verifying",
+            committed.schema_version, BASELINE_SCHEMA_VERSION
+        );
+        return Err(EXIT_REGRESSION);
+    }
+    if let Some(expected_kind_raw) = kvs.get("kind") {
+        let expected_kind = match parse_baseline_kind(expected_kind_raw) {
+            Ok(k) => k,
+            Err(msg) => {
+                eprintln!("verify-baseline: {msg}");
+                return Err(EXIT_USAGE);
+            }
+        };
+        if expected_kind != committed.kind {
+            eprintln!(
+                "verify-baseline: failed — committed kind {:?} does not match \
+                 expected kind {:?} (kind= argument); did you pass the wrong baseline file?",
+                committed.kind, expected_kind
+            );
+            return Err(EXIT_REGRESSION);
+        }
+    }
+    if committed.kind == BaselineKind::Reverse {
+        eprintln!(
+            "verify-baseline: failed — committed kind Reverse is not supported; \
+             reverse_baseline.json has a different body shape (use compare-baselines instead)"
+        );
+        return Err(EXIT_INFRA);
+    }
+    Ok(())
+}
+
 /// `verify-baseline baseline=<path>` — re-run evaluation, compare against the
 /// committed baseline.json under ADR 0002 tolerance, exit 0 + stderr banner
 /// `verify-baseline: passed` on success (FR-017 / AC-5.3).
@@ -1027,21 +1226,8 @@ fn run_verify_baseline(kvs: &HashMap<String, String>) -> ExitCode {
             return ExitCode::from(EXIT_INFRA);
         }
     };
-    if committed.schema_version != BASELINE_SCHEMA_VERSION {
-        eprintln!(
-            "verify-baseline: failed — committed schema_version {:?} does not match harness {:?}; \
-             regenerate the baseline before verifying",
-            committed.schema_version, BASELINE_SCHEMA_VERSION
-        );
-        return ExitCode::from(EXIT_INFRA);
-    }
-    if committed.kind != BaselineKind::Forward {
-        eprintln!(
-            "verify-baseline: failed — committed kind {:?} is not Forward; \
-             did you pass reverse_baseline.json or oracle_baseline.json by mistake?",
-            committed.kind
-        );
-        return ExitCode::from(EXIT_INFRA);
+    if let Err(code) = validate_committed_baseline_envelope(&committed, kvs) {
+        return ExitCode::from(code);
     }
     let ctx = match production_context() {
         Ok(c) => c,
@@ -1062,13 +1248,6 @@ fn run_verify_baseline_with<E: Embed, R: Rerank>(
     ctx: &EvalContext<E, R>,
     committed: &BaselineSnapshot,
 ) -> ExitCode {
-    let aggregation = match AggregationKind::from_name(&committed.aggregation) {
-        Ok(a) => a,
-        Err(msg) => {
-            eprintln!("verify-baseline: {msg}");
-            return ExitCode::from(EXIT_INFRA);
-        }
-    };
     let (corpus, queries) = match load_fixture_for_kind(&ctx.fixture_dir, "full") {
         Ok(v) => v,
         Err(msg) => {
@@ -1077,16 +1256,66 @@ fn run_verify_baseline_with<E: Embed, R: Rerank>(
         }
     };
     let config = PipelineConfig { k: PIPELINE_K };
-    let results = match dispatch_pipeline(
-        &corpus,
-        &queries,
-        &ctx.embedder,
-        Some(&ctx.reranker),
-        aggregation,
-        &committed.merge_config,
-        &committed.normalization,
-        &config,
-    ) {
+    // FR-021/FR-022: dispatch by committed.kind. Each kind owns its own
+    // aggregation parse + pipeline call so a reader can map the variant to
+    // its dispatch in one hop without re-splitting a merged arm.
+    let pipeline_outcome: Result<Vec<QueryResult>, String> = match committed.kind {
+        BaselineKind::Forward => {
+            let aggregation = match AggregationKind::from_name(&committed.aggregation) {
+                Ok(a) => a,
+                Err(msg) => {
+                    eprintln!("verify-baseline: {msg}");
+                    return ExitCode::from(EXIT_INFRA);
+                }
+            };
+            dispatch_pipeline(
+                &corpus,
+                &queries,
+                &ctx.embedder,
+                Some(&ctx.reranker),
+                aggregation,
+                &committed.merge_config,
+                &committed.normalization,
+                &config,
+            )
+            .map_err(|e| format!("{e}"))
+        }
+        BaselineKind::Oracle => {
+            let aggregation = match AggregationKind::from_name(&committed.aggregation) {
+                Ok(a) => a,
+                Err(msg) => {
+                    eprintln!("verify-baseline: {msg}");
+                    return ExitCode::from(EXIT_INFRA);
+                }
+            };
+            dispatch_oracle_pipeline(
+                &corpus,
+                &queries,
+                &ctx.embedder,
+                Some(&ctx.reranker),
+                aggregation,
+                &committed.merge_config,
+                &committed.normalization,
+                &config,
+            )
+            .map_err(|e| format!("{e}"))
+        }
+        BaselineKind::FirstSearchReplay => evaluate_first_search_replay(
+            &corpus,
+            &queries,
+            &ctx.embedder,
+            &committed.merge_config,
+            &committed.normalization,
+            &config,
+        )
+        .map_err(|e| format!("{e}")),
+        BaselineKind::Reverse => unreachable!(
+            "Reverse kind rejected by validate_committed_baseline_envelope at {}:{}",
+            file!(),
+            line!()
+        ),
+    };
+    let results = match pipeline_outcome {
         Ok(r) => r,
         Err(e) => {
             eprintln!("verify-baseline: pipeline failed: {e}");
@@ -1740,6 +1969,234 @@ mod tests {
         assert!(
             result.abs() < f64::EPSILON,
             "HitAt1.metric_fn() on grade-0 input must yield 0.0; got {result}"
+        );
+    }
+
+    // ── Issue #62 / Phase 2.3 — replay-first-search subcommand + verify-baseline 拡張 ──
+
+    /// Build a BaselineSnapshot with the requested schema/kind so envelope
+    /// validation tests don't drag in MockEmbedder + fixture setup.
+    fn snapshot_for_envelope_test(schema: &str, kind: BaselineKind) -> BaselineSnapshot {
+        BaselineSnapshot {
+            schema_version: schema.to_owned(),
+            kind,
+            captured_with: "test".to_owned(),
+            timestamp: "epoch:0".to_owned(),
+            model_id: "test/model".to_owned(),
+            model_revision: "rev".to_owned(),
+            mlx_rs_version: "0.0.0".to_owned(),
+            fixture_hash: "fnv1a64:0".to_owned(),
+            aggregation: "identity".to_owned(),
+            merge_config: HybridSearchConfig::default(),
+            normalization: QueryNormalizationConfig::default(),
+            global: vec![],
+            per_category: BTreeMap::new(),
+            latency_p50_ms: 0.0,
+            latency_p95_ms: 0.0,
+        }
+    }
+
+    /// Minimal (results, queries) pair for snapshot-builder tests.
+    /// Empty `ranked_hits` is fine — MetricSpec::ALL still iterates and
+    /// emits 0.0 for every metric, so ordering / presence assertions hold.
+    fn replay_snapshot_inputs() -> (Vec<QueryResult>, Vec<EvalQuery>) {
+        let queries = vec![EvalQuery {
+            id: "q1".to_owned(),
+            text: "alpha".to_owned(),
+            category: "test".to_owned(),
+            relevance_map: HashMap::from([("d1".to_owned(), 1u8)]),
+            annotation: "test".to_owned(),
+        }];
+        let results = vec![QueryResult {
+            query_id: "q1".to_owned(),
+            ranked_hits: vec![],
+            latency_ms: 5,
+        }];
+        (results, queries)
+    }
+
+    fn build_test_replay_snapshot() -> BaselineSnapshot {
+        let (results, queries) = replay_snapshot_inputs();
+        build_first_search_replay_snapshot(
+            &results,
+            &queries,
+            "fnv1a64:0".to_owned(),
+            "epoch:42".to_owned(),
+            &HybridSearchConfig::default(),
+            &QueryNormalizationConfig::default(),
+        )
+    }
+
+    // T-062-016: replay_first_search_subcommand_dispatches_to_evaluate_first_search_replay
+    //
+    // FR-016 / FR-017: the subcommand kind label maps through
+    // `parse_baseline_kind` to `BaselineKind::FirstSearchReplay`. Pinning
+    // the kind string round-trip guards against an accidental rename
+    // breaking the dispatch wiring (main()'s match arm + verify-baseline
+    // kind=).
+    #[test]
+    fn replay_first_search_subcommand_dispatches_to_evaluate_first_search_replay() {
+        assert_eq!(
+            parse_baseline_kind("first_search_replay")
+                .expect("first_search_replay kind must parse"),
+            BaselineKind::FirstSearchReplay,
+            "FR-016/FR-017: subcommand kind label must map to FirstSearchReplay"
+        );
+    }
+
+    // T-062-017: replay_first_search_writes_baseline_with_kind_first_search_replay
+    //
+    // FR-019: snapshot envelope kind == FirstSearchReplay so consumers can
+    // tell the file apart from forward / oracle baselines.
+    #[test]
+    fn replay_first_search_writes_baseline_with_kind_first_search_replay() {
+        let snap = build_test_replay_snapshot();
+        assert_eq!(snap.kind, BaselineKind::FirstSearchReplay);
+    }
+
+    // T-062-018: replay_first_search_writes_captured_with_replay_first_search
+    //
+    // FR-019: provenance string lets log readers tell which subcommand
+    // produced the file. Also doubles as the regenerate hint that
+    // `verify-baseline` emits on schema_version mismatch.
+    #[test]
+    fn replay_first_search_writes_captured_with_replay_first_search() {
+        let snap = build_test_replay_snapshot();
+        assert_eq!(snap.captured_with, "eval_harness replay-first-search");
+    }
+
+    // T-062-019: replay_first_search_writes_aggregation_none
+    //
+    // BR-003: replay path runs Stage 3 = MaxChunkAggregator only — no
+    // ranking-aware aggregator is invoked, so the field marker is "none".
+    #[test]
+    fn replay_first_search_writes_aggregation_none() {
+        let snap = build_test_replay_snapshot();
+        assert_eq!(
+            snap.aggregation, "none",
+            "BR-003: replay path's Stage 3 strategy is MaxChunkAggregator only \
+             (no ranking-aware aggregator) → aggregation marker is \"none\""
+        );
+    }
+
+    // T-062-020: verify_baseline_dispatches_on_first_search_replay_kind
+    //
+    // FR-021 / FR-022: when committed.kind == FirstSearchReplay and the
+    // optional kind=first_search_replay argument matches, the envelope
+    // check passes — caller (`run_verify_baseline_with`) then dispatches
+    // to `evaluate_first_search_replay`.
+    #[test]
+    fn verify_baseline_dispatches_on_first_search_replay_kind() {
+        let snap =
+            snapshot_for_envelope_test(BASELINE_SCHEMA_VERSION, BaselineKind::FirstSearchReplay);
+        let mut kvs = HashMap::new();
+        kvs.insert("kind".to_owned(), "first_search_replay".to_owned());
+        let result = validate_committed_baseline_envelope(&snap, &kvs);
+        assert!(
+            result.is_ok(),
+            "FR-021/FR-022: replay kind + matching kvs must pass envelope check; got {result:?}"
+        );
+    }
+
+    // T-062-021: verify_baseline_iterates_metric_spec_all_for_replay_kind
+    //
+    // FR-022 / NFR-005 / BR-001: replay path emits every MetricSpec::ALL
+    // entry to global, in the same order as forward / oracle. Ensures
+    // verify-baseline's `MetricSpec::ALL` iterator (Issue #61 soundness
+    // gap) covers FirstSearchReplay too.
+    #[test]
+    fn verify_baseline_iterates_metric_spec_all_for_replay_kind() {
+        let snap = build_test_replay_snapshot();
+        let names: Vec<&str> = snap.global.iter().map(|m| m.name.as_str()).collect();
+        let expected: Vec<&str> = MetricSpec::ALL.iter().map(|s| s.name()).collect();
+        assert_eq!(
+            names, expected,
+            "FR-022/NFR-005/BR-001: replay global must mirror MetricSpec::ALL order"
+        );
+    }
+
+    // T-062-022: verify_baseline_rejects_committed_baseline_with_schema_version_1_2
+    //
+    // FR-023 / NFR-005: stale 1.2 baseline must `EXIT_REGRESSION` (not
+    // silent skip). Ensures Issue #62's SCHEMA bump gate matches Issue
+    // #61's verify-baseline soundness contract.
+    #[test]
+    fn verify_baseline_rejects_committed_baseline_with_schema_version_1_2() {
+        let snap = snapshot_for_envelope_test("1.2", BaselineKind::Forward);
+        let kvs = HashMap::new();
+        let result = validate_committed_baseline_envelope(&snap, &kvs);
+        assert_eq!(
+            result,
+            Err(EXIT_REGRESSION),
+            "FR-023/NFR-005: stale 1.2 baseline must EXIT_REGRESSION"
+        );
+    }
+
+    // T-062-023: replay_first_search_records_latency_p50_ms
+    //
+    // FR-019 / NFR-004: the replay snapshot carries latency_p50_ms so the
+    // ADR-0003 第 4 reassessment trigger ("forward 比 2-5x 高速化に届かない")
+    // can be checked against committed JSON.
+    #[test]
+    fn replay_first_search_records_latency_p50_ms() {
+        let snap = build_test_replay_snapshot();
+        assert!(
+            snap.latency_p50_ms.is_finite(),
+            "FR-019/NFR-004: latency_p50_ms must be finite, got {}",
+            snap.latency_p50_ms
+        );
+    }
+
+    // T-062-024: replay_first_search_records_latency_p95_ms
+    //
+    // FR-019 / NFR-004: tail latency p95 lives next to p50 in the snapshot
+    // envelope so capacity drift can be tracked alongside median speedup.
+    #[test]
+    fn replay_first_search_records_latency_p95_ms() {
+        let snap = build_test_replay_snapshot();
+        assert!(
+            snap.latency_p95_ms.is_finite(),
+            "FR-019/NFR-004: latency_p95_ms must be finite, got {}",
+            snap.latency_p95_ms
+        );
+    }
+
+    // T-062-025: replay_first_search_emits_hit_at_k_in_global_metrics
+    //
+    // FR-018: replay reuses `build_global_metrics`, which iterates
+    // `MetricSpec::ALL` (HitAt1 / HitAt3 first per Issue #61). Pins the
+    // first two slots so the ADR-0003 "first-result quality" indicator
+    // is visible at the top of the snapshot JSON.
+    #[test]
+    fn replay_first_search_emits_hit_at_k_in_global_metrics() {
+        let snap = build_test_replay_snapshot();
+        assert_eq!(
+            snap.global.first().map(|m| m.name.as_str()),
+            Some("hit@1"),
+            "FR-018: replay global[0] must be hit@1 (Issue #61 ALL ordering)"
+        );
+        assert_eq!(
+            snap.global.get(1).map(|m| m.name.as_str()),
+            Some("hit@3"),
+            "FR-018: replay global[1] must be hit@3"
+        );
+    }
+
+    // T-062-026: verify_baseline_rejects_kind_mismatch
+    //
+    // FR-024 / AC-7: `verify-baseline baseline=forward.json kind=replay`
+    // must `EXIT_REGRESSION`. Guards against running the replay metric
+    // dispatch against a forward snapshot (or vice versa).
+    #[test]
+    fn verify_baseline_rejects_kind_mismatch() {
+        let snap = snapshot_for_envelope_test(BASELINE_SCHEMA_VERSION, BaselineKind::Forward);
+        let mut kvs = HashMap::new();
+        kvs.insert("kind".to_owned(), "first_search_replay".to_owned());
+        let result = validate_committed_baseline_envelope(&snap, &kvs);
+        assert_eq!(
+            result,
+            Err(EXIT_REGRESSION),
+            "FR-024/AC-7: kind mismatch (forward baseline + kind=replay) must EXIT_REGRESSION"
         );
     }
 }

--- a/src/eval/baseline.rs
+++ b/src/eval/baseline.rs
@@ -42,18 +42,27 @@ pub const UNINFORMATIVE_HALF_WIDTH: f64 = 0.10;
 ///   Forward and Reverse files round-trip unchanged. The bump lets
 ///   `oracle-gap` refuse to compare snapshots produced under different
 ///   semantic versions.
-pub const BASELINE_SCHEMA_VERSION: &str = "1.2";
+/// - `1.3`: First-search replay baseline kind (Issue #62).
+///   [`BaselineKind`] gained a `FirstSearchReplay` variant; older
+///   harnesses cannot deserialise a
+///   `first_search_replay_baseline.json` (variant unknown to their
+///   enum), but Forward, Reverse, and Oracle files round-trip unchanged.
+///   The bump lets `verify-baseline` refuse to compare a Forward
+///   baseline against a `replay-first-search` capture by mistake.
+pub const BASELINE_SCHEMA_VERSION: &str = "1.3";
 
-/// Discriminator distinguishing forward (`capture-baseline`) from reverse
-/// (`capture-reverse-baseline`) and oracle (`capture-oracle`) baseline files.
+/// Discriminator distinguishing forward (`capture-baseline`), reverse
+/// (`capture-reverse-baseline`), oracle (`capture-oracle`), and
+/// first-search replay (`replay-first-search`) baseline files.
 ///
-/// All three files share the [`BASELINE_SCHEMA_VERSION`] envelope; consumers
+/// All four files share the [`BASELINE_SCHEMA_VERSION`] envelope; consumers
 /// read `kind` first to pick the right body shape rather than inferring
-/// from the presence of fields. `Forward` and `Oracle` share the
-/// [`BaselineSnapshot`] body shape — the discriminator distinguishes the
-/// production-ranker capture from the retrieval-ceiling capture so
-/// `oracle-gap` (Issue #52) can refuse to compare a Forward against a
-/// Forward by mistake.
+/// from the presence of fields. `Forward`, `Oracle`, and `FirstSearchReplay`
+/// share the [`BaselineSnapshot`] body shape — the discriminator
+/// distinguishes production-ranker, retrieval-ceiling, and Stage 1+2-only
+/// captures so `oracle-gap` (Issue #52) and `verify-baseline` (Issue #62)
+/// can refuse to compare snapshots produced under different semantic
+/// modes by mistake.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BaselineKind {
@@ -69,6 +78,16 @@ pub enum BaselineKind {
     /// from `Forward` is that Stage 2 forced every relevance_map doc to
     /// rank 0 so Stage 3 + Stage 4 ran against an idealised retrieval.
     Oracle,
+    /// First-search replay baseline produced by `replay-first-search`
+    /// (Issue #62). Body matches [`BaselineSnapshot`]; Stage 1+2 produce
+    /// the merged hits, [`MaxChunkAggregator`] performs parent-level
+    /// rollup, and Stage 4 (rerank) is skipped. Records the agentic-search
+    /// "first-result quality" indicator (ADR-0003) so downstream consumers
+    /// can isolate ranking-strategy sensitivity from aggregator / reranker
+    /// effects.
+    ///
+    /// [`MaxChunkAggregator`]: rurico::retrieval::MaxChunkAggregator
+    FirstSearchReplay,
 }
 
 /// Frozen baseline produced by `eval_harness capture-baseline` and verified
@@ -398,6 +417,106 @@ mod tests {
             BaselineKind::Forward,
             "committed baseline.json must declare kind=forward"
         );
+    }
+
+    // T-062-011 / T-062-015: baseline_kind_first_search_replay_serialises_as_snake_case
+    //
+    // FR-012: BaselineKind::FirstSearchReplay round-trips through serde_json
+    // as the snake_case label "first_search_replay". Pinning the wire format
+    // guards against a future variant rename silently breaking committed
+    // first_search_replay_baseline.json files. A serde-attribute regression
+    // (e.g. dropping `rename_all = "snake_case"`) would break both serialize
+    // and deserialize together, so wire-format pin and enum-level round-trip
+    // collapse into one test (mirrors T-052-301 for Oracle).
+    #[test]
+    fn baseline_kind_first_search_replay_serialises_as_snake_case() {
+        let json = serde_json::to_string(&BaselineKind::FirstSearchReplay).expect("serialise");
+        assert_eq!(
+            json, "\"first_search_replay\"",
+            "FR-012: FirstSearchReplay variant must serialise to \"first_search_replay\""
+        );
+        let parsed: BaselineKind = serde_json::from_str(&json).expect("round-trip");
+        assert_eq!(parsed, BaselineKind::FirstSearchReplay);
+    }
+
+    // T-062-012: baseline_snapshot_round_trips_with_first_search_replay_kind
+    //
+    // FR-013: BaselineSnapshot envelope round-trips with
+    // `kind=FirstSearchReplay`, proving the new variant shares Forward /
+    // Oracle's body shape and `replay-first-search` can reuse `write_json`
+    // without forking the serialisation path. `aggregation="none"` is the
+    // BR-003 marker for "Stage 3 ran MaxChunkAggregator only".
+    #[test]
+    fn baseline_snapshot_round_trips_with_first_search_replay_kind() {
+        let snap = BaselineSnapshot {
+            schema_version: BASELINE_SCHEMA_VERSION.to_owned(),
+            kind: BaselineKind::FirstSearchReplay,
+            captured_with: "eval_harness replay-first-search".to_owned(),
+            timestamp: "epoch:42".to_owned(),
+            model_id: "test/model".to_owned(),
+            model_revision: "rev".to_owned(),
+            mlx_rs_version: "0.0.0".to_owned(),
+            fixture_hash: "fnv1a64:0".to_owned(),
+            aggregation: "none".to_owned(),
+            merge_config: HybridSearchConfig::default(),
+            normalization: pre_phase_5_disabled(),
+            global: vec![],
+            per_category: BTreeMap::new(),
+            latency_p50_ms: 0.0,
+            latency_p95_ms: 0.0,
+        };
+        let json = serde_json::to_string(&snap).expect("serialise");
+        let parsed: BaselineSnapshot = serde_json::from_str(&json).expect("round-trip");
+        assert_eq!(parsed.kind, BaselineKind::FirstSearchReplay);
+        assert_eq!(parsed.captured_with, "eval_harness replay-first-search");
+        assert_eq!(
+            parsed.aggregation, "none",
+            "BR-003: aggregation marker is \"none\" for FirstSearchReplay"
+        );
+    }
+
+    // T-062-013: baseline_schema_version_is_1_3
+    //
+    // FR-014: BASELINE_SCHEMA_VERSION bumped to "1.3" so verify-baseline
+    // refuses 1.2 stamps via EXIT_REGRESSION (silent skip would mask
+    // FirstSearchReplay readiness).
+    #[test]
+    fn baseline_schema_version_is_1_3() {
+        assert_eq!(
+            BASELINE_SCHEMA_VERSION, "1.3",
+            "FR-014: schema must be 1.3 to gate stale 1.2 baselines"
+        );
+    }
+
+    // T-062-014: committed_baselines_deserialize_under_schema_1_3
+    //
+    // FR-014 / AC-6: every committed baseline file (forward / oracle /
+    // first-search replay) deserialises cleanly under schema 1.3. Pinning
+    // the three-file invariant in a single test surfaces a stale fixture
+    // (e.g. one regenerated under a different schema) in CI before
+    // verify-baseline hits it at runtime.
+    #[test]
+    fn committed_baselines_deserialize_under_schema_1_3() {
+        let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/eval");
+        for (name, expected_kind) in [
+            ("baseline.json", BaselineKind::Forward),
+            ("oracle_baseline.json", BaselineKind::Oracle),
+            (
+                "first_search_replay_baseline.json",
+                BaselineKind::FirstSearchReplay,
+            ),
+        ] {
+            let path = fixture_dir.join(name);
+            let text = fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            let parsed: BaselineSnapshot = serde_json::from_str(&text)
+                .unwrap_or_else(|e| panic!("{name} must deserialise under schema 1.3 ({e})"));
+            assert_eq!(parsed.schema_version, "1.3", "{name} schema must be 1.3");
+            assert_eq!(
+                parsed.kind, expected_kind,
+                "{name} kind must be {expected_kind:?}"
+            );
+        }
     }
 
     // T-022: atomic_write_replaces_destination_on_each_call

--- a/src/eval/pipeline.rs
+++ b/src/eval/pipeline.rs
@@ -13,8 +13,8 @@ use bytemuck::cast_slice;
 use rurico::embed::{EMBEDDING_DIMS, Embed, EmbedError};
 use rurico::reranker::{Rerank, RerankerError};
 use rurico::retrieval::{
-    Aggregator, Candidate, CandidateSource, HybridSearchConfig, MergeStrategy, MergedHit,
-    WeightedRrf,
+    Aggregator, Candidate, CandidateSource, HybridSearchConfig, MaxChunkAggregator, MergeStrategy,
+    MergedHit, WeightedRrf,
 };
 use rurico::storage::{
     QueryNormalizationConfig, SanitizeError, ensure_sqlite_vec, normalize_for_fts,
@@ -179,6 +179,68 @@ where
     Ok(results)
 }
 
+/// Run Stage 1+2 over the corpus and apply [`MaxChunkAggregator`] parent
+/// rollup, skipping Stage 3 ranking-aware aggregators and Stage 4 rerank.
+///
+/// Records the agentic-search "first-result quality" indicator (ADR-0003).
+/// Output `ranked_hits` are parent-granular: every entry has
+/// `chunk_id == None` and unique `doc_id` within the top-k window
+/// (FR-007a / BR-007), so the top-k window measures unique parent docs
+/// (pgr "top-k unique docs include relevant" semantics).
+///
+/// Stage 4 (rerank) is unreachable on this path because the signature has
+/// no `reranker` parameter (FR-008 / FR-010 compile-time guard). Stage 3
+/// is fixed to [`MaxChunkAggregator`] — ranking-aware aggregators (e.g.
+/// [`IdentityAggregator`]) are not selectable.
+///
+/// # Errors
+///
+/// See [`PipelineError`] variants — same surface as [`evaluate`] minus
+/// rerank-related errors (no reranker invoked).
+///
+/// [`MaxChunkAggregator`]: rurico::retrieval::MaxChunkAggregator
+/// [`IdentityAggregator`]: rurico::retrieval::IdentityAggregator
+pub fn evaluate_first_search_replay<E>(
+    corpus: &[EvalDocument],
+    queries: &[EvalQuery],
+    embedder: &E,
+    merge_config: &HybridSearchConfig,
+    normalization: &QueryNormalizationConfig,
+    config: &PipelineConfig,
+) -> Result<Vec<QueryResult>, PipelineError>
+where
+    E: Embed,
+{
+    let conn = setup_pipeline_connection(corpus, embedder, normalization)?;
+    let merge_strategy = WeightedRrf::new(merge_config.clone());
+    let aggregator = MaxChunkAggregator;
+
+    let mut results = Vec::with_capacity(queries.len());
+    for query in queries {
+        let started = Instant::now();
+        let merged_hits = run_stage1_plus_2(
+            &conn,
+            query,
+            embedder,
+            &merge_strategy,
+            normalization,
+            config,
+        )?;
+        // Aggregator::aggregate guarantees score-descending output (trait
+        // contract; MaxChunkAggregator's impl sorts unconditionally), so
+        // truncate-after does not silently drop higher-scoring hits.
+        let mut ranked_hits = aggregator.aggregate(&merged_hits);
+        ranked_hits.truncate(config.k);
+        let latency_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        results.push(QueryResult {
+            query_id: query.id.clone(),
+            ranked_hits,
+            latency_ms,
+        });
+    }
+    Ok(results)
+}
+
 /// Initialise an in-memory SQLite connection, build the eval-harness
 /// schema, and index `corpus` into all three tables.
 ///
@@ -295,6 +357,44 @@ fn index_corpus<E: Embed>(
     Ok(())
 }
 
+/// Run Stage 1 (FTS + vec retrieval) and Stage 2 (RRF merge) for one query.
+///
+/// Composes [`retrieve_fts`] and [`retrieve_vec`] with `merge_strategy.merge()`.
+/// The returned [`MergedHit`] vector reflects the merge strategy's output
+/// verbatim — neither sorted, truncated, nor passed through any Stage 3
+/// aggregator. Callers own post-merge composition (truncate to `k`,
+/// aggregator pass, parent rollup, rerank, etc.).
+///
+/// `pub(super)` so [`run_single_query`] (forward / oracle paths) and
+/// [`evaluate_first_search_replay`] share this helper without forking the
+/// per-query Stage 1+2 wiring.
+///
+/// # Errors
+///
+/// Surfaces [`PipelineError::Sqlite`] / [`PipelineError::Sanitize`] from
+/// FTS retrieval and [`PipelineError::Embed`] / [`PipelineError::Sqlite`]
+/// from vector retrieval.
+pub(super) fn run_stage1_plus_2<E, M>(
+    conn: &Connection,
+    query: &EvalQuery,
+    embedder: &E,
+    merge_strategy: &M,
+    normalization: &QueryNormalizationConfig,
+    config: &PipelineConfig,
+) -> Result<Vec<MergedHit>, PipelineError>
+where
+    E: Embed,
+    M: MergeStrategy,
+{
+    let candidate_limit = config.k * RRF_CANDIDATE_MULTIPLIER;
+    let fts_hits = retrieve_fts(conn, &query.text, candidate_limit, normalization)?;
+    let vec_hits = retrieve_vec(conn, embedder, &query.text, candidate_limit)?;
+    let mut all_candidates = Vec::with_capacity(fts_hits.len() + vec_hits.len());
+    all_candidates.extend(fts_hits);
+    all_candidates.extend(vec_hits);
+    Ok(merge_strategy.merge(&all_candidates))
+}
+
 /// Drive one `EvalQuery` through FTS + vec retrieval, RRF merge, Stage 3
 /// aggregation, and (when supplied) reranker rescoring.
 ///
@@ -319,13 +419,8 @@ where
     A: Aggregator,
     M: MergeStrategy,
 {
-    let candidate_limit = config.k * RRF_CANDIDATE_MULTIPLIER;
-    let fts_hits = retrieve_fts(conn, &query.text, candidate_limit, normalization)?;
-    let vec_hits = retrieve_vec(conn, embedder, &query.text, candidate_limit)?;
-    let mut all_candidates = Vec::with_capacity(fts_hits.len() + vec_hits.len());
-    all_candidates.extend(fts_hits);
-    all_candidates.extend(vec_hits);
-    let merged_hits = merge_strategy.merge(&all_candidates);
+    let merged_hits =
+        run_stage1_plus_2(conn, query, embedder, merge_strategy, normalization, config)?;
 
     // Aggregator::aggregate guarantees score-descending output (see trait
     // doc), so truncate-then-rerank does not silently drop higher-scoring
@@ -507,18 +602,19 @@ fn apply_reranker<R: Rerank>(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
     use rurico::embed::{MockChunkedEmbedder, MockEmbedder};
     use rurico::reranker::MockReranker;
     use rurico::retrieval::{
-        HybridSearchConfig, IdentityAggregator, MaxChunkAggregator, MergedHit,
+        HybridSearchConfig, IdentityAggregator, MaxChunkAggregator, MergedHit, WeightedRrf,
     };
     use rurico::storage::QueryNormalizationConfig;
 
-    use super::{PipelineConfig, evaluate};
+    use super::{
+        PipelineConfig, evaluate, evaluate_first_search_replay, run_stage1_plus_2,
+        setup_pipeline_connection,
+    };
     use crate::eval::fixture::{EvalDocument, EvalQuery};
 
     /// Build an [`EvalDocument`] with stub title / source. The body carries
@@ -781,6 +877,395 @@ mod tests {
              max_chunk_len={} identity_len={}",
             max_chunk_result[0].ranked_hits.len(),
             identity_result[0].ranked_hits.len()
+        );
+    }
+
+    // T-062-001: run_stage1_plus_2_returns_merged_hits_for_mock_corpus
+    //
+    // FR-001 / FR-002: helper composes retrieve_fts + retrieve_vec → merge_strategy.merge.
+    // Indexed corpus + valid query → non-empty Vec<MergedHit>.
+    #[test]
+    fn run_stage1_plus_2_returns_merged_hits_for_mock_corpus() {
+        let corpus = vec![
+            make_document("d1", "alpha document about retrieval"),
+            make_document("d2", "beta document about ranking"),
+            make_document("d3", "gamma document about indexing"),
+        ];
+        let query = make_query("q1", "alpha retrieval", "d1");
+        let embedder = MockEmbedder::default();
+        let merge_strategy = WeightedRrf::new(HybridSearchConfig::default());
+        let normalization = QueryNormalizationConfig::default();
+        let config = PipelineConfig { k: 5 };
+
+        let conn = setup_pipeline_connection(&corpus, &embedder, &normalization)
+            .expect("setup must succeed for MockEmbedder corpus");
+        let merged = run_stage1_plus_2(
+            &conn,
+            &query,
+            &embedder,
+            &merge_strategy,
+            &normalization,
+            &config,
+        )
+        .expect("Stage 1+2 helper must succeed");
+
+        assert!(
+            !merged.is_empty(),
+            "FR-001/FR-002: indexed corpus + valid query → run_stage1_plus_2 must \
+             return non-empty Vec<MergedHit>, got empty"
+        );
+    }
+
+    // T-062-002: run_stage1_plus_2_does_not_truncate_or_sort_or_aggregate
+    //
+    // FR-003: helper returns merge_strategy.merge() output verbatim. Verified by
+    //   1. chunk-level fixture (MockChunkedEmbedder::new(2)) → at least one
+    //      MergedHit retains chunk_id=Some(_); a Stage 3 aggregator (e.g.
+    //      MaxChunkAggregator) would collapse all chunk_ids to None.
+    //   2. merged.len() > config.k → no truncate to k.
+    #[test]
+    fn run_stage1_plus_2_does_not_truncate_or_sort_or_aggregate() {
+        let corpus = vec![
+            make_document("d1", "alpha document about retrieval"),
+            make_document("d2", "beta document about ranking"),
+            make_document("d3", "gamma document about indexing"),
+        ];
+        let query = make_query("q1", "alpha retrieval", "d1");
+        let embedder = MockChunkedEmbedder::new(2);
+        let merge_strategy = WeightedRrf::new(HybridSearchConfig::default());
+        let normalization = QueryNormalizationConfig::default();
+        let config = PipelineConfig { k: 2 };
+
+        let conn = setup_pipeline_connection(&corpus, &embedder, &normalization)
+            .expect("setup must succeed for chunk-level corpus");
+        let merged = run_stage1_plus_2(
+            &conn,
+            &query,
+            &embedder,
+            &merge_strategy,
+            &normalization,
+            &config,
+        )
+        .expect("Stage 1+2 helper must succeed");
+
+        let chunk_id_some_count = merged.iter().filter(|h| h.chunk_id.is_some()).count();
+        assert!(
+            chunk_id_some_count > 0,
+            "FR-003: helper must NOT invoke any Stage 3 aggregator. \
+             A Stage 3 aggregator would collapse chunk_id to None, but \
+             retrieved chunk-level hits should be preserved verbatim. \
+             Got {chunk_id_some_count} hits with chunk_id=Some, merged={merged:?}"
+        );
+
+        // candidate_limit = k * RRF_CANDIDATE_MULTIPLIER (= 2 * 3 = 6); with
+        // 3 docs × 2 chunks per doc, vec retrieval contributes ≤ 6 hits.
+        // After merge, length should exceed config.k (= 2) — proving the
+        // helper did not truncate.
+        assert!(
+            merged.len() > config.k,
+            "FR-003: helper must NOT truncate to k={}, got merged.len()={}",
+            config.k,
+            merged.len()
+        );
+    }
+
+    // T-062-004: evaluate_first_search_replay_returns_one_result_per_query
+    //
+    // FR-006 / FR-007: Stage 1+2 + parent rollup → exactly one
+    // QueryResult per EvalQuery, in the same order as `queries`.
+    #[test]
+    fn evaluate_first_search_replay_returns_one_result_per_query() {
+        let corpus = vec![
+            make_document("d1", "alpha document about retrieval"),
+            make_document("d2", "beta document about ranking"),
+            make_document("d3", "gamma document about indexing"),
+        ];
+        let queries = vec![
+            make_query("q1", "alpha retrieval", "d1"),
+            make_query("q2", "beta ranking", "d2"),
+        ];
+        let embedder = MockEmbedder::default();
+        let merge_config = HybridSearchConfig::default();
+        let normalization = QueryNormalizationConfig::default();
+        let config = PipelineConfig { k: 3 };
+
+        let results = evaluate_first_search_replay(
+            &corpus,
+            &queries,
+            &embedder,
+            &merge_config,
+            &normalization,
+            &config,
+        )
+        .expect("replay must succeed");
+
+        assert_eq!(
+            results.len(),
+            queries.len(),
+            "FR-006/FR-007: one QueryResult per query, got {} results for {} queries",
+            results.len(),
+            queries.len()
+        );
+        assert_eq!(
+            results[0].query_id, "q1",
+            "QueryResult order must mirror input queries"
+        );
+        assert_eq!(results[1].query_id, "q2", "QueryResult order preserved");
+    }
+
+    // T-062-005 / T-062-006: evaluate_first_search_replay_signature_excludes_aggregator_and_reranker
+    //
+    // FR-008 / FR-010 compile-time guard: the signature has neither an
+    // `Aggregator` nor a `Reranker` parameter — verified by the call
+    // below compiling without either. A single passing call site pins
+    // the entire parameter list, so T-062-005 (no aggregator) and
+    // T-062-006 (no reranker) collapse into one test.
+    #[test]
+    fn evaluate_first_search_replay_signature_excludes_aggregator_and_reranker() {
+        let corpus = vec![make_document("d1", "alpha")];
+        let queries = vec![make_query("q1", "alpha", "d1")];
+        let embedder = MockEmbedder::default();
+        let merge_config = HybridSearchConfig::default();
+        let normalization = QueryNormalizationConfig::default();
+        let config = PipelineConfig { k: 1 };
+
+        let _ = evaluate_first_search_replay(
+            &corpus,
+            &queries,
+            &embedder,
+            &merge_config,
+            &normalization,
+            &config,
+        )
+        .expect("replay must succeed");
+    }
+
+    // T-062-007: evaluate_first_search_replay_results_are_score_descending
+    //
+    // FR-007 / BR-005: ranked_hits sorted by descending score. The order
+    // comes from Aggregator::aggregate's trait contract (MaxChunkAggregator
+    // sorts unconditionally), so no explicit sort is needed in the replay
+    // path.
+    #[test]
+    fn evaluate_first_search_replay_results_are_score_descending() {
+        let corpus = vec![
+            make_document("d1", "alpha document about retrieval"),
+            make_document("d2", "beta document about ranking"),
+            make_document("d3", "gamma document about indexing"),
+            make_document("d4", "delta document about scoring"),
+            make_document("d5", "epsilon document about evaluation"),
+        ];
+        let queries = vec![make_query("q1", "alpha retrieval", "d1")];
+        let embedder = MockChunkedEmbedder::new(2);
+        let merge_config = HybridSearchConfig::default();
+        let normalization = QueryNormalizationConfig::default();
+        let config = PipelineConfig { k: 5 };
+
+        let results = evaluate_first_search_replay(
+            &corpus,
+            &queries,
+            &embedder,
+            &merge_config,
+            &normalization,
+            &config,
+        )
+        .expect("replay must succeed");
+
+        let scores: Vec<f64> = results[0].ranked_hits.iter().map(|h| h.score).collect();
+        let mut prev = f64::INFINITY;
+        for (i, score) in scores.iter().enumerate() {
+            assert!(
+                *score <= prev,
+                "BR-005: ranked_hits must be score-descending; \
+                 hit {i} has score {score} > prev {prev}, full scores={scores:?}"
+            );
+            prev = *score;
+        }
+    }
+
+    // T-062-007a: evaluate_first_search_replay_results_have_unique_doc_ids
+    //
+    // FR-007a / BR-007: parent rollup collapses sibling chunks of the same
+    // doc_id to a single MergedHit (max score), so the top-k window
+    // measures unique parent docs (pgr "top-k unique docs include
+    // relevant" semantics, ADR-0003 第 2 deliverable).
+    #[test]
+    fn evaluate_first_search_replay_results_have_unique_doc_ids() {
+        let corpus = vec![
+            make_document("d1", "alpha document about retrieval"),
+            make_document("d2", "beta document about ranking"),
+            make_document("d3", "gamma document about indexing"),
+        ];
+        let queries = vec![make_query("q1", "alpha retrieval", "d1")];
+        let embedder = MockChunkedEmbedder::new(2);
+        let merge_config = HybridSearchConfig::default();
+        let normalization = QueryNormalizationConfig::default();
+        let config = PipelineConfig { k: 5 };
+
+        let results = evaluate_first_search_replay(
+            &corpus,
+            &queries,
+            &embedder,
+            &merge_config,
+            &normalization,
+            &config,
+        )
+        .expect("replay must succeed");
+
+        let doc_ids: Vec<&str> = results[0]
+            .ranked_hits
+            .iter()
+            .map(|h| h.doc_id.as_str())
+            .collect();
+        let unique: HashSet<&str> = doc_ids.iter().copied().collect();
+        assert_eq!(
+            doc_ids.len(),
+            unique.len(),
+            "FR-007a/BR-007: ranked_hits must have unique doc_ids after \
+             parent rollup; got duplicates in {doc_ids:?}"
+        );
+    }
+
+    // T-062-007b: evaluate_first_search_replay_results_have_chunk_id_none
+    //
+    // BR-007: parent rollup post-condition — every entry has
+    // `chunk_id == None`. MaxChunkAggregator strips chunk_id when
+    // collapsing siblings; replay path must preserve that invariant
+    // through truncate-to-k.
+    #[test]
+    fn evaluate_first_search_replay_results_have_chunk_id_none() {
+        let corpus = vec![
+            make_document("d1", "alpha document about retrieval"),
+            make_document("d2", "beta document about ranking"),
+            make_document("d3", "gamma document about indexing"),
+        ];
+        let queries = vec![make_query("q1", "alpha retrieval", "d1")];
+        let embedder = MockChunkedEmbedder::new(2);
+        let merge_config = HybridSearchConfig::default();
+        let normalization = QueryNormalizationConfig::default();
+        let config = PipelineConfig { k: 5 };
+
+        let results = evaluate_first_search_replay(
+            &corpus,
+            &queries,
+            &embedder,
+            &merge_config,
+            &normalization,
+            &config,
+        )
+        .expect("replay must succeed");
+
+        assert!(
+            results[0].ranked_hits.iter().all(|h| h.chunk_id.is_none()),
+            "BR-007: parent rollup must strip chunk_id; got {:?}",
+            results[0].ranked_hits
+        );
+    }
+
+    // T-062-008: evaluate_first_search_replay_truncates_to_k
+    //
+    // FR-007: caller truncates to config.k after rollup + sort.
+    #[test]
+    fn evaluate_first_search_replay_truncates_to_k() {
+        let corpus = vec![
+            make_document("d1", "alpha document about retrieval"),
+            make_document("d2", "beta document about ranking"),
+            make_document("d3", "gamma document about indexing"),
+            make_document("d4", "delta document about scoring"),
+            make_document("d5", "epsilon document about evaluation"),
+        ];
+        let queries = vec![make_query("q1", "alpha retrieval", "d1")];
+        let embedder = MockEmbedder::default();
+        let merge_config = HybridSearchConfig::default();
+        let normalization = QueryNormalizationConfig::default();
+        let config = PipelineConfig { k: 2 };
+
+        let results = evaluate_first_search_replay(
+            &corpus,
+            &queries,
+            &embedder,
+            &merge_config,
+            &normalization,
+            &config,
+        )
+        .expect("replay must succeed");
+
+        assert!(
+            results[0].ranked_hits.len() <= config.k,
+            "FR-007: replay must truncate to k={}, got len={}",
+            config.k,
+            results[0].ranked_hits.len()
+        );
+    }
+
+    // T-062-009: evaluate_first_search_replay_records_per_query_latency
+    //
+    // FR-009: per-query latency_ms is recorded on QueryResult.
+    // latency_ms is u64 by type, so its presence on QueryResult is the
+    // FR-009 signal — referencing the field below proves it exists.
+    #[test]
+    fn evaluate_first_search_replay_records_per_query_latency() {
+        let corpus = vec![make_document("d1", "alpha")];
+        let queries = vec![make_query("q1", "alpha", "d1")];
+        let embedder = MockEmbedder::default();
+        let merge_config = HybridSearchConfig::default();
+        let normalization = QueryNormalizationConfig::default();
+        let config = PipelineConfig { k: 1 };
+
+        let results = evaluate_first_search_replay(
+            &corpus,
+            &queries,
+            &embedder,
+            &merge_config,
+            &normalization,
+            &config,
+        )
+        .expect("replay must succeed");
+
+        let _latency: u64 = results[0].latency_ms;
+    }
+
+    // T-062-010: evaluate_first_search_replay_does_not_invoke_identity_aggregator
+    //
+    // FR-008 / BR-008: replay path uses MaxChunkAggregator only. Under
+    // chunk-level retrieval (MockChunkedEmbedder::new(2)),
+    // IdentityAggregator would surface per-chunk hits (chunk_id=Some).
+    // Replay's MaxChunkAggregator must collapse them — every result has
+    // chunk_id=None — proving Identity (or any aggregator that preserves
+    // chunk_id) was not invoked.
+    #[test]
+    fn evaluate_first_search_replay_does_not_invoke_identity_aggregator() {
+        let corpus = vec![
+            make_document("d1", "alpha document about retrieval"),
+            make_document("d2", "beta document about ranking"),
+        ];
+        let queries = vec![make_query("q1", "alpha retrieval", "d1")];
+        let embedder = MockChunkedEmbedder::new(2);
+        let merge_config = HybridSearchConfig::default();
+        let normalization = QueryNormalizationConfig::default();
+        let config = PipelineConfig { k: 5 };
+
+        let results = evaluate_first_search_replay(
+            &corpus,
+            &queries,
+            &embedder,
+            &merge_config,
+            &normalization,
+            &config,
+        )
+        .expect("replay must succeed");
+
+        let chunk_id_some_count = results[0]
+            .ranked_hits
+            .iter()
+            .filter(|h| h.chunk_id.is_some())
+            .count();
+        assert_eq!(
+            chunk_id_some_count, 0,
+            "FR-008/BR-008: replay must NOT invoke IdentityAggregator (or \
+             any aggregator that preserves chunk_id). Got \
+             {chunk_id_some_count} hits with chunk_id=Some, ranked_hits={:?}",
+            results[0].ranked_hits
         );
     }
 }

--- a/tests/fixtures/eval/first_search_replay_baseline.json
+++ b/tests/fixtures/eval/first_search_replay_baseline.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.3",
-  "kind": "forward",
-  "captured_with": "eval_harness capture-baseline",
-  "timestamp": "epoch:1778316144",
+  "kind": "first_search_replay",
+  "captured_with": "eval_harness replay-first-search",
+  "timestamp": "epoch:1778315861",
   "model_id": "cl-nagoya/ruri-v3-310m",
   "model_revision": "pinned-via-rurico-embed-cache",
   "mlx_rs_version": "0.25",
   "fixture_hash": "fnv1a64:88afbfc4e99e0a84",
-  "aggregation": "identity",
+  "aggregation": "none",
   "merge_config": {
     "rrf_k": 60.0,
     "source_weights": {
@@ -24,8 +24,8 @@
     {
       "name": "hit@1",
       "k": 1,
-      "point_estimate": 1.0,
-      "ci_lower": 1.0,
+      "point_estimate": 0.9940476190476191,
+      "ci_lower": 0.9821428571428571,
       "ci_upper": 1.0,
       "uninformative": false
     },
@@ -40,9 +40,9 @@
     {
       "name": "recall@5",
       "k": 5,
-      "point_estimate": 0.6299603174603176,
-      "ci_lower": 0.5985119047619046,
-      "ci_upper": 0.6635912698412697,
+      "point_estimate": 0.5804563492063493,
+      "ci_lower": 0.549702380952381,
+      "ci_upper": 0.6142857142857143,
       "uninformative": false
     },
     {
@@ -56,17 +56,17 @@
     {
       "name": "mrr@10",
       "k": 10,
-      "point_estimate": 1.0,
-      "ci_lower": 1.0,
+      "point_estimate": 0.9970238095238095,
+      "ci_lower": 0.9910714285714286,
       "ci_upper": 1.0,
       "uninformative": false
     },
     {
       "name": "ndcg@10",
       "k": 10,
-      "point_estimate": 0.8927152322843769,
-      "ci_lower": 0.8758959682081754,
-      "ci_upper": 0.9060020209389352,
+      "point_estimate": 0.886043807135979,
+      "ci_lower": 0.8706501310840375,
+      "ci_upper": 0.8996254653009721,
       "uninformative": false
     }
   ],
@@ -91,9 +91,9 @@
       {
         "name": "recall@5",
         "k": 5,
-        "point_estimate": 0.6095238095238096,
-        "ci_lower": 0.5119047619047619,
-        "ci_upper": 0.7047619047619047,
+        "point_estimate": 0.5380952380952382,
+        "ci_lower": 0.44761904761904764,
+        "ci_upper": 0.6309523809523809,
         "uninformative": false
       },
       {
@@ -115,9 +115,9 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.898389793154694,
-        "ci_lower": 0.8564482005383541,
-        "ci_upper": 0.9325460147776281,
+        "point_estimate": 0.8773701966503167,
+        "ci_lower": 0.8367313073222894,
+        "ci_upper": 0.9113358825260621,
         "uninformative": false
       }
     ],
@@ -141,9 +141,9 @@
       {
         "name": "recall@5",
         "k": 5,
-        "point_estimate": 0.5682539682539682,
-        "ci_lower": 0.4888888888888888,
-        "ci_upper": 0.6420634920634921,
+        "point_estimate": 0.49920634920634926,
+        "ci_lower": 0.42936507936507934,
+        "ci_upper": 0.5722222222222223,
         "uninformative": false
       },
       {
@@ -165,9 +165,9 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.8703370297846807,
-        "ci_lower": 0.8326182473316168,
-        "ci_upper": 0.9046574980745109,
+        "point_estimate": 0.8573090425535389,
+        "ci_lower": 0.8239297054165885,
+        "ci_upper": 0.8902545227161589,
         "uninformative": false
       }
     ],
@@ -191,9 +191,9 @@
       {
         "name": "recall@5",
         "k": 5,
-        "point_estimate": 0.5801587301587302,
-        "ci_lower": 0.4888888888888888,
-        "ci_upper": 0.6753968253968254,
+        "point_estimate": 0.5587301587301587,
+        "ci_lower": 0.4746031746031746,
+        "ci_upper": 0.6468253968253969,
         "uninformative": false
       },
       {
@@ -215,9 +215,9 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.8886513595583997,
-        "ci_lower": 0.8513403560181254,
-        "ci_upper": 0.9244545423942179,
+        "point_estimate": 0.8899405590314363,
+        "ci_lower": 0.8594877459327235,
+        "ci_upper": 0.9205836590090851,
         "uninformative": false
       }
     ],
@@ -241,9 +241,9 @@
       {
         "name": "recall@5",
         "k": 5,
-        "point_estimate": 0.6865079365079364,
-        "ci_lower": 0.5992063492063492,
-        "ci_upper": 0.765873015873016,
+        "point_estimate": 0.619047619047619,
+        "ci_lower": 0.5396825396825398,
+        "ci_upper": 0.7063492063492064,
         "uninformative": false
       },
       {
@@ -265,9 +265,9 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.9183631980078937,
-        "ci_lower": 0.8937393353685754,
-        "ci_upper": 0.9408027792462884,
+        "point_estimate": 0.9095954404403841,
+        "ci_lower": 0.8641600757637269,
+        "ci_upper": 0.9434427939469183,
         "uninformative": false
       }
     ],
@@ -291,9 +291,9 @@
       {
         "name": "recall@5",
         "k": 5,
-        "point_estimate": 0.6277777777777779,
-        "ci_lower": 0.5349206349206349,
-        "ci_upper": 0.7285714285714286,
+        "point_estimate": 0.596031746031746,
+        "ci_lower": 0.5174603174603176,
+        "ci_upper": 0.6714285714285714,
         "uninformative": false
       },
       {
@@ -315,9 +315,9 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.8506109193434975,
-        "ci_lower": 0.7644094410548943,
-        "ci_upper": 0.9168053624815402,
+        "point_estimate": 0.8547958996625882,
+        "ci_lower": 0.774154746480688,
+        "ci_upper": 0.9097280279310944,
         "uninformative": false
       }
     ],
@@ -341,9 +341,9 @@
       {
         "name": "recall@5",
         "k": 5,
-        "point_estimate": 0.5476190476190477,
-        "ci_lower": 0.46904761904761905,
-        "ci_upper": 0.6309523809523809,
+        "point_estimate": 0.5238095238095238,
+        "ci_lower": 0.4523809523809524,
+        "ci_upper": 0.6071428571428571,
         "uninformative": false
       },
       {
@@ -365,9 +365,9 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.874912057259853,
-        "ci_lower": 0.8445471840611899,
-        "ci_upper": 0.9033664674442551,
+        "point_estimate": 0.8818279634030972,
+        "ci_lower": 0.8480077212286888,
+        "ci_upper": 0.9108611988229237,
         "uninformative": false
       }
     ],
@@ -391,9 +391,9 @@
       {
         "name": "recall@5",
         "k": 5,
-        "point_estimate": 0.65,
-        "ci_lower": 0.5666666666666667,
-        "ci_upper": 0.7380952380952381,
+        "point_estimate": 0.5785714285714286,
+        "ci_lower": 0.4904761904761905,
+        "ci_upper": 0.6738095238095239,
         "uninformative": false
       },
       {
@@ -415,9 +415,9 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.9041683890277755,
-        "ci_lower": 0.8691657670447677,
-        "ci_upper": 0.9372754866066317,
+        "point_estimate": 0.8903868154263032,
+        "ci_lower": 0.8615751645407292,
+        "ci_upper": 0.9175811503765059,
         "uninformative": false
       }
     ],
@@ -425,8 +425,8 @@
       {
         "name": "hit@1",
         "k": 1,
-        "point_estimate": 1.0,
-        "ci_lower": 1.0,
+        "point_estimate": 0.9523809523809523,
+        "ci_lower": 0.8571428571428571,
         "ci_upper": 1.0,
         "uninformative": false
       },
@@ -441,9 +441,9 @@
       {
         "name": "recall@5",
         "k": 5,
-        "point_estimate": 0.7698412698412698,
-        "ci_lower": 0.6587301587301587,
-        "ci_upper": 0.8730158730158731,
+        "point_estimate": 0.7301587301587301,
+        "ci_lower": 0.6269841269841269,
+        "ci_upper": 0.8333333333333334,
         "uninformative": true
       },
       {
@@ -457,21 +457,21 @@
       {
         "name": "mrr@10",
         "k": 10,
-        "point_estimate": 1.0,
-        "ci_lower": 1.0,
+        "point_estimate": 0.9761904761904762,
+        "ci_lower": 0.9285714285714286,
         "ci_upper": 1.0,
         "uninformative": false
       },
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.9362891121382129,
-        "ci_lower": 0.9099351071237409,
-        "ci_upper": 0.9606261115951567,
+        "point_estimate": 0.9271245399201643,
+        "ci_lower": 0.8790384043196676,
+        "ci_upper": 0.9630566665279103,
         "uninformative": false
       }
     ]
   },
-  "latency_p50_ms": 1573.0,
-  "latency_p95_ms": 2575.0
+  "latency_p50_ms": 50.0,
+  "latency_p95_ms": 63.0
 }

--- a/tests/fixtures/eval/oracle_baseline.json
+++ b/tests/fixtures/eval/oracle_baseline.json
@@ -1,8 +1,8 @@
 {
-  "schema_version": "1.2",
+  "schema_version": "1.3",
   "kind": "oracle",
   "captured_with": "eval_harness capture-oracle",
-  "timestamp": "epoch:1778271389",
+  "timestamp": "epoch:1778316425",
   "model_id": "cl-nagoya/ruri-v3-310m",
   "model_revision": "pinned-via-rurico-embed-cache",
   "mlx_rs_version": "0.25",
@@ -40,9 +40,9 @@
     {
       "name": "recall@5",
       "k": 5,
-      "point_estimate": 0.7185515873015874,
-      "ci_lower": 0.6878968253968254,
-      "ci_upper": 0.7495039682539681,
+      "point_estimate": 0.7170634920634922,
+      "ci_lower": 0.6876984126984127,
+      "ci_upper": 0.7489087301587302,
       "uninformative": false
     },
     {
@@ -64,9 +64,9 @@
     {
       "name": "ndcg@10",
       "k": 10,
-      "point_estimate": 0.9475268057575891,
-      "ci_lower": 0.9377598165614695,
-      "ci_upper": 0.9555558053772821,
+      "point_estimate": 0.9477642985697524,
+      "ci_lower": 0.9379680269041076,
+      "ci_upper": 0.9557758299624382,
       "uninformative": false
     }
   ],
@@ -115,9 +115,9 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.9569265217686284,
-        "ci_lower": 0.9391914260511298,
-        "ci_upper": 0.9736789700043081,
+        "point_estimate": 0.9570131387426085,
+        "ci_lower": 0.9391914260511297,
+        "ci_upper": 0.9739230629079416,
         "uninformative": false
       }
     ],
@@ -165,8 +165,8 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.9505880085302805,
-        "ci_lower": 0.9343798876650027,
+        "point_estimate": 0.9506746255042603,
+        "ci_lower": 0.9344869648048872,
         "ci_upper": 0.9662463831054537,
         "uninformative": false
       }
@@ -215,9 +215,9 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.9385225697523962,
-        "ci_lower": 0.9168675056567677,
-        "ci_upper": 0.9578637210311838,
+        "point_estimate": 0.9384380314139351,
+        "ci_lower": 0.9168296230632106,
+        "ci_upper": 0.9577487356809053,
         "uninformative": false
       }
     ],
@@ -315,9 +315,9 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.9222622532390031,
-        "ci_lower": 0.8735235642004637,
-        "ci_upper": 0.9631790103705432,
+        "point_estimate": 0.9237492963270287,
+        "ci_lower": 0.8747037724359266,
+        "ci_upper": 0.9644899640806488,
         "uninformative": false
       }
     ],
@@ -365,9 +365,9 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.932948166458314,
-        "ci_lower": 0.9150871653619601,
-        "ci_upper": 0.9518346130876413,
+        "point_estimate": 0.9329165850531231,
+        "ci_lower": 0.915233881430269,
+        "ci_upper": 0.9517330588944153,
         "uninformative": false
       }
     ],
@@ -391,8 +391,8 @@
       {
         "name": "recall@5",
         "k": 5,
-        "point_estimate": 0.6976190476190476,
-        "ci_lower": 0.6333333333333334,
+        "point_estimate": 0.6857142857142857,
+        "ci_lower": 0.6095238095238096,
         "ci_upper": 0.7619047619047619,
         "uninformative": false
       },
@@ -415,9 +415,9 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.9514431171772477,
-        "ci_lower": 0.9338896690772103,
-        "ci_upper": 0.9676585548569386,
+        "point_estimate": 0.9516561634018718,
+        "ci_lower": 0.9338328326078263,
+        "ci_upper": 0.9674186362264731,
         "uninformative": false
       }
     ],
@@ -465,13 +465,13 @@
       {
         "name": "ndcg@10",
         "k": 10,
-        "point_estimate": 0.9673456423678749,
-        "ci_lower": 0.949941847757764,
-        "ci_upper": 0.9813843255296133,
+        "point_estimate": 0.9674883813482223,
+        "ci_lower": 0.9500444914133921,
+        "ci_upper": 0.9815270645099607,
         "uninformative": false
       }
     ]
   },
-  "latency_p50_ms": 1735.0,
-  "latency_p95_ms": 1975.0
+  "latency_p50_ms": 1849.0,
+  "latency_p95_ms": 2489.0
 }


### PR DESCRIPTION
## 概要

- ADR-0003 第 2 deliverable。Stage 1+2 + parent rollup (`MaxChunkAggregator`) のみで走る `replay-first-search` subcommand を追加し、agentic-search "first-result quality" 指標 (Hit@k) を Stage 4/5 (rerank/final) の影響なしに観測可能化
- `BaselineKind::FirstSearchReplay` variant + `BASELINE_SCHEMA_VERSION` 1.2 → 1.3 bump、`verify-baseline` を kind discrimination + EXIT_REGRESSION で stale 1.2 baseline を reject する形に拡張
- forward p50 1573ms vs replay p50 50ms = **31x speedup** (AC-4 target 2-5x 大幅超過)

## 決定要因

- **Stage 3 minimum (MaxChunkAggregator) 採択** — chunk-level retrieval 下で pgr "top-k unique docs" semantics を担保するため、ranking-aware aggregator は不在でも parent rollup は必須。ADR-0003 Decision Outcome 第 2 項 amendment で明文化 (Stage 3 全 skip → Stage 3 minimum)
- **`run_stage1_plus_2` helper 切り出し** — forward / oracle / replay 3 path で共通の Stage 1+2 wiring を pub(super) helper に抽象化、既存 forward/oracle 経路は helper 呼び出しに refactor
- **`BASELINE_SCHEMA_VERSION` 1.3 bump** — Issue #61 verify-baseline soundness gate (stale baseline silent skip 防止) と整合、3 baseline 全件 1.3 stamp で committed
- **NFR-001 bit-equal を tolerance 内一致に reframe** — MLX 浮動小数 inherent variance (refactor 前後で ndcg@10 1.45e-4 変動、tolerance(NdcgAt10)=1e-3 内)。spec 厳格 bit-equal は MLX 環境で達成不能、tolerance 内一致が実質基準
- **/polish 5 finding fix**: REUSE-001 (explicit sort_by 削除、`Aggregator::aggregate` trait contract 既定保証) / CQ-001 (`parse_baseline_kind` を serde 経由、wire format single source) / CQ-002 (`verify-baseline` 3 explicit arms) / CQ-004 (T-062-005/006 merge) / CQ-005 (`unreachable!` に file!()/line!() 埋め込み)

## テスト計画

- [x] `cargo test --workspace --features eval-harness --lib --bins` 全 pass (227 tests、T-062 系 26 新規)
- [x] `cargo clippy --workspace --features eval-harness --all-targets -- -D warnings` clean
- [x] `verify-baseline baseline=tests/fixtures/eval/baseline.json` (forward) → exit 0、stderr "passed"
- [x] `verify-baseline baseline=tests/fixtures/eval/first_search_replay_baseline.json` (replay) → exit 0、stderr "passed"
- [x] `replay-first-search output=...` → exit 0、`kind=first_search_replay`, `aggregation=none`, schema 1.3 で書き出し
- [x] schema 1.2 reject + kind mismatch reject は T-062-022 / T-062-026 unit test で確認
- [x] AC-4 latency: replay p50 50ms / forward p50 1573ms / oracle p50 1849ms — 31x speedup
- [x] AC-8 semantic correctness: T-062-007a (parent rollup unique doc_ids) + T-062-007b (chunk_id=None) + T-062-010 (no Identity aggregator) で検証

## スコープ外

- **Codex P2 (replay 用 embedder-only context)**: EvalContext `<E: Embed, R: Rerank>` 改修が forward/oracle/replay 全 path 影響。実環境で reranker model cached 済 → 影響なし。follow-up issue 候補
- **CQ-003 (3-site BaselineSnapshot builder dedup)**: forward/oracle inline literal の helper 化は TIDYINGS scope 外、別 PR
- **下流 rev pin bump (sae/recall/yomu)**: 別 repo session、Issue #61 (Hit@k) + Issue #62 (schema 1.3) 同時伝播
- **ADR-0003 Status: proposed → accepted promote**: 本 PR land 後の別 commit
- **fixture ceiling 解除**: replay でも \`mrr@10=1.0\` ceiling のため \`hit@k=1.0\` 固定。downstream 計測 (yomu#163 / sae#107) で sub-fixture 必要性発覚時の別 issue

## レビュー履歴

| Tool | Findings | Action |
|------|----------|--------|
| simplify (reuse/quality/efficiency) | 5 (REUSE-001 / CQ-001 / CQ-002 / CQ-004 / CQ-005) | 全 fix |
| Codex | 1 fix (REUSE-001 sort_by) + 2 P2 skip (replay 用 reranker init、follow-up) | partial fix |
| CodeRabbit | 1 major (latency 増加調査) — false positive (intentional regenerate) | skip |
| Gemini | 429 quota exhausted (Issue #61 と同 pattern) | skip |
| enhancer-code Phase 2 | T-062 comment refresh + test merge (T-062-011/015) + import combine | 全 fix |

## 参考

- Issue #62: feat(eval): first-search replay モードの追加
- ADR-0003: \`docs/decisions/0003-add-pgr-style-first-search-offline-retrieval-benchmark.md\` (本 PR で Decision Outcome 第 2 項 amendment)
- Predecessor: PR #65 (Issue #61 Hit@1/Hit@3 metrics、main HEAD 3dd1856)
- pgr blog post: https://entire.io/blog/improving-agentic-search-in-coding-agents (2026-05-06)
- ADR-0002: Search Quality Evaluation Methodology

Closes #62