### PR TITLE
feat(cli): UNKNOWN exit code と INTERNAL alias を追加 (ADR-0066 Group 2 共通基盤)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,27 @@ can write deterministic retry logic.
 > CI pipelines, and parent processes that branch on a specific number must
 > be updated. Announce the change in the CLI's release notes.
 
+#### Group 2 baseline (ADR-0066)
+
+ADR-0066 partitions the CLI suite into three groups by error topology and
+assigns each group a shared exit-code baseline. amici is the baseline for
+**Group 2 — local semantic search** (sae / yomu / recall / rurico).
+Downstream CLIs alias `amici::cli::exit_code::codes` so classification stays
+consistent across the group, and a metrics dashboard tracking the rate of
+`UNKNOWN` (104) can detect `anyhow::Error` swallowing or unclassified
+failures from a single value regardless of which Group 2 CLI emitted it.
+
+The `codes` module exposes two source ranges side-by-side:
+
+| Range  | Source                             | Codes                                                    |
+| ------ | ---------------------------------- | -------------------------------------------------------- |
+| 64–78  | sysexits.h                         | `USAGE`, `SOFTWARE`, `CANT_CREAT`, `IO_ERR`, `TEMP_FAIL` |
+| 80–119 | Project extension range (ADR-0066) | `UNKNOWN` (104)                                          |
+
+`codes::INTERNAL` is provided as an alias for `SOFTWARE` so call sites can use
+the name that ADR-0066's classification table uses — the numeric value is
+unchanged (70 = `EX_SOFTWARE`).
+
 ### Oracle mode
 
 > Requires the `eval-harness` Cargo feature.

--- a/src/cli/exit_code.rs
+++ b/src/cli/exit_code.rs
@@ -3,13 +3,31 @@
 //! Provides:
 //! - [`CliError`] trait — implement on the crate-level `Error` enum so
 //!   `main.rs` can call `e.exit_code()` directly.
-//! - [`codes`] module — `u8` constants for the
-//!   [sysexits.h](https://man.openbsd.org/sysexits.3) convention. Wrap with
-//!   `ExitCode::from(codes::USAGE)` at the call site (see *Why `u8`* below).
+//! - [`codes`] module — `u8` constants from two sources, kept side-by-side
+//!   so call sites do not need to import from two places:
+//!   1. [sysexits.h](https://man.openbsd.org/sysexits.3) (64–78). Standard
+//!      Unix exit categories — `USAGE`, `SOFTWARE`, `CANT_CREAT`, `IO_ERR`,
+//!      `TEMP_FAIL`.
+//!   2. Project extension range (80–119). Assigned per ADR-0066 when no
+//!      sysexits variant fits. Currently: `UNKNOWN` (104).
+//!
+//! Wrap with `ExitCode::from(codes::USAGE)` at the call site (see
+//! *Why `u8`* below).
 //!
 //! These are **convention, not enforcement**. Each CLI is free to pick any
 //! distinct schema — the requirement is only "distinct codes per error variant
 //! so LLMs / scripts can branch on retry policy".
+//!
+//! # Group 2 baseline (ADR-0066)
+//!
+//! ADR-0066 partitions the CLI suite into three groups by error topology and
+//! assigns each group a shared exit-code baseline. This crate is the baseline
+//! for **Group 2 — local semantic search** (sae / yomu / recall / rurico).
+//! Downstream CLIs alias `amici::cli::exit_code::codes` so classification
+//! stays consistent across the group: a metrics dashboard tracking the rate
+//! of `UNKNOWN` (104) can pivot on a single value to detect `anyhow::Error`
+//! swallowing or unclassified failures regardless of which Group 2 CLI emitted
+//! the code.
 //!
 //! # Why `u8` rather than `ExitCode` constants
 //!
@@ -24,6 +42,7 @@
 //! enum MyError {
 //!     BadArgs,
 //!     IoFailure,
+//!     Other,
 //! }
 //!
 //! impl CliError for MyError {
@@ -31,6 +50,7 @@
 //!         match self {
 //!             MyError::BadArgs => ExitCode::from(codes::USAGE),
 //!             MyError::IoFailure => ExitCode::from(codes::IO_ERR),
