### PR TITLE
fix(eval-harness): EXIT_* と codes::* baseline の divergence を comment で明示

### DIFF
--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -145,6 +145,19 @@ const VALID_AGGREGATION_KINDS: &[&str] = &["identity", "max-chunk", "dedupe", "t
 /// chunks per document" framing without needing a flag for first capture.
 const DEFAULT_TOPK_AVERAGE_K: usize = 3;
 
+// The 1 / 2 / 3 codes below intentionally diverge from the `codes::*`
+// baseline ([`amici::cli::exit_code::codes`], sysexits 64 / 70 / 75 per
+// ADR-0066). That baseline targets downstream Group 2 *production* CLIs
+// (sae / yomu / recall); `eval_harness` is internal evaluation tooling
+// invoked through `just eval-*` recipes, not a downstream consumer.
+//
+// `EXIT_REGRESSION = 1` is documented as the public gate signal for
+// `oracle-gap` in ADR-0002 § Decision Outcome, and `tests/eval_annotation.rs`
+// adopts the same scheme for the `annotate` subcommand. Promoting these to
+// `codes::*` would force an ADR-0002 revision plus a breaking-change
+// announcement to every `justfile` recipe user that observes the exit
+// status, so the divergence is preserved deliberately.
+
 /// Exit code for a metric regression detected by `verify-baseline`. Reserved
 /// for *expected* failure modes — the gate fired because numbers moved.
 const EXIT_REGRESSION: u8 = 1;


### PR DESCRIPTION
## 概要

Issue #80 (eval_harness の `EXIT_REGRESSION/USAGE/INFRA` が `codes::*` baseline と矛盾) の調査結果に基づき、**intentional divergence + comment** で intent を明示する 1 PR 解消案。

`src/bin/eval_harness.rs` の L148 に divergence note (13 行コメント) を追加。コードの数値は維持。

## 調査結果

| 確認項目 | 結果 |
| --- | --- |
| eval_harness の位置づけ | internal evaluation tooling (justfile 経由)。production CLI ではない |
| ADR-0066 baseline 規約 | 下流 Group 2 production CLI (sae / yomu / recall) 向け |
| ADR-0002 (accepted, 2026-04-27) | `EXIT_REGRESSION=1` を公式 gate signal として documentation 済 |
| `tests/eval_annotation.rs` | 同じ internal scheme (`EXIT_USAGE: i32 = 2`) を 50+ 件で採用 |
| CI workflow (`ci.yml`) | `cargo test/clippy/fmt` のみ。exit code 数値依存なし |
| `EXIT_*` callsite | 80+ 件 (eval_harness のみで完結) |

結論: pre-ADR-0066 leftover ではなく、**internal-tooling intentional divergence**。置換すれば ADR-0002 改訂 + justfile recipe 利用者への breaking-change が必要なため、divergence を維持して comment で明示する方が outcome に近い。

## 変更内容

- `src/bin/eval_harness.rs`: `EXIT_REGRESSION/USAGE/INFRA` 定数群の直前に 13 行の divergence note を追加
  - eval_harness が production CLI でない旨
  - ADR-0066 baseline の対象範囲 (downstream Group 2 production CLI)
  - ADR-0002 § Decision Outcome が `EXIT_REGRESSION=1` を documentation 済
  - `tests/eval_annotation.rs` が同 scheme を採用
  - 置換コスト (ADR-0002 改訂 + breaking change)

## テスト計画

- [x] `cargo fmt --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test --all-features` 通過 (lib + integration + doc 全 0 failed)
- [x] divergence comment は doc-only、behavior 変更なし

## 対象外

- ADR-0002 / ADR-0066 自体の変更
- `EXIT_*` 数値の置換 (intentional divergence 維持のため)
- 下流 CLI (sae / yomu / recall) への影響なし (本件は amici 内部完結)

## 参考

- Issue: #80
- Audit: `docs/audit/2026-05-14-undocumented-decisions.md` § Recommended Follow-up #13
- ADR-0002: `docs/decisions/0002-evaluation-methodology.md` § Decision Outcome
- ADR-0066 (global): `~/.claude/docs/decisions/0066-cli-exit-code-policy-grouped-by-error-topology.md`
- 関連: `src/cli/exit_code.rs` (`codes::*` baseline 提供側)
