### PR TITLE
未使用 serial_test を削除し rurico rev を b4f27da に更新

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,13 +1905,11 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=73c5b69#73c5b691e341e4068f04ec75a72cbf79208ca856"
+source = "git+https://github.com/thkt/rurico?rev=b4f27da#b4f27dae11965dd4fe1f0041425745cdbcb2e38e"
 dependencies = [
  "bytemuck",
  "hf-hub",
  "mlx-rs",
- "rand 0.10.1",
- "rand_chacha 0.10.0",
  "rurico-ffi",
  "rusqlite",
  "serde",
@@ -1925,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=73c5b69#73c5b691e341e4068f04ec75a72cbf79208ca856"
+source = "git+https://github.com/thkt/rurico?rev=b4f27da#b4f27dae11965dd4fe1f0041425745cdbcb2e38e"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,6 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "serial_test",
  "tempfile",
  "thiserror",
  "tracing",
@@ -2015,15 +2014,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2037,12 +2027,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -2126,32 +2110,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serial_test"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
-dependencies = [
- "futures-executor",
- "futures-util",
- "log",
- "once_cell",
- "parking_lot",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3274,9 +3232,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ required-features = ["eval-harness"]
 bytemuck           = "1"
 rand               = "0.10"
 rand_chacha        = "0.10"
-rurico             = { git = "https://github.com/thkt/rurico", rev = "73c5b69" }
+rurico             = { git = "https://github.com/thkt/rurico", rev = "b4f27da" }
 rusqlite           = { version = "0.39", features = ["bundled"] }
 serde              = { version = "1", features = ["derive"] }
 serde_json         = "1"
@@ -29,7 +29,7 @@ tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico   = { git = "https://github.com/thkt/rurico", rev = "73c5b69", features = ["test-support"] }
+rurico   = { git = "https://github.com/thkt/rurico", rev = "b4f27da", features = ["test-support"] }
 tempfile = "3"
 
 [lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,8 @@ tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico      = { git = "https://github.com/thkt/rurico", rev = "73c5b69", features = ["test-support"] }
-serial_test = "3"
-tempfile    = "3"
+rurico   = { git = "https://github.com/thkt/rurico", rev = "73c5b69", features = ["test-support"] }
+tempfile = "3"
 
 [lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
## What & Why

依存関係の整理 2 件をまとめた PR。`cargo-machete` だけでは見落とされた未使用 dev-dep の削除と、rurico main HEAD への追従を実施。

- **serial_test 削除**: `cargo-machete` は「未使用なし」と返したが、`ugrep` で全 `.rs` を cross-check したところ `serial_test` / `#[serial]` / `use serial_test` の参照が一切ないことを確認（machete の false negative）。
- **rurico rev bump**: rurico 側で `chore(deps): remove unused rand and rand_chacha` (PR #156) が merge されたため amici も追従。public API 変更なし。

## Changes

- `[dev-dependencies]` から `serial_test = "3"` を削除（コミット `9f6b463`）。Cargo.lock の transitive 削除: `scc 2.4.0`, `sdd 3.0.10`, `serial_test 3.4.0`, `serial_test_derive`。
- `rurico` の git rev を `73c5b69` → `b4f27da` に更新（コミット `c21875e`）。`[dependencies]` と `[dev-dependencies]` の 2 箇所。
- Cargo.lock には main から持ち越した無関係な `zerofrom 0.1.7 → 0.1.8` の transitive bump も含む（コミット `9f6b463` 本文で明示）。

## Scope

- **Not included**: 下流 (sae / recall / yomu) の rurico rev 追従は別セッションで対応（memory 方針「PR merge 後の整理は amici 単体で完結」に従う）。
- **Not included**: amici 自身が direct 使用している `rand` / `rand_chacha` は今回維持（`src/bin/eval_harness.rs`, `src/eval/metrics.rs` で直接 import）。

## Design Decisions

- **`cargo-machete` を盲信しない**: 今回 machete が `serial_test` を見落としたため、検出ゼロでも `ugrep` で全 `.rs` への参照件数を確認するフローが有効だった。次回以降の `chore(deps)` 系作業でも cross-check 推奨。
- **2 commit を 1 PR にまとめる**: ブランチ名 `chore/remove-unused-serial-test` は serial_test 削除に特化しているが、rurico bump も同一ブランチに同梱（ユーザー判断）。スコープは異なるが、いずれも軽量な `chore(deps)` で同時レビューしてもコスト低い。

## How to Test

1. `git fetch && git checkout chore/remove-unused-serial-test`
2. `cargo check --all-targets --all-features` → `Finished` で clean 終了することを確認
3. `cargo machete` → `didn't find any unused dependencies. Good job!` を確認
4. `cargo test --lib` (任意) → 既存ライブラリテストが通ることを確認
5. `Cargo.lock` の rurico source が `git+https://github.com/thkt/rurico?rev=b4f27da#b4f27dae...` になっていることを確認
