### PR TITLE
docs(audit): comment fixes 1-5 完了を PR #82 で反映

### DIFF
--- a/docs/audit/2026-05-14-undocumented-decisions.md
+++ b/docs/audit/2026-05-14-undocumented-decisions.md
@@ -224,11 +224,13 @@ Per-file summary: `keep 2 / downgrade 5 / drop 8 / bug-fix 1 (eval_harness.rs)`.
 
 ### Documentation/comment fixes (no ADR)
 
-3. `src/storage/filter.rs` module doc → add `# Filter contract` paragraph covering `Option<>` `None=no-op / Some(empty)=1=0` rule.
-4. `src/eval/pipeline.rs::evaluate_first_search_replay` docstring → add "do not DRY-merge with `evaluate`; the signature is the FR-008/010 compile-time guard".
-5. `src/model.rs::ModelLoad::Failed` rustdoc → add `# Stability` note on stringly-typed payload + downstream UX coupling.
-6. `src/model.rs::degrade_with_warn` rustdoc → add `# Examples` warning "never collapse with bare `.map_err(|_| Reason::X)`".
-7. `src/model.rs::download_and_verify_model` rustdoc → add to `# Prerequisites` "verify means probe-load; hash check is delegated to rurico".
+Status: all 5 items landed via [PR #82](https://github.com/thkt/amici/pull/82) (merged 2026-05-14, tracked in issue #81).
+
+3. `src/storage/filter.rs` module doc → add `# Filter contract` paragraph covering `Option<>` `None=no-op / Some(empty)=1=0` rule. — done (PR #82).
+4. `src/eval/pipeline.rs::evaluate_first_search_replay` docstring → add "do not DRY-merge with `evaluate`; the signature is the FR-008/010 compile-time guard". — done (PR #82).
+5. `src/model.rs::ModelLoad::Failed` rustdoc → add `# Stability` note on stringly-typed payload + downstream UX coupling. — done (PR #82).
+6. `src/model.rs::degrade_with_warn` rustdoc → add `# Examples` warning "never collapse with bare `.map_err(|_| Reason::X)`". — done (PR #82, covers `record_degraded` as well).
+7. `src/model.rs::download_and_verify_model` rustdoc → add to `# Prerequisites` "verify means probe-load; hash check is delegated to rurico". — done (PR #82).
 
 ### Code fixes (type-system / lint)
 


### PR DESCRIPTION
## 概要

Issue #81 acceptance criteria 2/3 (audit report に各項目の PR リンク追記) を満たす単発の進捗反映。

`docs/audit/2026-05-14-undocumented-decisions.md` の Documentation/comment fixes セクション (items 3-7) に PR #82 (merged 2026-05-14) のリンクを追加。

## 変更内容

- `docs/audit/2026-05-14-undocumented-decisions.md` の `### Documentation/comment fixes (no ADR)` に "Status: all 5 items landed via PR #82" 行を追加
- 各 item 末尾に `— done (PR #82)` 追記。item 6 は `record_degraded` も併せてカバーしている旨を併記。

## テスト計画

- [x] Markdown のみの変更。code-affecting なし
- [x] `git diff --stat`: 1 file changed, 7 insertions(+), 5 deletions(-)

## 残課題

- Code fixes (items 8-12): Issue #81 で継続トラッキング、別 PR 予定
- Bug investigation (item 13): Issue #80 で継続

## 参考

- Issue: #81
- Comment fixes PR: #82
