### PR TITLE
feat(eval): block-mode session capture を行う annotate subcommand を追加 (#53)

### DIFF
--- a/docs/decisions/0004-annotation-framework.md
+++ b/docs/decisions/0004-annotation-framework.md
@@ -79,6 +79,7 @@ Option 1 を採用する。
 - T-001 (naming collision readability) が PASS していても、実運用で `EvalQuery.annotation` と `eval::annotation::Entry` の混同による不具合が報告された場合 → §Considered Options Option 3 (rename existing field) を再評価
 - contributor 数が増え authoring tool の使用頻度が baseline capture と同等以上になり、capture / authoring envelope の symmetric 化要望が複数 contributor から出た場合 → Option 2 (`BaselineSnapshot` mirror + `BaselineKind::Annotation`) を再評価
 - `ANNOTATION_SCHEMA_VERSION` の bump 頻度が `BASELINE_SCHEMA_VERSION` を超える状態が継続した場合 → 2 envelope 維持の正当性 (独立進化) が機能している証左、本 ADR の方針継続を強化
+- Phase 1.5 (sub-PR-D) Collaborative mode 着手時、§Decision Outcome 第 3 項 (`Provenance.model_id` / `mlx_rs_version` 追加 + `ANNOTATION_SCHEMA_VERSION` 1.0→1.1 bump) は `LlmProvider` trait を `annotation_context` に optional injection する経路で達成することを default 設計とする。`EvalContext<E, R>` を annotate に流用する経路 (MLX runtime 直結) は §Decision Outcome 第 1 項 (annotation 側境界の独立進化) と衝突するため reject。本 trigger は sub-PR-D の design step で再評価する
 
 ## References
 

--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -23,6 +23,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
 use std::fs;
+use std::io::{self, BufRead, IsTerminal};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -31,6 +32,7 @@ use rand::SeedableRng;
 use rand::seq::SliceRandom;
 use rand_chacha::ChaCha8Rng;
 
+use amici::eval::annotation::{ANNOTATION_SCHEMA_VERSION, Entry, Provenance, Session};
 use amici::eval::baseline::{
     BASELINE_SCHEMA_VERSION, BaselineKind, BaselineSnapshot, atomic_write, build_metric_result,
     write_json,
@@ -553,6 +555,7 @@ fn main() -> ExitCode {
         "oracle-gap" => run_oracle_gap(&kvs),
         "verify-baseline" => run_verify_baseline(&kvs),
         "compare-baselines" => run_compare_baselines(&kvs),
+        "annotate" => run_annotate(&kvs),
         other => {
             eprintln!("unknown mode: {other}");
             ExitCode::from(EXIT_USAGE)
@@ -1798,9 +1801,238 @@ fn hash_fixture_dir(fixture_dir: &Path) -> Result<String, String> {
     Ok(format!("fnv1a64:{hash:016x}"))
 }
 
+/// MLX-free runtime context for the `annotate` subcommand. Carries the
+/// fixture directory whose `queries.jsonl` content hash is stamped into
+/// `Provenance.queries_jsonl_hash`, plus an injectable timestamp closure
+/// so tests can pin a deterministic `epoch:N` label without faking
+/// `SystemTime`.
+///
+/// Distinct from [`EvalContext`] because Phase 1 block-mode authoring
+/// touches no MLX runtime — embedder/reranker fields would be dead
+/// weight here.
+struct AnnotationContext {
+    fixture_dir: PathBuf,
+    timestamp: Box<dyn Fn() -> String>,
+}
+
+/// Build the runtime [`AnnotationContext`] for `annotate`.
+///
+/// Honours `fixture_dir=<path>` argv (used by the integration tests to
+/// redirect to a sandbox tempdir). Falls back to the production
+/// `tests/fixtures/eval/` under `CARGO_MANIFEST_DIR`. The timestamp
+/// closure resolves to the live [`capture_timestamp_label`].
+fn annotation_context(kvs: &HashMap<String, String>) -> AnnotationContext {
+    let fixture_dir = kvs.get("fixture_dir").map_or_else(
+        || Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/eval"),
+        PathBuf::from,
+    );
+    AnnotationContext {
+        fixture_dir,
+        timestamp: Box::new(capture_timestamp_label),
+    }
+}
+
+/// Category allowlist for `Entry.category`. Tracks the eight categories
+/// present in `tests/fixtures/eval/queries.jsonl` (AS-001). A new category
+/// in the fixture must be propagated here (BR-004) before annotations
+/// containing it will be accepted.
+const CATEGORY_ALLOWLIST: &[&str] = &[
+    "comparative",
+    "conceptual",
+    "definitional",
+    "factoid",
+    "howto",
+    "listing",
+    "troubleshooting",
+    "variant_notation",
+];
+
+/// Maximum graded relevance value accepted in `Entry.relevance_map`. The
+/// `u8` parse already enforces ≥ 0 (FR-V002).
+const MAX_RELEVANCE_GRADE: u8 = 3;
+
+/// FR-011: literal stderr line emitted when `annotate` is invoked with a
+/// TTY stdin. Phase 1 has no interactive UX (deferred to sub-PR-D), so
+/// the only safe ingress is `cat session.jsonl | eval_harness annotate ...`.
+const TTY_REJECT_MESSAGE: &str =
+    "annotate: pipe jsonl into stdin (interactive UX deferred to sub-PR-D)";
+
+/// FR-011 dispatch helper. Returns `Some(ExitCode)` for a TTY stdin so
+/// callers can short-circuit before stdin parsing; `None` lets the caller
+/// continue. Pure boolean argument so unit tests can verify the branch
+/// table without faking [`std::io::IsTerminal`] (CI lanes inherit stdin as
+/// pipe / null and cannot reproduce the TTY case via subprocess spawn).
+fn check_stdin_tty_guard(is_tty: bool) -> Option<ExitCode> {
+    if is_tty {
+        eprintln!("{TTY_REJECT_MESSAGE}");
+        Some(ExitCode::from(EXIT_USAGE))
+    } else {
+        None
+    }
+}
+
+/// `annotate output=<path> annotator_id=<id> session_id=<id>` — Phase 1
+/// block-mode session capture (Issue #53 sub-PR-B).
+///
+/// Reads jsonl [`Entry`] lines from stdin, builds a [`Session`] with
+/// canonical [`Provenance`], runs `validate_schema_version`, and atomic-writes
+/// pretty JSON to `<path>`. MLX-free per NFR-001 — excluded from
+/// [`MLX_DEPENDENT_MODES`].
+fn run_annotate(kvs: &HashMap<String, String>) -> ExitCode {
+    let Some(output_path_raw) = kvs.get("output") else {
+        eprintln!("annotate: output= argument required");
+        return ExitCode::from(EXIT_USAGE);
+    };
+    if let Some(exit) = check_stdin_tty_guard(io::stdin().is_terminal()) {
+        return exit;
+    }
+    let output_path = match validate_output_path(output_path_raw) {
+        Ok(p) => p,
+        Err(msg) => {
+            eprintln!("annotate: {msg}");
+            return ExitCode::from(EXIT_USAGE);
+        }
+    };
+    let Some(annotator_id) = kvs.get("annotator_id") else {
+        eprintln!("annotate: annotator_id= argument required");
+        return ExitCode::from(EXIT_USAGE);
+    };
+    let Some(session_id) = kvs.get("session_id") else {
+        eprintln!("annotate: session_id= argument required");
+        return ExitCode::from(EXIT_USAGE);
+    };
+
+    let ctx = annotation_context(kvs);
+    let queries_jsonl_hash = match hash_fixture_dir(&ctx.fixture_dir) {
+        Ok(h) => h,
+        Err(msg) => {
+            eprintln!("annotate: {msg}");
+            return ExitCode::from(EXIT_INFRA);
+        }
+    };
+
+    let stdin = io::stdin();
+    let mut entries: Vec<Entry> = Vec::new();
+    let mut seen_ids: HashMap<String, usize> = HashMap::new();
+    for (line_idx, line_result) in stdin.lock().lines().enumerate() {
+        let line_no = line_idx + 1;
+        let line = match line_result {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("annotate: line {line_no} read error: {e}");
+                return ExitCode::from(EXIT_USAGE);
+            }
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let entry: Entry = match serde_json::from_str(&line) {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("annotate: line {line_no} parse error: {e}");
+                return ExitCode::from(EXIT_USAGE);
+            }
+        };
+        if !CATEGORY_ALLOWLIST.contains(&entry.category.as_str()) {
+            eprintln!(
+                "annotate: line {line_no} invalid category {got:?}; expected one of {CATEGORY_ALLOWLIST:?}",
+                got = entry.category,
+            );
+            return ExitCode::from(EXIT_USAGE);
+        }
+        if let Some((doc_id, grade)) = entry
+            .relevance_map
+            .iter()
+            .find(|(_, g)| **g > MAX_RELEVANCE_GRADE)
+        {
+            eprintln!("annotate: line {line_no} invalid grade {doc_id}={grade}; expected 0..=3");
+            return ExitCode::from(EXIT_USAGE);
+        }
+        if let Some(prev_line) = seen_ids.get(&entry.id) {
+            eprintln!(
+                "annotate: line {line_no} duplicate id {id} (first seen on line {prev_line})",
+                id = entry.id,
+            );
+            return ExitCode::from(EXIT_USAGE);
+        }
+        seen_ids.insert(entry.id.clone(), line_no);
+        entries.push(entry);
+    }
+
+    if entries.is_empty() {
+        eprintln!("annotate: empty session, no entries written");
+        return ExitCode::from(EXIT_USAGE);
+    }
+
+    let session = Session {
+        provenance: Provenance {
+            schema_version: ANNOTATION_SCHEMA_VERSION.to_owned(),
+            captured_with: "annotate".to_owned(),
+            timestamp: (ctx.timestamp)(),
+            annotator_id: annotator_id.clone(),
+            session_id: session_id.clone(),
+            queries_jsonl_hash,
+        },
+        entries,
+    };
+
+    if let Err(e) = session.validate_schema_version() {
+        eprintln!("annotate: schema version mismatch: {e}");
+        return ExitCode::from(EXIT_INFRA);
+    }
+
+    if let Err(e) = session.write_json(&output_path) {
+        eprintln!("annotate: write failed: {e}");
+        return ExitCode::from(EXIT_INFRA);
+    }
+
+    let n_entries = session.entries.len();
+    eprintln!(
+        "annotate: wrote {} ({n_entries} entries)",
+        output_path.display()
+    );
+    ExitCode::SUCCESS
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // T-004: tty_reject_message_contains_fr_011_substring
+    // FR-011: TTY_REJECT_MESSAGE must literally contain
+    //         "pipe jsonl into stdin" so an interactive run prints the
+    //         exact substring required by Spec FR-011.
+    //
+    // Spec Evolution 2026-05-10: integration variant infeasible —
+    // `cargo test` lanes inherit stdin as pipe / null, so
+    // `is_terminal() == true` is unreproducible across CI hosts. The
+    // boolean dispatch is verified separately in
+    // `tty_guard_returns_usage_for_terminal` so the constant + dispatch
+    // pair fully cover FR-011.
+    #[test]
+    fn tty_reject_message_contains_fr_011_substring() {
+        assert!(
+            TTY_REJECT_MESSAGE.contains("pipe jsonl into stdin"),
+            "FR-011: TTY_REJECT_MESSAGE must contain 'pipe jsonl into stdin'; \
+             got: {TTY_REJECT_MESSAGE}"
+        );
+    }
+
+    // T-004: tty_guard_returns_usage_for_terminal
+    // FR-011: when stdin is a TTY, `check_stdin_tty_guard` returns
+    //         `Some(ExitCode)`; otherwise it returns `None` so
+    //         `run_annotate` proceeds with stdin parsing.
+    #[test]
+    fn tty_guard_returns_usage_for_terminal() {
+        assert!(
+            check_stdin_tty_guard(true).is_some(),
+            "FR-011: TTY stdin must short-circuit run_annotate"
+        );
+        assert!(
+            check_stdin_tty_guard(false).is_none(),
+            "FR-011: piped stdin must not short-circuit run_annotate"
+        );
+    }
 
     // T-067-007: aggregation_kind_topk_average_roundtrips_through_name
     //

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -9,6 +9,7 @@
 pub mod annotation;
 pub mod baseline;
 pub mod fixture;
+pub mod io;
 pub mod metrics;
 pub mod oracle_gap;
 pub mod oracle_pipeline;

--- a/src/eval/annotation.rs
+++ b/src/eval/annotation.rs
@@ -13,6 +13,8 @@
 //! `docs/decisions/0004-annotation-framework.md`.
 
 use std::collections::BTreeMap;
+use std::io;
+use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
@@ -110,6 +112,24 @@ impl Session {
         }
         Ok(())
     }
+
+    /// Atomic-write this session as pretty JSON to `path`.
+    ///
+    /// Delegates to [`super::io::write_json`] so [`Session`] and
+    /// [`super::baseline::BaselineSnapshot`] share one atomic-write
+    /// code path. `serde_json` failures are funneled through
+    /// [`io::Error::other`] inside that helper, so callers only need
+    /// to match [`AnnotationError::Io`] for both serialisation and
+    /// filesystem faults.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnnotationError::Io`] when the temp file cannot be
+    /// created, written, fsynced, or renamed into place.
+    pub fn write_json(&self, path: &Path) -> Result<(), AnnotationError> {
+        super::io::write_json(self, path)?;
+        Ok(())
+    }
 }
 
 /// Errors surfaced by annotation framework operations.
@@ -128,9 +148,19 @@ pub enum AnnotationError {
     /// Annotation session contains zero entries.
     #[error("annotation session is empty")]
     EmptySession,
-    /// JSON serialisation / deserialisation failure.
+    /// JSON serialisation / deserialisation failure. Retained for
+    /// forward compatibility — Phase 1 onwards, `serde_json::Error`
+    /// raised inside [`Session::write_json`] is funneled via
+    /// [`io::Error::other`] in [`super::io::write_json`] and surfaces as
+    /// [`AnnotationError::Io`]. Future deserialise paths (e.g.
+    /// `Session::read_json`) will fire this variant directly.
     #[error("annotation serialise error: {0}")]
     Serialise(#[from] serde_json::Error),
+    /// I/O failure during atomic write or read of session JSON. Wraps
+    /// both raw [`io::Error`] and `serde_json` failures funneled via
+    /// [`io::Error::other`] in [`super::io::write_json`].
+    #[error("annotation io error: {0}")]
+    Io(#[from] io::Error),
 }
 
 #[cfg(test)]

--- a/src/eval/annotation/tests.rs
+++ b/src/eval/annotation/tests.rs
@@ -1,11 +1,19 @@
-//! Unit tests for [`crate::eval::annotation`] (Issue #53 sub-PR-A).
+//! Unit tests for [`crate::eval::annotation`] (Issue #53 sub-PR-A and sub-PR-B).
 //!
-//! Maps to spec Test Scenarios T-001..T-004 in
+//! Sub-PR-A: T-001..T-004 in
 //! `docs/spec/2026-05-08-issue-53-annotation-foundation/spec.md`. The
 //! Spec's Skip rationale (FR-V002 Serialise wrapper) explicitly defers
 //! that case to the implicit serde path coverage from T-002.
+//!
+//! Sub-PR-B: T-002 (this file's `session_write_json_round_trips_through_tempdir`
+//! and `annotation_error_io_variant_is_reachable_via_from`) in
+//! `.claude/workspace/planning/2026-05-09-issue-53-annotate-subcommand/spec.md`.
 
 use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::io;
+
+use tempfile::tempdir;
 
 use super::*;
 use crate::eval::fixture::EvalQuery;
@@ -146,6 +154,44 @@ fn annotation_error_empty_session_variant_is_reachable() {
     assert!(
         matches!(err, AnnotationError::EmptySession),
         "FR-001: AnnotationError::EmptySession variant must be reachable via matches!; \
+         got: {err:?}"
+    );
+}
+
+// T-002 (sub-PR-B): session_write_json_round_trips_through_tempdir
+// FR-004: Session::write_json writes pretty JSON via the shared
+//         atomic-write path (eval::io::write_json). A stub Session
+//         routed through Session::write_json must deserialise back to
+//         a PartialEq-equal value.
+#[test]
+fn session_write_json_round_trips_through_tempdir() {
+    let dir = tempdir().expect("tempdir for Session::write_json round-trip");
+    let path = dir.path().join("session.json");
+    let original = make_session(ANNOTATION_SCHEMA_VERSION);
+
+    original
+        .write_json(&path)
+        .expect("Session::write_json must succeed");
+
+    let body = fs::read_to_string(&path).expect("read session.json");
+    let parsed: Session = serde_json::from_str(&body).expect("deserialise session.json");
+    assert_eq!(
+        parsed, original,
+        "round-trip via Session::write_json must preserve PartialEq equality"
+    );
+}
+
+// T-002 (sub-PR-B): annotation_error_io_variant_is_reachable_via_from
+// FR-003: AnnotationError gains an Io variant carrying std::io::Error
+//         with #[from] for `?`-propagation. Confirms the variant is
+//         reachable via From conversion.
+#[test]
+fn annotation_error_io_variant_is_reachable_via_from() {
+    let io_err = io::Error::other("stub io error");
+    let err: AnnotationError = io_err.into();
+    assert!(
+        matches!(err, AnnotationError::Io(_)),
+        "FR-003: AnnotationError::Io must be reachable via From<io::Error>; \
          got: {err:?}"
     );
 }

--- a/src/eval/baseline.rs
+++ b/src/eval/baseline.rs
@@ -224,17 +224,19 @@ pub fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
 
 /// Serialise `snapshot` as pretty JSON to `path` (atomic write).
 ///
-/// Uses [`atomic_write`] so a partial write never corrupts a committed
-/// baseline file in the git tree.
+/// Delegates to [`super::io::write_json`] so the `BaselineSnapshot`
+/// and `Session` writers share a single atomic-write code path.
 ///
 /// # Errors
 ///
-/// Returns [`BaselineError::Io`] when the destination cannot be created and
-/// [`BaselineError::Serialise`] when JSON encoding fails.
+/// Returns [`BaselineError::Io`] when the destination cannot be
+/// created or when JSON encoding fails — `serde_json` failures are
+/// wrapped as [`io::ErrorKind::Other`] inside [`super::io::write_json`]
+/// before they reach this layer. [`BaselineError::Serialise`] is
+/// retained for forward-compatible callers that wrap their own
+/// `serde_json::Error` directly.
 pub fn write_json(snapshot: &BaselineSnapshot, path: &Path) -> Result<(), BaselineError> {
-    let mut json = serde_json::to_string_pretty(snapshot)?;
-    json.push('\n');
-    atomic_write(path, json.as_bytes())?;
+    super::io::write_json(snapshot, path)?;
     Ok(())
 }
 

--- a/src/eval/io.rs
+++ b/src/eval/io.rs
@@ -1,0 +1,99 @@
+//! Atomic JSON write helper shared by [`crate::eval::baseline`] and
+//! [`crate::eval::annotation`].
+//!
+//! Generic over `T: Serialize` so [`BaselineSnapshot`] and [`Session`]
+//! reach a single atomic-write code path. `serde_json` failures are
+//! funneled into [`io::ErrorKind::Other`] so callers' typed error
+//! enums (`BaselineError`, `AnnotationError`) only need a single
+//! `Io(#[from] io::Error)` variant for both serialisation and
+//! filesystem failures.
+//!
+//! [`BaselineSnapshot`]: crate::eval::baseline::BaselineSnapshot
+//! [`Session`]: crate::eval::annotation::Session
+
+use std::io;
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::eval::baseline::atomic_write;
+
+/// Serialise `value` as pretty JSON terminated by a newline and
+/// atomically replace the file at `path`.
+///
+/// # Errors
+///
+/// Returns the underlying [`io::Error`] when the temp file cannot be
+/// created, written, fsynced, or renamed into place. `serde_json`
+/// encoding failures are wrapped via [`io::Error::other`] so callers
+/// match a single variant for both serialisation and filesystem
+/// faults.
+pub fn write_json<T: Serialize>(value: &T, path: &Path) -> io::Result<()> {
+    let mut json = serde_json::to_string_pretty(value).map_err(io::Error::other)?;
+    json.push('\n');
+    atomic_write(path, json.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::fs;
+
+    use rurico::retrieval::HybridSearchConfig;
+    use rurico::storage::pre_phase_5_disabled;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::eval::baseline::{BASELINE_SCHEMA_VERSION, BaselineKind, BaselineSnapshot};
+
+    /// Build a minimal [`BaselineSnapshot`] with deterministic literal
+    /// stub values. Only the round-trip shape is exercised, so each
+    /// field carries a placeholder rather than a fixture-derived value.
+    fn stub_snapshot() -> BaselineSnapshot {
+        BaselineSnapshot {
+            schema_version: BASELINE_SCHEMA_VERSION.to_owned(),
+            kind: BaselineKind::Forward,
+            captured_with: "io::tests".to_owned(),
+            timestamp: "epoch:0".to_owned(),
+            model_id: "test-model".to_owned(),
+            model_revision: "test-rev".to_owned(),
+            mlx_rs_version: "0.0".to_owned(),
+            fixture_hash: "fnv1a64:0".to_owned(),
+            aggregation: "identity".to_owned(),
+            merge_config: HybridSearchConfig::default(),
+            normalization: pre_phase_5_disabled(),
+            global: Vec::new(),
+            per_category: BTreeMap::new(),
+            latency_p50_ms: 0.0,
+            latency_p95_ms: 0.0,
+        }
+    }
+
+    // T-001: write_json_round_trips_baseline_snapshot
+    // FR-001: write_json<T: Serialize> writes pretty JSON via the
+    //         shared atomic-write path. A BaselineSnapshot routed
+    //         through write_json must deserialise back to a JSON-value-
+    //         equal Value. Comparison goes through serde_json::Value so
+    //         the assertion does not depend on HashMap iteration order
+    //         inside HybridSearchConfig.source_weights (BaselineSnapshot
+    //         does not derive PartialEq, and Phase 1 keeps the derive
+    //         set unchanged).
+    #[test]
+    fn write_json_round_trips_baseline_snapshot() {
+        let dir = tempdir().expect("tempdir for write_json round-trip");
+        let path = dir.path().join("snapshot.json");
+        let snapshot = stub_snapshot();
+
+        write_json(&snapshot, &path).expect("write_json must succeed");
+
+        let body = fs::read_to_string(&path).expect("read snapshot.json");
+        let parsed: BaselineSnapshot =
+            serde_json::from_str(&body).expect("deserialise snapshot.json");
+        let original_value = serde_json::to_value(&snapshot).expect("encode original as Value");
+        let parsed_value = serde_json::to_value(&parsed).expect("encode parsed as Value");
+        assert_eq!(
+            parsed_value, original_value,
+            "round-trip via write_json must preserve JSON value equality"
+        );
+    }
+}

--- a/tests/eval_annotation.rs
+++ b/tests/eval_annotation.rs
@@ -1,0 +1,413 @@
+//! Subprocess integration tests for the `eval_harness annotate` subcommand
+//! (Issue #53 sub-PR-B).
+//!
+//! Maps to spec Test Scenarios T-003..T-013 in
+//! `.claude/workspace/planning/2026-05-09-issue-53-annotate-subcommand/spec.md`.
+//!
+//! Tests are gated behind `eval-harness`. Unlike `tests/eval_smoke.rs`, none
+//! of these carry `#[ignore]`: Phase 1 block-mode authoring is MLX-free
+//! (NFR-001) and runs in the default `cargo test --features eval-harness`
+//! lane on any host.
+
+#![cfg(feature = "eval-harness")]
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+
+use amici::eval::annotation::{ANNOTATION_SCHEMA_VERSION, Session};
+use amici::eval::fixture::{EvalQuery, load_queries};
+use tempfile::tempdir;
+
+const EXIT_USAGE: i32 = 2;
+
+/// Spawn `eval_harness annotate` with `argv` arguments, write `stdin_bytes`
+/// to its stdin pipe, and capture the resulting [`std::process::Output`].
+fn spawn_annotate(argv: &[&str], stdin_bytes: &[u8]) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_eval_harness"))
+        .arg("annotate")
+        .args(argv)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn eval_harness annotate");
+    {
+        let stdin = child
+            .stdin
+            .as_mut()
+            .expect("annotate stdin must be piped for integration tests");
+        stdin
+            .write_all(stdin_bytes)
+            .expect("write stdin to annotate child");
+    }
+    child
+        .wait_with_output()
+        .expect("wait for eval_harness annotate")
+}
+
+// T-011a: t011a_annotate_missing_output_argv_exits_with_usage
+// FR-012: missing output= → EXIT_USAGE (2) + "annotate: output= argument required"
+#[test]
+fn t011a_annotate_missing_output_argv_exits_with_usage() {
+    let output = spawn_annotate(&["annotator_id=thkt", "session_id=s1"], b"");
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_USAGE),
+        "[T-011a] missing output= must exit {EXIT_USAGE}; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("annotate: output= argument required"),
+        "[T-011a] stderr must mention output= argument required; got: {stderr}"
+    );
+}
+
+// T-011b: t011b_annotate_missing_annotator_id_argv_exits_with_usage
+// FR-013: missing annotator_id= → EXIT_USAGE (2) + "annotate: annotator_id= argument required"
+#[test]
+fn t011b_annotate_missing_annotator_id_argv_exits_with_usage() {
+    let output = spawn_annotate(&["output=/tmp/_amici_t011b.json", "session_id=s1"], b"");
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_USAGE),
+        "[T-011b] missing annotator_id= must exit {EXIT_USAGE}; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("annotate: annotator_id= argument required"),
+        "[T-011b] stderr must mention annotator_id= argument required; got: {stderr}"
+    );
+}
+
+// T-011c: t011c_annotate_missing_session_id_argv_exits_with_usage
+// FR-014: missing session_id= → EXIT_USAGE (2) + "annotate: session_id= argument required"
+#[test]
+fn t011c_annotate_missing_session_id_argv_exits_with_usage() {
+    let output = spawn_annotate(&["output=/tmp/_amici_t011c.json", "annotator_id=thkt"], b"");
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_USAGE),
+        "[T-011c] missing session_id= must exit {EXIT_USAGE}; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("annotate: session_id= argument required"),
+        "[T-011c] stderr must mention session_id= argument required; got: {stderr}"
+    );
+}
+
+// T-003: t003_annotate_writes_session_with_provenance_envelope
+// FR-010, FR-016, FR-020, FR-021, FR-022, FR-023, FR-026:
+//   2 valid jsonl Entry lines pipe → exit 0; <output> deserialises as
+//   Session; provenance.schema_version == "1.0", captured_with == "annotate",
+//   timestamp.starts_with("epoch:"), queries_jsonl_hash.starts_with("fnv1a64:");
+//   stderr contains "annotate: wrote" and "(2 entries)".
+#[test]
+fn t003_annotate_writes_session_with_provenance_envelope() {
+    let dir = tempdir().expect("tempdir for annotate happy-path output");
+    let session_path = dir.path().join("session.json");
+    let stdin_jsonl = b"{\"id\":\"q1\",\"text\":\"alpha\",\"category\":\"factoid\",\"relevance_map\":{\"d1\":2},\"annotation_note\":\"first note\",\"mode\":\"standard\"}\n\
+                       {\"id\":\"q2\",\"text\":\"beta\",\"category\":\"howto\",\"relevance_map\":{\"d2\":3},\"annotation_note\":\"second note\",\"mode\":\"standard\"}\n";
+    let argv = [
+        format!("output={}", session_path.display()),
+        "annotator_id=thkt".to_owned(),
+        "session_id=s1".to_owned(),
+    ];
+    let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+
+    let output = spawn_annotate(&argv_refs, stdin_jsonl);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "[T-003] happy path must exit 0; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("annotate: wrote") && stderr.contains("(2 entries)"),
+        "[T-003] FR-026: stderr must announce wrote + (2 entries); got: {stderr}"
+    );
+
+    let body = fs::read_to_string(&session_path).expect("read session.json");
+    let session: Session =
+        serde_json::from_str(&body).expect("[T-003] FR-010: session.json must deserialise");
+    assert_eq!(
+        session.provenance.schema_version, ANNOTATION_SCHEMA_VERSION,
+        "[T-003] FR-023: schema_version must equal canonical constant"
+    );
+    assert_eq!(
+        session.provenance.captured_with, "annotate",
+        "[T-003] FR-020: captured_with must equal \"annotate\""
+    );
+    assert!(
+        session.provenance.timestamp.starts_with("epoch:"),
+        "[T-003] FR-021: timestamp must start with \"epoch:\"; got: {}",
+        session.provenance.timestamp
+    );
+    assert!(
+        session
+            .provenance
+            .queries_jsonl_hash
+            .starts_with("fnv1a64:"),
+        "[T-003] FR-022: queries_jsonl_hash must start with \"fnv1a64:\"; got: {}",
+        session.provenance.queries_jsonl_hash
+    );
+    assert_eq!(
+        session.entries.len(),
+        2,
+        "[T-003] FR-016: 2 jsonl lines must yield 2 entries; got: {:?}",
+        session.entries
+    );
+    assert_eq!(session.entries[0].id, "q1");
+    assert_eq!(session.entries[1].id, "q2");
+}
+
+/// Build the `output=` / `annotator_id=` / `session_id=` argv triple for a
+/// reject-path test that does not need to inspect the written file. The
+/// `output=` path resolves under `dir` so the canonicalising
+/// `validate_output_path` parent check passes — without this, every reject
+/// test would fail on argv parsing instead of its intended reject reason.
+fn reject_argv(dir: &Path) -> [String; 3] {
+    let session_path = dir.join("session.json");
+    [
+        format!("output={}", session_path.display()),
+        "annotator_id=thkt".to_owned(),
+        "session_id=s1".to_owned(),
+    ]
+}
+
+// T-005: t005_annotate_empty_stdin_exits_with_usage
+// FR-015: empty stdin → EXIT_USAGE (2) + "annotate: empty session, no entries written";
+//         <output> must NOT be created.
+#[test]
+fn t005_annotate_empty_stdin_exits_with_usage() {
+    let dir = tempdir().expect("tempdir for T-005");
+    let argv = reject_argv(dir.path());
+    let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let session_path = dir.path().join("session.json");
+
+    let output = spawn_annotate(&argv_refs, b"");
+
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_USAGE),
+        "[T-005] empty stdin must exit {EXIT_USAGE}; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("annotate: empty session, no entries written"),
+        "[T-005] FR-015: stderr must mention empty session; got: {stderr}"
+    );
+    assert!(
+        !session_path.exists(),
+        "[T-005] FR-015: empty session must not create output file"
+    );
+}
+
+// T-010: t010_annotate_malformed_json_exits_with_parse_error
+// FR-017: malformed JSON line → EXIT_USAGE (2) + "annotate: line 1 parse error: ..."
+#[test]
+fn t010_annotate_malformed_json_exits_with_parse_error() {
+    let dir = tempdir().expect("tempdir for T-010");
+    let argv = reject_argv(dir.path());
+    let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+
+    let output = spawn_annotate(&argv_refs, b"{not valid json\n");
+
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_USAGE),
+        "[T-010] malformed JSON must exit {EXIT_USAGE}; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("annotate: line 1 parse error"),
+        "[T-010] FR-017: stderr must mention line 1 parse error; got: {stderr}"
+    );
+}
+
+// T-009: t009_annotate_unknown_mode_variant_exits_with_parse_error
+// FR-V004 / FR-017: mode="highlight" (Phase 1.5+ variant) → parse error path
+//   with serde wording mentioning "highlight" or "unknown variant".
+#[test]
+fn t009_annotate_unknown_mode_variant_exits_with_parse_error() {
+    let dir = tempdir().expect("tempdir for T-009");
+    let argv = reject_argv(dir.path());
+    let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let stdin_jsonl = b"{\"id\":\"q1\",\"text\":\"alpha\",\"category\":\"factoid\",\"relevance_map\":{\"d1\":2},\"annotation_note\":\"note\",\"mode\":\"highlight\"}\n";
+
+    let output = spawn_annotate(&argv_refs, stdin_jsonl);
+
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_USAGE),
+        "[T-009] unknown mode must exit {EXIT_USAGE}; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("annotate: line 1 parse error"),
+        "[T-009] FR-V004: stderr must mention line 1 parse error; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("highlight") || stderr.contains("unknown variant"),
+        "[T-009] FR-V004: stderr must mention the unknown variant name; got: {stderr}"
+    );
+}
+
+// T-006: t006_annotate_invalid_category_exits_with_usage
+// FR-V001: category="bogus" (not in 8 allowlist) → EXIT_USAGE (2) +
+//   "annotate: line 1 invalid category" + "bogus" + at least one allowlist
+//   value (e.g. "factoid")
+#[test]
+fn t006_annotate_invalid_category_exits_with_usage() {
+    let dir = tempdir().expect("tempdir for T-006");
+    let argv = reject_argv(dir.path());
+    let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let stdin_jsonl = b"{\"id\":\"q1\",\"text\":\"alpha\",\"category\":\"bogus\",\"relevance_map\":{\"d1\":2},\"annotation_note\":\"note\",\"mode\":\"standard\"}\n";
+
+    let output = spawn_annotate(&argv_refs, stdin_jsonl);
+
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_USAGE),
+        "[T-006] invalid category must exit {EXIT_USAGE}; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("annotate: line 1 invalid category"),
+        "[T-006] FR-V001: stderr must mention line 1 invalid category; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("bogus"),
+        "[T-006] FR-V001: stderr must echo observed value; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("factoid"),
+        "[T-006] FR-V001: stderr must list at least one allowlist value; got: {stderr}"
+    );
+}
+
+// T-007: t007_annotate_grade_above_three_exits_with_usage
+// FR-V002: relevance_map={"d1":99} (grade > 3) → EXIT_USAGE (2) +
+//   "annotate: line 1 invalid grade" + "d1=99"
+#[test]
+fn t007_annotate_grade_above_three_exits_with_usage() {
+    let dir = tempdir().expect("tempdir for T-007");
+    let argv = reject_argv(dir.path());
+    let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let stdin_jsonl = b"{\"id\":\"q1\",\"text\":\"alpha\",\"category\":\"factoid\",\"relevance_map\":{\"d1\":99},\"annotation_note\":\"note\",\"mode\":\"standard\"}\n";
+
+    let output = spawn_annotate(&argv_refs, stdin_jsonl);
+
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_USAGE),
+        "[T-007] grade > 3 must exit {EXIT_USAGE}; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("annotate: line 1 invalid grade"),
+        "[T-007] FR-V002: stderr must mention line 1 invalid grade; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("d1=99"),
+        "[T-007] FR-V002: stderr must echo doc_id=grade; got: {stderr}"
+    );
+}
+
+// T-008: t008_annotate_duplicate_id_exits_with_usage
+// FR-V003: 2 entries with same id → EXIT_USAGE (2) +
+//   "annotate: line 2 duplicate id" + "(first seen on line 1)"
+#[test]
+fn t008_annotate_duplicate_id_exits_with_usage() {
+    let dir = tempdir().expect("tempdir for T-008");
+    let argv = reject_argv(dir.path());
+    let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let stdin_jsonl = b"{\"id\":\"q1\",\"text\":\"alpha\",\"category\":\"factoid\",\"relevance_map\":{\"d1\":2},\"annotation_note\":\"first\",\"mode\":\"standard\"}\n\
+                       {\"id\":\"q1\",\"text\":\"beta\",\"category\":\"howto\",\"relevance_map\":{\"d2\":3},\"annotation_note\":\"second\",\"mode\":\"standard\"}\n";
+
+    let output = spawn_annotate(&argv_refs, stdin_jsonl);
+
+    assert_eq!(
+        output.status.code(),
+        Some(EXIT_USAGE),
+        "[T-008] duplicate id must exit {EXIT_USAGE}; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("annotate: line 2 duplicate id"),
+        "[T-008] FR-V003: stderr must mention line 2 duplicate id; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("first seen on line 1"),
+        "[T-008] FR-V003: stderr must include first-seen line number; got: {stderr}"
+    );
+}
+
+// T-012: t012_eval_query_annotation_and_entry_annotation_note_coexist
+// FR-010 + sub-PR-A FR-005: a happy-path Session whose entry id matches
+//   an existing EvalQuery in queries.jsonl. Both `EvalQuery.annotation`
+//   (existing field, sub-PR-A FR-005) and `Entry.annotation_note`
+//   (sub-PR-A new field) must be readable in shared scope without rename.
+#[test]
+fn t012_eval_query_annotation_and_entry_annotation_note_coexist() {
+    let queries_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/eval/queries.jsonl");
+    let queries: Vec<EvalQuery> = load_queries(&queries_path).expect("load queries.jsonl");
+    let first_query = queries
+        .first()
+        .expect("[T-012] queries.jsonl must have at least one entry");
+
+    let dir = tempdir().expect("tempdir for T-012");
+    let session_path = dir.path().join("session.json");
+    let stdin_jsonl = format!(
+        "{{\"id\":\"{id}\",\"text\":\"alpha\",\"category\":\"factoid\",\
+         \"relevance_map\":{{\"d1\":2}},\"annotation_note\":\"new block-mode note\",\
+         \"mode\":\"standard\"}}\n",
+        id = first_query.id,
+    );
+    let argv = [
+        format!("output={}", session_path.display()),
+        "annotator_id=thkt".to_owned(),
+        "session_id=s1".to_owned(),
+    ];
+    let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+
+    let output = spawn_annotate(&argv_refs, stdin_jsonl.as_bytes());
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "[T-012] happy path must exit 0; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let body = fs::read_to_string(&session_path).expect("[T-012] read session.json");
+    let session: Session = serde_json::from_str(&body).expect("[T-012] deserialise session.json");
+    let entry = session
+        .entries
+        .first()
+        .expect("[T-012] session.entries must be non-empty");
+    assert_eq!(
+        entry.id, first_query.id,
+        "[T-012] Entry.id must mirror EvalQuery.id"
+    );
+    let _eval_annotation: &str = &first_query.annotation;
+    let _entry_annotation_note: &str = &entry.annotation_note;
+    assert_eq!(
+        entry.annotation_note, "new block-mode note",
+        "[T-012] FR-005: Entry.annotation_note must be the new free-form note, \
+         not aliased to EvalQuery.annotation"
+    );
+}

