### PR TITLE
docs(rustdoc): Option フィルタ規約 / replay ガード / DegradedReason 規律を明文化

### DIFF
--- a/src/eval/pipeline.rs
+++ b/src/eval/pipeline.rs
@@ -193,6 +193,18 @@ where
 /// is fixed to [`MaxChunkAggregator`] — ranking-aware aggregators (e.g.
 /// [`IdentityAggregator`]) are not selectable.
 ///
+/// # Do not DRY-merge with [`evaluate`]
+///
+/// The separate signature **is** the FR-008 / FR-010 guard: a refactor that
+/// adds `Option<&R>` reranker / `Option<&A>` aggregator parameters to fold
+/// this fn into [`evaluate`] silently breaks the compile-time guarantee
+/// that the replay path never invokes rerank or a ranking-aware aggregator.
+/// The runtime behaviour would still pass every existing test (passing
+/// `None` matches the current shape), so the regression is invisible until
+/// a caller threads through `Some(reranker)` by mistake. Keep the two
+/// entry points distinct; share helpers via [`run_stage1_plus_2`] and
+/// [`setup_pipeline_connection`] instead.
+///
 /// # Errors
 ///
 /// See [`PipelineError`] variants — same surface as [`evaluate`] minus

--- a/src/model.rs
+++ b/src/model.rs
@@ -66,6 +66,16 @@ pub fn degraded_reason_user_note(reason: DegradedReason) -> Option<&'static str>
 /// The structured warn event carries `error`, `reason`, and `context` fields
 /// with the message `"operation degraded"`.
 ///
+/// # Anti-pattern
+///
+/// Never collapse a typed error to a [`DegradedReason`] with a bare
+/// `.map_err(|_| DegradedReason::X)`: the underlying cause is dropped from
+/// the warn event, so log consumers cannot tell `EmbedError::Backend` apart
+/// from a cache-lookup permission error once both arrive as `ProbeFailed`.
+/// PR review will not flag the regression because the function's return
+/// type is unchanged. Always route the conversion through this helper (or
+/// [`record_degraded`] when there is no underlying error to preserve).
+///
 /// # Examples
 ///
 /// ```no_run
@@ -96,6 +106,14 @@ pub fn degrade_with_warn<E: fmt::Display>(
 ///
 /// The structured warn event carries `reason` and `context` fields with the
 /// message `"operation degraded"`.
+///
+/// # Anti-pattern
+///
+/// Do not pre-collapse a `Result<_, OtherError>` to a [`DegradedReason`]
+/// via `.map_err(|_| DegradedReason::X)` and then call this fn — the
+/// `error` field that would let log consumers diagnose the cause is gone
+/// before the warn event is emitted. Use [`degrade_with_warn`] inside the
+/// `map_err` so the original error stays in the structured log.
 ///
 /// # Examples
 ///
@@ -129,6 +147,17 @@ pub enum ModelLoad<T> {
     #[default]
     Absent,
     /// The model could not be loaded. The `String` contains a human-readable error message.
+    ///
+    /// # Stability
+    ///
+    /// The erasure to `String` is deliberate — the source error type
+    /// ([`ModelDownloadError`], `ModelInitError`, or a probe failure) is
+    /// flattened so callers can render the message without knowing the
+    /// originating layer. Downstream CLIs (sae / yomu / recall) surface this
+    /// string verbatim to the user via [`Self::emit_load_hint`], so the
+    /// wording is part of the user-visible API surface. Changing the message
+    /// shape is a behaviour change for every downstream consumer, not an
+    /// internal log refactor.
     Failed(String),
 }
 
@@ -209,6 +238,14 @@ impl Error for ModelDownloadError {}
 /// Shows a spinner on stderr during download and probe phases.
 ///
 /// # Prerequisites
+///
+/// "Verify" here means **probe-load**: after the download, the fn calls
+/// [`Embedder::probe`] and [`Embedder::new`] to confirm the artifacts
+/// actually load on this machine. It is **not** a content-hash check —
+/// artifact integrity is delegated to `rurico::embed::download_model`,
+/// whose own checksum step runs before this fn's post-download probe. A
+/// successful return guarantees "the model loads here and now", not
+/// "the downloaded bytes match the registry manifest".
 ///
 /// The calling binary must invoke `rurico::handle_probe_if_needed()`
 /// at the very start of `main()`. Without it, the post-download probe returns

--- a/src/storage/filter.rs
+++ b/src/storage/filter.rs
@@ -4,6 +4,21 @@
 //! `params: &mut Vec<Box<dyn ToSql>>`, appending an `AND`-prefixed predicate
 //! that relies on the caller's base clause (typically `WHERE 1 = 1`).
 //!
+//! # Filter contract
+//!
+//! `Option<T>`-receiving helpers split the empty-input case explicitly:
+//!
+//! - `None` → no-op (the caller did not request this filter).
+//! - `Some(empty)` → `" AND 1 = 0"` (the caller asked for "match nothing").
+//! - `Some(non-empty)` → the normal predicate.
+//!
+//! Helpers receiving a plain non-`Option` collection (e.g. `&HashSet`) treat
+//! an empty collection as no-op, because "exclude nothing" or "no LIKE
+//! pattern" is the only sensible reading at that call site. New helpers must
+//! follow the same split before adding new variants — silently picking a
+//! different convention would let callers conflate "no filter" with "match
+//! nothing".
+//!
 //! # Security
 //!
 //! All `column` parameters are `&'static str`. The compiler rejects runtime


### PR DESCRIPTION
## 概要

Issue #81 の Comment fixes 5 件を 1 PR で land。3 ファイル、+64 lines、behavior 変更ゼロ (rustdoc 追記のみ)。

critic-design challenge で「ADR より rustdoc 強化が適切」と判定された項目群を実装。silent drift / silent collapse / silent contract violation を PR レビューで気付ける形に明文化する。

## 変更内容

| # | File | Item |
| - | ---- | ---- |
| 1 | `src/storage/filter.rs` | module-doc に `# Filter contract` 追加 (`None=no-op` / `Some(empty)=1=0` を module-wide rule 化) |
| 2 | `src/eval/pipeline.rs::evaluate_first_search_replay` | `# Do not DRY-merge with evaluate` 警告追加 (FR-008/FR-010 compile-time guard 保護) |
| 3 | `src/model.rs::ModelLoad::Failed` | `# Stability` note 追加 (message wording は user-visible API) |
| 4 | `src/model.rs::degrade_with_warn` / `record_degraded` | `# Anti-pattern` セクション追加 (`bare .map_err(\|_\| Reason::X)` 禁止) |
| 5 | `src/model.rs::download_and_verify_model` | `# Prerequisites` 補強 (verify=probe-load, hash check は rurico に delegate) |

## テスト計画

- [x] `cargo fmt --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo doc --no-deps` 通過 (warning 新規追加なし)
- [x] `cargo test --lib` 通過 (135 passed / 0 failed)
- [x] `cargo test --doc` 通過 (18 passed / 0 failed)

## 対象外

- Issue #81 の Code-system fixes (items 6-10): 型/lint 強化系。別 PR で順次対応。
- Issue #80 (bug-fix investigation): exit code 矛盾の調査、別 issue で進行。

## 参考

- Issue: #81 (Comment fixes 1-5 of 5)
- Audit: `docs/audit/2026-05-14-undocumented-decisions.md` § Recommended Follow-up Issues #3-#7
