### PR TITLE
docs(adr): ADR-0003 のステータスを accepted に変更

### DIFF
--- a/docs/decisions/0003-add-pgr-style-first-search-offline-retrieval-benchmark.md
+++ b/docs/decisions/0003-add-pgr-style-first-search-offline-retrieval-benchmark.md
@@ -1,6 +1,6 @@
 # Add pgr-style First-Search Offline Retrieval Benchmark
 
-- Status: proposed
+- Status: accepted
 - Deciders: thkt
 - Date: 2026-05-08
 - Confidence: medium — pgr 記事 (entire.io 2026-05-06) で `MRR` / `Hit@1` / `Hit@3` の感度差は実証済み (fff vs baseline で Hit@1 -8 ポイント、pgr vs baseline で Hit@1 +8 ポイント)。amici の既存 fixture / Bootstrap CI / Oracle pipeline は再利用可能で実装コストは低い。一方、自社プロジェクト (yomu / sae) の ranking 改善でも同等の感度が出るかは要観測。


### PR DESCRIPTION
## 概要

ADR-0003 (pgr-style first-search offline retrieval benchmark) のステータスを `proposed` → `accepted` に変更。

## 決定要因

- Issue #61 (PR #65) で第 1 deliverable (`Hit@1` / `Hit@3` metrics + `MetricSpec::ALL` 先頭配置 + verify-baseline soundness gate) land 済
- Issue #62 (PR #66) で第 2 deliverable (`replay-first-search` subcommand + `BaselineKind::FirstSearchReplay` + schema 1.3 bump + ADR-0003 Decision Outcome 第 2 項 amendment) land 済
- 31x speedup (replay p50 50ms vs forward 1573ms) — AC-4 target 2-5x 大幅超過で性能目標達成
- downstream (yomu#163 definitions-first ranking 効果測定 / sae#107 hybrid retrieval benchmark 化) は本 ADR を前提として動く、accepted status が前提

## テスト計画

- [x] git diff: 1 line のみ (`Status: proposed` → `Status: accepted`)
- [x] ADR の Decision Outcome / References / Downstream consumers セクションは既存 PR (#65 / #66) で更新済

## スコープ外

- 後続実装 (sub-PR-B annotate subcommand / sub-PR-C annotation-stats / 下流 rev pin bump 等) は別 issue / 別 repo session

## 参考

- ADR-0003: \`docs/decisions/0003-add-pgr-style-first-search-offline-retrieval-benchmark.md\`
- PR #65 (Issue #61 第 1 deliverable)
- PR #66 (Issue #62 第 2 deliverable + ADR amendment)