--- a/tests/eval_annotation.rs
+++ b/tests/eval_annotation.rs
@@ -411,3 +411,40 @@ fn t012_eval_query_annotation_and_entry_annotation_note_coexist() {
          not aliased to EvalQuery.annotation"
     );
 }
+
+// T-013: t013_adr_0004_reassessment_triggers_record_llm_provider_path
+// FR-030 / FR-031 / FR-032: ADR-0004 §Reassessment Triggers must mention
+//   "LlmProvider" so sub-PR-D's design step surfaces the assumption
+//   (AS-005). Status header must remain `- Status: proposed` until
+//   sub-PR-C lands. NFR-003 forbids post-cutoff external citations
+//   (`arXiv:2602`, `AIANO`, `ADR-0021`).
+#[test]
+fn t013_adr_0004_reassessment_triggers_record_llm_provider_path() {
+    let adr_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("docs/decisions/0004-annotation-framework.md");
+    let content = fs::read_to_string(&adr_path)
+        .unwrap_or_else(|e| panic!("[T-013] read {}: {e}", adr_path.display()));
+
+    assert!(
+        content.contains("LlmProvider"),
+        "[T-013] FR-030: ADR-0004 must mention LlmProvider in §Reassessment Triggers; \
+         content snapshot:\n{content}"
+    );
+
+    let has_proposed_status = content
+        .lines()
+        .any(|line| line.trim() == "- Status: proposed");
+    assert!(
+        has_proposed_status,
+        "[T-013] FR-031: ADR-0004 Status header must remain `- Status: proposed`; \
+         content snapshot:\n{content}"
+    );
+
+    for forbidden in ["arXiv:2602", "AIANO", "ADR-0021"] {
+        assert!(
+            !content.contains(forbidden),
+            "[T-013] FR-032 / NFR-003: ADR-0004 must not cite {forbidden:?} \
+             (post-cutoff external citation); content snapshot:\n{content}"
+        );
+    }
+}


