### PR TITLE
refactor(eval): replay-first-search で LazyReranker を採用 (Closes #68)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,7 +1906,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=e44fefe#e44fefe59a33e25ce443478ea06cdddbc281d88c"
+source = "git+https://github.com/thkt/rurico?rev=73c5b69#73c5b691e341e4068f04ec75a72cbf79208ca856"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -1926,7 +1926,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=e44fefe#e44fefe59a33e25ce443478ea06cdddbc281d88c"
+source = "git+https://github.com/thkt/rurico?rev=73c5b69#73c5b691e341e4068f04ec75a72cbf79208ca856"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ required-features = ["eval-harness"]
 bytemuck           = "1"
 rand               = "0.10"
 rand_chacha        = "0.10"
-rurico             = { git = "https://github.com/thkt/rurico", rev = "e44fefe" }
+rurico             = { git = "https://github.com/thkt/rurico", rev = "73c5b69" }
 rusqlite           = { version = "0.39", features = ["bundled"] }
 serde              = { version = "1", features = ["derive"] }
 serde_json         = "1"
@@ -29,7 +29,7 @@ tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico      = { git = "https://github.com/thkt/rurico", rev = "e44fefe", features = ["test-support"] }
+rurico      = { git = "https://github.com/thkt/rurico", rev = "73c5b69", features = ["test-support"] }
 serial_test = "3"
 tempfile    = "3"
 

--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -61,15 +61,12 @@ use rurico::{embed, reranker};
 
 /// Mock-friendly bundle of every external seam the four mode handlers touch.
 ///
-/// Generic over the embedder and reranker types so production wiring uses
-/// `embed::Embedder` plus `LazyReranker<reranker::Reranker>` — the rerank
-/// model only loads on the first method call, letting modes that never
-/// rerank (e.g. `replay-first-search`,
-/// `verify-baseline kind=first_search_replay`) skip the load entirely.
-/// Tests can swap in `MockEmbedder` / `MockReranker` (or wrap a
-/// `MockReranker` in `LazyReranker` when verifying lazy semantics). The
-/// `timestamp` closure isolates `SystemTime::now()` from the snapshot-write
-/// code path so tests can fix a deterministic capture-time label.
+/// Tests swap in `MockEmbedder` / `MockReranker`, or wrap `MockReranker`
+/// in `LazyReranker` when verifying lazy semantics (see
+/// `replay_first_search_skips_reranker_init`). The `timestamp` closure
+/// isolates `SystemTime::now()` from the snapshot-write code path so tests
+/// can fix a deterministic capture-time label. Production wiring lives in
+/// [`production_context`].
 struct EvalContext<E: Embed, R: Rerank> {
     /// Directory holding `documents.jsonl`, `queries.jsonl`, and
     /// `known_answers.jsonl`. Production uses `tests/fixtures/eval/` under
@@ -83,11 +80,10 @@ struct EvalContext<E: Embed, R: Rerank> {
     timestamp: Box<dyn Fn() -> String>,
 }
 
-/// Build the production [`EvalContext`] — loads the cached MLX embedder
-/// eagerly and wires a [`LazyReranker`] so the rerank model is only
-/// fetched on the first call. Modes that never rerank
+/// Build the production [`EvalContext`]. The embedder loads up front; the
+/// reranker is wrapped in [`LazyReranker`] so modes that never rerank
 /// (`replay-first-search`, `verify-baseline kind=first_search_replay`)
-/// avoid the cache/download/load cost entirely (ADR-0005 / Issue #68).
+/// skip the cache/download/load cost entirely (ADR-0005 / Issue #68).
 fn production_context()
 -> Result<EvalContext<embed::Embedder, LazyReranker<reranker::Reranker>>, String> {
     let embedder = init_embedder()?;
@@ -2214,18 +2210,9 @@ mod tests {
 
     // ── Issue #62 / Phase 2.3 — replay-first-search subcommand + verify-baseline 拡張 ──
 
-    // T-068-001: replay_first_search_skips_reranker_init
-    //
-    // ADR-0005 / Issue #68: production_context wraps the reranker in
-    // LazyReranker so modes that never call rerank skip the model-load
-    // cost. Drives run_replay_first_search_with against the committed
-    // fixture with a counting init closure; asserts (a) the snapshot was
-    // written with kind=FirstSearchReplay so the full pipeline executed,
-    // and (b) the init closure was never invoked.
+    // T-068-001: ADR-0005 — LazyReranker init must not fire when only the replay path runs.
     #[test]
     fn replay_first_search_skips_reranker_init() {
-        use std::fs::File;
-        use std::io::BufReader;
         use std::sync::Arc;
         use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -2238,10 +2225,12 @@ mod tests {
         let output_path = dir.path().join("replay.json");
 
         let init_calls = Arc::new(AtomicUsize::new(0));
-        let counter = Arc::clone(&init_calls);
-        let reranker = LazyReranker::<MockReranker>::new(move || {
-            counter.fetch_add(1, Ordering::SeqCst);
-            Ok(MockReranker::default())
+        let reranker = LazyReranker::new({
+            let init_calls = Arc::clone(&init_calls);
+            move || {
+                init_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(MockReranker::default())
+            }
         });
 
         let ctx = EvalContext {
@@ -2255,11 +2244,7 @@ mod tests {
         let normalization = QueryNormalizationConfig::default();
         let _exit = run_replay_first_search_with(&ctx, &output_path, &merge_config, &normalization);
 
-        let snapshot: BaselineSnapshot = serde_json::from_reader(BufReader::new(
-            File::open(&output_path)
-                .unwrap_or_else(|e| panic!("T-068-001: replay output not written: {e}")),
-        ))
-        .expect("T-068-001: replay output must deserialize as BaselineSnapshot");
+        let snapshot = read_snapshot(&output_path).unwrap_or_else(|e| panic!("T-068-001: {e}"));
         assert_eq!(
             snapshot.kind,
             BaselineKind::FirstSearchReplay,

--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -50,7 +50,7 @@ use amici::eval::pipeline::{
     evaluate_first_search_replay,
 };
 use rurico::embed::Embed;
-use rurico::reranker::Rerank;
+use rurico::reranker::{LazyReranker, Rerank};
 use rurico::retrieval::{
     CandidateSource, DedupeAggregator, HybridSearchConfig, IdentityAggregator, MaxChunkAggregator,
     MergedHit, TopKAverageAggregator,
@@ -62,10 +62,14 @@ use rurico::{embed, reranker};
 /// Mock-friendly bundle of every external seam the four mode handlers touch.
 ///
 /// Generic over the embedder and reranker types so production wiring uses
-/// concrete `embed::Embedder` / `reranker::Reranker` while tests can swap
-/// in `MockEmbedder` / `MockReranker`. The `timestamp` closure isolates
-/// `SystemTime::now()` from the snapshot-write code path so tests can fix a
-/// deterministic capture-time label.
+/// `embed::Embedder` plus `LazyReranker<reranker::Reranker>` — the rerank
+/// model only loads on the first method call, letting modes that never
+/// rerank (e.g. `replay-first-search`,
+/// `verify-baseline kind=first_search_replay`) skip the load entirely.
+/// Tests can swap in `MockEmbedder` / `MockReranker` (or wrap a
+/// `MockReranker` in `LazyReranker` when verifying lazy semantics). The
+/// `timestamp` closure isolates `SystemTime::now()` from the snapshot-write
+/// code path so tests can fix a deterministic capture-time label.
 struct EvalContext<E: Embed, R: Rerank> {
     /// Directory holding `documents.jsonl`, `queries.jsonl`, and
     /// `known_answers.jsonl`. Production uses `tests/fixtures/eval/` under
@@ -79,11 +83,15 @@ struct EvalContext<E: Embed, R: Rerank> {
     timestamp: Box<dyn Fn() -> String>,
 }
 
-/// Build the production [`EvalContext`] — loads the cached MLX models and
-/// resolves the fixture directory under the crate manifest.
-fn production_context() -> Result<EvalContext<embed::Embedder, reranker::Reranker>, String> {
+/// Build the production [`EvalContext`] — loads the cached MLX embedder
+/// eagerly and wires a [`LazyReranker`] so the rerank model is only
+/// fetched on the first call. Modes that never rerank
+/// (`replay-first-search`, `verify-baseline kind=first_search_replay`)
+/// avoid the cache/download/load cost entirely (ADR-0005 / Issue #68).
+fn production_context()
+-> Result<EvalContext<embed::Embedder, LazyReranker<reranker::Reranker>>, String> {
     let embedder = init_embedder()?;
-    let reranker = init_reranker()?;
+    let reranker = LazyReranker::new(init_reranker);
     Ok(EvalContext {
         fixture_dir: Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/eval"),
         embedder,
@@ -2205,6 +2213,64 @@ mod tests {
     }
 
     // ── Issue #62 / Phase 2.3 — replay-first-search subcommand + verify-baseline 拡張 ──
+
+    // T-068-001: replay_first_search_skips_reranker_init
+    //
+    // ADR-0005 / Issue #68: production_context wraps the reranker in
+    // LazyReranker so modes that never call rerank skip the model-load
+    // cost. Drives run_replay_first_search_with against the committed
+    // fixture with a counting init closure; asserts (a) the snapshot was
+    // written with kind=FirstSearchReplay so the full pipeline executed,
+    // and (b) the init closure was never invoked.
+    #[test]
+    fn replay_first_search_skips_reranker_init() {
+        use std::fs::File;
+        use std::io::BufReader;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use rurico::embed::MockEmbedder;
+        use rurico::reranker::MockReranker;
+        use tempfile::tempdir;
+
+        let dir = tempdir().expect("tempdir for replay output");
+        let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/eval");
+        let output_path = dir.path().join("replay.json");
+
+        let init_calls = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&init_calls);
+        let reranker = LazyReranker::<MockReranker>::new(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Ok(MockReranker::default())
+        });
+
+        let ctx = EvalContext {
+            fixture_dir,
+            embedder: MockEmbedder::default(),
+            reranker,
+            timestamp: Box::new(|| "epoch:0".to_owned()),
+        };
+
+        let merge_config = HybridSearchConfig::default();
+        let normalization = QueryNormalizationConfig::default();
+        let _exit = run_replay_first_search_with(&ctx, &output_path, &merge_config, &normalization);
+
+        let snapshot: BaselineSnapshot = serde_json::from_reader(BufReader::new(
+            File::open(&output_path)
+                .unwrap_or_else(|e| panic!("T-068-001: replay output not written: {e}")),
+        ))
+        .expect("T-068-001: replay output must deserialize as BaselineSnapshot");
+        assert_eq!(
+            snapshot.kind,
+            BaselineKind::FirstSearchReplay,
+            "T-068-001: snapshot kind must be FirstSearchReplay (proves pipeline ran)"
+        );
+        assert_eq!(
+            init_calls.load(Ordering::SeqCst),
+            0,
+            "T-068-001: replay-first-search must not invoke the reranker init closure"
+        );
+    }
 
     /// Build a BaselineSnapshot with the requested schema/kind so envelope
     /// validation tests don't drag in MockEmbedder + fixture setup.


### PR DESCRIPTION
## 概要

ADR-0005 (PR #72) / rurico #154 を踏まえて、eval_harness の `production_context` を
`EvalContext<embed::Embedder, LazyReranker<reranker::Reranker>>` に置き換えた。
reranker モデルロードを初回 rerank 呼び出しまで遅延させることで、
`replay-first-search` と `verify-baseline kind=first_search_replay` は
cache lookup / download / load コストを完全に skip する。

## 変更点

- `chore(deps)`: rurico を `73c5b69` に bump (LazyReranker + `RerankerError::InitFailed` を取り込み)
- `refactor(eval)`: `production_context()` を `LazyReranker::new(init_reranker)` でラップ。`EvalContext` / `production_context` の docstring 更新
- `T-068-001` `replay_first_search_skips_reranker_init`: committed fixture に対して `run_replay_first_search_with` を回し、init closure が呼ばれず snapshot が `kind=FirstSearchReplay` で書かれることを end-to-end で検証
- polish 反映 (codex / coderabbit / reviewer-reuse / reviewer-readability / reviewer-efficiency / enhancer-code): docstring トリム + `read_snapshot` ヘルパ再利用 + `std::fs::File` / `std::io::BufReader` import 削減

## テスト計画

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --features eval-harness -- -D warnings` clean
- [x] `cargo test --features eval-harness` 25/25 pass (ignored 9 件は MLX 必須の smoke)
- [x] `cargo test replay_first_search_skips_reranker_init` 単体 pass

## 関連

- Closes #68
- ADR-0005 (PR #72) の決定に基づく実装
- rurico #154 で追加された `LazyReranker<R>` / `RerankerError::InitFailed` を利用