+//!             MyError::Other => ExitCode::from(codes::UNKNOWN), // PJ extension (ADR-0066)
 //!         }
 //!     }
 //! }
@@ -49,12 +69,16 @@ pub trait CliError {
     fn exit_code(&self) -> ExitCode;
 }
 
-/// `sysexits.h`-derived `u8` exit-code constants.
+/// `u8` exit-code constants from sysexits.h plus the ADR-0066 project
+/// extension range.
 ///
 /// Convert with `ExitCode::from(codes::CONST)` — see the module doc for why
 /// these are `u8` rather than `ExitCode`.
 pub mod codes {
-    /// Successful termination.
+    // ── sysexits.h (64–78) ──
+    // Source: https://man.openbsd.org/sysexits.3
+
+    /// Successful termination (`EX_OK`).
     pub const SUCCESS: u8 = 0;
     /// `EX_USAGE`. Bad command-line usage (missing arg, unknown flag, etc.).
     pub const USAGE: u8 = 64;
@@ -67,6 +91,21 @@ pub mod codes {
     /// `EX_TEMPFAIL`. Transient failure — retry may succeed (downloads,
     /// optional models unavailable, etc.).
     pub const TEMP_FAIL: u8 = 75;
+
+    // ── Project extension range (80–119) ──
+    // Source: ADR-0066. Assigned when no sysexits.h variant fits.
+
+    /// Classification fallback. Emit when an error cannot be mapped to any
+    /// sysexits variant. An increase in this code's rate signals that the
+    /// classification design needs review (typically an `anyhow::Error` path
+    /// that should be promoted to a typed variant).
+    pub const UNKNOWN: u8 = 104;
+
+    /// Alias for [`SOFTWARE`]. Provided so call sites can use the
+    /// `INTERNAL` name that ADR-0066's classification table uses, keeping
+    /// the table-vs-implementation diff trivial. Numerically identical to
+    /// `EX_SOFTWARE` (70).
+    pub const INTERNAL: u8 = SOFTWARE;
 }
 
 #[cfg(test)]
@@ -75,7 +114,9 @@ mod tests {
 
     // sysexits.h reference values pinned here so a future refactor that
     // touches `codes::*` fails visibly instead of silently breaking
-    // downstream CLIs that depend on these numbers.
+    // downstream CLIs that depend on these numbers. Project-extension-range
+    // codes (UNKNOWN, INTERNAL) live in a separate test so a reader can tell
+    // sysexits-derived codes from project extensions by which test owns them.
 
     // T-122: codes_match_sysexits_constants
     #[test]
@@ -86,5 +127,17 @@ mod tests {
         assert_eq!(codes::CANT_CREAT, 73);
         assert_eq!(codes::IO_ERR, 74);
         assert_eq!(codes::TEMP_FAIL, 75);
+    }
+
+    // T-123: codes_match_pj_extension_constants
+    #[test]
+    fn codes_match_pj_extension_constants() {
+        // PJ extension range (80–119), per ADR-0066.
+        assert_eq!(codes::UNKNOWN, 104);
+
+        // INTERNAL is an alias for SOFTWARE; pin both that it resolves to
+        // the same constant and that the numeric value is EX_SOFTWARE (70).
+        assert_eq!(codes::INTERNAL, codes::SOFTWARE);
+        assert_eq!(codes::INTERNAL, 70);
     }
 }


### PR DESCRIPTION
## 概要

- `codes::UNKNOWN = 104` を追加 (project extension range, ADR-0066)。sysexits.h のどの variant にも当てはまらないエラーの分類フォールバック。
- `codes::INTERNAL` を `SOFTWARE` への alias として追加。ADR-0066 の分類テーブルが使う名称と call site を揃え、table と実装の照合を容易化。
- 新規 `T-123: codes_match_pj_extension_constants` で両方を pin。`T-122` は sysexits 専用に維持し、テスト名から出典 (sysexits か PJ 拡張枠か) が分かる構造に。
- amici を Group 2 (local semantic search: sae / yomu / recall / rurico) の共通基盤として module rustdoc と README に位置付けを記述。

## 検証

- [x] `cargo test --all-features` — 135 unit + 18 doctests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] T-122 (sysexits constants) regression check unchanged
- [x] T-123 (PJ extension constants) new pin passes

Closes #76