### PR DESCRIPTION
## 概要

- `eval_harness annotate output=<path> annotator_id=<id> session_id=<id>` subcommand: jsonl stdin から Phase 1 block-mode `Session` JSON を共有 `write_json<T>` helper で capture する。NFR-001 に従い MLX-free (`MLX_DEPENDENT_MODES` から除外)
- Phase 1 / AC-1: generic `write_json<T: Serialize>` を `src/eval/io.rs` に抽出、`BaselineSnapshot` と新規 `Session::write_json` で共有。`serde_json::Error` は `io::Error::other` でラップし、caller は `#[from] io::Error` 1 経路で両方吸収
- Phase 3 / AC-3: ADR-0004 §Reassessment Triggers で sub-PR-D Collaborative mode を `LlmProvider` の `annotation_context` への injection 経路に commit。`EvalContext<E, R>` 流用は §Decision Outcome ¶1 (annotation 側境界の独立進化) に反するため reject。T-013 file-content test で contract を pin

## レビュー時に注意が必要な決定事項

- **`captured_with = "annotate"` (短形式)** — 既存 long-form label (例: `"eval_harness replay-first-search"`) と divergent。Spec FR-020 が短形式を指定しているため verbatim を維持
- **T-004 (TTY reject) は integration ではなく unit test** — `cargo test` lane では stdin を pipe / null として inherit するため、subprocess spawn で `is_terminal() == true` を再現不可能。`check_stdin_tty_guard(bool)` を pure dispatch helper として unit test がカバー、production call site は `io::stdin().is_terminal()` のまま。Spec evolution 2026-05-10
- **`AnnotationError::Serialise` は現状 unreachable** — `serde_json::Error` は `eval::io::write_json` 内で `io::Error::other` にラップされるため `AnnotationError::Io` として surface。Future `Session::read_json` 経路用に variant 保持。Phase 1 で `BaselineError::Serialise` に下した decision と整合
- **ADR-0004 Status は `proposed` のまま** — `accepted` promote は ADR-0003 precedent に従い sub-PR-C land 後の別 PR で実施

## コミット

| Phase | AC | Commit | Deliverable |
| ----- | -- | ------ | ----------- |
| 1 | AC-1 | `3538ece` | `write_json<T>` shared helper |
| 2 | AC-2 | `a9032c4` | `annotate` subcommand + 12 integration tests |
| 3 | AC-3 | `acf07b9` | ADR-0004 §Reassessment Triggers + T-013 |

## テスト計画

- [x] `cargo test --features eval-harness --lib` — 206 pass
- [x] `cargo test --features eval-harness --test eval_annotation` — 12 pass (T-003..T-013)
- [x] `cargo test --features eval-harness --test eval_smoke` — 1 pass / 9 ignored、main と挙動不変
- [x] `cargo clippy --features eval-harness -p amici --lib --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo doc --features eval-harness -p amici --no-deps` — 新規 warning 無し (既存 2 件は本 PR と無関係)
- [ ] Manual smoke (reviewer 推奨): `echo '{"id":"q1","text":"a","category":"factoid","relevance_map":{"d1":2},"annotation_note":"n","mode":"standard"}' | cargo run --features eval-harness --bin eval_harness -- annotate output=/tmp/s.json annotator_id=t session_id=s` で `annotate: wrote /tmp/s.json (1 entries)` を出力

Closes #53.