### PR TITLE
feat(eval): aggregation を typed AggregationKind enum に昇格

### DIFF
--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -34,8 +34,8 @@ use rand_chacha::ChaCha8Rng;
 
 use amici::eval::annotation::{ANNOTATION_SCHEMA_VERSION, Entry, Provenance, Session};
 use amici::eval::baseline::{
-    BASELINE_SCHEMA_VERSION, BaselineKind, BaselineSnapshot, atomic_write, build_metric_result,
-    write_json,
+    AggregationKind, BASELINE_SCHEMA_VERSION, BaselineKind, BaselineSnapshot, atomic_write,
+    build_metric_result, write_json,
 };
 use amici::eval::fixture::{
     EvalDocument, EvalQuery, load_documents, load_known_answers, load_queries,
@@ -127,17 +127,9 @@ const VALID_EVALUATE_KINDS: &[&str] = &[
 /// only appears in one place across argv validation and dispatch.
 const ORACLE_KIND_SUFFIX: &str = "_oracle";
 
-/// BR-003 marker written to [`BaselineSnapshot::aggregation`] for
-/// [`BaselineKind::FirstSearchReplay`]. Stage 3 runs `MaxChunkAggregator`
-/// only — no ranking-aware aggregator is invoked, so the field has no
-/// `AggregationKind::name()` to record. Kept as a constant so the
-/// production capture and the test helper that mirrors it share one
-/// source of truth.
-const AGGREGATION_NONE: &str = "none";
-
 /// Closed set of Stage 3 aggregation kinds accepted by `aggregation=...`.
-/// Anchors argv validation and round-tripping with the `aggregation` field
-/// on [`BaselineSnapshot`].
+/// Anchors argv validation; the wire format on [`BaselineSnapshot`] is owned
+/// by [`AggregationKind`] in `amici::eval::baseline`.
 const VALID_AGGREGATION_KINDS: &[&str] = &["identity", "max-chunk", "dedupe", "topk-average"];
 
 /// Default `k` for the `topk-average` strategy when no `topk_k=` override is
@@ -212,31 +204,22 @@ fn parse_merge_config_from_kvs(
     Ok(config)
 }
 
-/// Closed set of Stage 3 aggregation kinds. Anchors `aggregation=` argv
-/// validation, the JSON `aggregation` field on [`BaselineSnapshot`], and
-/// [`run_verify_baseline`]'s reverse lookup of which strategy to dispatch.
+/// Runtime spec for Stage 3 aggregation. Carries the `k` parameter for
+/// `TopKAverage`, which the storage-side [`AggregationKind`] preserves on
+/// the wire as `"topk-average:k"`.
+///
+/// Binary-local; the JSON wire form is owned by [`AggregationKind`] in
+/// `amici::eval::baseline`. Convert at the boundary via [`From`] /
+/// [`TryFrom`] to keep argv parsing and storage concerns separate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AggregationKind {
+enum AggregationSpec {
     Identity,
     MaxChunk,
     Dedupe,
     TopKAverage(usize),
 }
 
-impl AggregationKind {
-    /// Stable label written to `BaselineSnapshot.aggregation`. `TopKAverage`
-    /// encodes `k` as `"topk-average:K"` so a baseline captured with a
-    /// non-default `k` round-trips through [`Self::from_name`] without
-    /// silently falling back to [`DEFAULT_TOPK_AVERAGE_K`] at verify time.
-    fn name(self) -> String {
-        match self {
-            Self::Identity => "identity".to_owned(),
-            Self::MaxChunk => "max-chunk".to_owned(),
-            Self::Dedupe => "dedupe".to_owned(),
-            Self::TopKAverage(k) => format!("topk-average:{k}"),
-        }
-    }
-
+impl AggregationSpec {
     /// Parse `aggregation=<kind>` (and optional `topk_k=<n>`) from argv `kvs`.
     /// Returns `Self::Identity` when the key is absent so callers that don't
     /// pass the flag preserve the pre-Phase-3 behaviour.
@@ -263,26 +246,38 @@ impl AggregationKind {
             )),
         }
     }
+}
 
-    /// Resolve `BaselineSnapshot.aggregation` back to a dispatchable kind for
-    /// `verify-baseline`. Recognises both the encoded `"topk-average:K"` form
-    /// (post-fix) and the legacy bare `"topk-average"` form (pre-fix
-    /// baselines fall back to [`DEFAULT_TOPK_AVERAGE_K`]).
-    fn from_name(name: &str) -> Result<Self, String> {
-        match name {
-            "identity" => Ok(Self::Identity),
-            "max-chunk" => Ok(Self::MaxChunk),
-            "dedupe" => Ok(Self::Dedupe),
-            "topk-average" => Ok(Self::TopKAverage(DEFAULT_TOPK_AVERAGE_K)),
-            other => match other.strip_prefix("topk-average:") {
-                Some(k_str) => k_str
-                    .parse::<usize>()
-                    .map(Self::TopKAverage)
-                    .map_err(|e| format!("topk-average:K parse error in baseline: {e}")),
-                None => Err(format!(
-                    "unknown aggregation in baseline: {other:?}; expected one of {VALID_AGGREGATION_KINDS:?}"
-                )),
-            },
+impl From<AggregationSpec> for AggregationKind {
+    fn from(spec: AggregationSpec) -> Self {
+        match spec {
+            AggregationSpec::Identity => Self::Identity,
+            AggregationSpec::MaxChunk => Self::MaxChunk,
+            AggregationSpec::Dedupe => Self::Dedupe,
+            AggregationSpec::TopKAverage(k) => Self::TopKAverage(k),
+        }
+    }
+}
+
+impl TryFrom<AggregationKind> for AggregationSpec {
+    type Error = String;
+
+    /// Lower a storage-side [`AggregationKind`] back to a runtime spec for
+    /// `verify-baseline` dispatch. [`AggregationKind::NotApplicable`] is the
+    /// FirstSearchReplay marker and has no Stage 3 dispatch counterpart, so
+    /// it is rejected explicitly rather than silently collapsing to a
+    /// runtime default.
+    fn try_from(kind: AggregationKind) -> Result<Self, Self::Error> {
+        match kind {
+            AggregationKind::Identity => Ok(Self::Identity),
+            AggregationKind::MaxChunk => Ok(Self::MaxChunk),
+            AggregationKind::Dedupe => Ok(Self::Dedupe),
+            AggregationKind::TopKAverage(k) => Ok(Self::TopKAverage(k)),
+            AggregationKind::NotApplicable => Err(
+                "AggregationKind::NotApplicable cannot dispatch as a runtime AggregationSpec \
+                 — it is the FirstSearchReplay-only marker; use replay-first-search instead"
+                    .to_owned(),
+            ),
         }
     }
 }
@@ -298,7 +293,7 @@ fn dispatch_pipeline<E, R>(
     queries: &[EvalQuery],
     embedder: &E,
     reranker: Option<&R>,
-    aggregation: AggregationKind,
+    aggregation: AggregationSpec,
     merge_config: &HybridSearchConfig,
     normalization: &QueryNormalizationConfig,
     config: &PipelineConfig,
@@ -308,7 +303,7 @@ where
     R: Rerank,
 {
     match aggregation {
-        AggregationKind::Identity => run_pipeline(
+        AggregationSpec::Identity => run_pipeline(
             corpus,
             queries,
             embedder,
@@ -318,7 +313,7 @@ where
             normalization,
             config,
         ),
-        AggregationKind::MaxChunk => run_pipeline(
+        AggregationSpec::MaxChunk => run_pipeline(
             corpus,
             queries,
             embedder,
@@ -328,7 +323,7 @@ where
             normalization,
             config,
         ),
-        AggregationKind::Dedupe => run_pipeline(
+        AggregationSpec::Dedupe => run_pipeline(
             corpus,
             queries,
             embedder,
@@ -338,7 +333,7 @@ where
             normalization,
             config,
         ),
-        AggregationKind::TopKAverage(k) => run_pipeline(
+        AggregationSpec::TopKAverage(k) => run_pipeline(
             corpus,
             queries,
             embedder,
@@ -361,7 +356,7 @@ fn dispatch_oracle_pipeline<E, R>(
     queries: &[EvalQuery],
     embedder: &E,
     reranker: Option<&R>,
-    aggregation: AggregationKind,
+    aggregation: AggregationSpec,
     merge_config: &HybridSearchConfig,
     normalization: &QueryNormalizationConfig,
     config: &PipelineConfig,
@@ -371,7 +366,7 @@ where
     R: Rerank,
 {
     match aggregation {
-        AggregationKind::Identity => evaluate_oracle(
+        AggregationSpec::Identity => evaluate_oracle(
             corpus,
             queries,
             embedder,
@@ -381,7 +376,7 @@ where
             normalization,
             config,
         ),
-        AggregationKind::MaxChunk => evaluate_oracle(
+        AggregationSpec::MaxChunk => evaluate_oracle(
             corpus,
             queries,
             embedder,
@@ -391,7 +386,7 @@ where
             normalization,
             config,
         ),
-        AggregationKind::Dedupe => evaluate_oracle(
+        AggregationSpec::Dedupe => evaluate_oracle(
             corpus,
             queries,
             embedder,
@@ -401,7 +396,7 @@ where
             normalization,
             config,
         ),
-        AggregationKind::TopKAverage(k) => evaluate_oracle(
+        AggregationSpec::TopKAverage(k) => evaluate_oracle(
             corpus,
             queries,
             embedder,
@@ -597,7 +592,7 @@ fn run_evaluate(kvs: &HashMap<String, String>) -> ExitCode {
         eprintln!("evaluate: unknown kind {kind:?}; expected one of {VALID_EVALUATE_KINDS:?}");
         return ExitCode::from(EXIT_USAGE);
     }
-    let aggregation = match AggregationKind::from_kvs(kvs) {
+    let aggregation = match AggregationSpec::from_kvs(kvs) {
         Ok(a) => a,
         Err(msg) => {
             eprintln!("evaluate: {msg}");
@@ -632,7 +627,7 @@ fn run_evaluate(kvs: &HashMap<String, String>) -> ExitCode {
 fn run_evaluate_with<E: Embed, R: Rerank>(
     ctx: &EvalContext<E, R>,
     kind: &str,
-    aggregation: AggregationKind,
+    aggregation: AggregationSpec,
     merge_config: &HybridSearchConfig,
     normalization: &QueryNormalizationConfig,
 ) -> ExitCode {
@@ -715,7 +710,7 @@ fn run_capture_baseline(kvs: &HashMap<String, String>) -> ExitCode {
             return ExitCode::from(EXIT_USAGE);
         }
     };
-    let aggregation = match AggregationKind::from_kvs(kvs) {
+    let aggregation = match AggregationSpec::from_kvs(kvs) {
         Ok(a) => a,
         Err(msg) => {
             eprintln!("capture-baseline: {msg}");
@@ -756,7 +751,7 @@ fn run_capture_baseline(kvs: &HashMap<String, String>) -> ExitCode {
 fn run_capture_baseline_with<E: Embed, R: Rerank>(
     ctx: &EvalContext<E, R>,
     output_path: &Path,
-    aggregation: AggregationKind,
+    aggregation: AggregationSpec,
     merge_config: &HybridSearchConfig,
     normalization: &QueryNormalizationConfig,
 ) -> ExitCode {
@@ -795,7 +790,7 @@ fn run_capture_baseline_with<E: Embed, R: Rerank>(
     let snapshot = build_baseline_snapshot(
         BaselineKind::Forward,
         "eval_harness capture-baseline",
-        aggregation.name(),
+        aggregation.into(),
         &results,
         &queries,
         fixture_hash,
@@ -860,7 +855,7 @@ fn run_capture_reverse_baseline_with<E: Embed, R: Rerank>(
         &queries,
         &ctx.embedder,
         Some(&ctx.reranker),
-        AggregationKind::Identity,
+        AggregationSpec::Identity,
         &merge_config,
         &normalization,
         &config,
@@ -922,7 +917,7 @@ fn run_capture_oracle(kvs: &HashMap<String, String>) -> ExitCode {
             return ExitCode::from(EXIT_USAGE);
         }
     };
-    let aggregation = match AggregationKind::from_kvs(kvs) {
+    let aggregation = match AggregationSpec::from_kvs(kvs) {
         Ok(a) => a,
         Err(msg) => {
             eprintln!("capture-oracle: {msg}");
@@ -963,7 +958,7 @@ fn run_capture_oracle(kvs: &HashMap<String, String>) -> ExitCode {
 fn run_capture_oracle_with<E: Embed, R: Rerank>(
     ctx: &EvalContext<E, R>,
     output_path: &Path,
-    aggregation: AggregationKind,
+    aggregation: AggregationSpec,
     merge_config: &HybridSearchConfig,
     normalization: &QueryNormalizationConfig,
 ) -> ExitCode {
@@ -1002,7 +997,7 @@ fn run_capture_oracle_with<E: Embed, R: Rerank>(
     let snapshot = build_baseline_snapshot(
         BaselineKind::Oracle,
         "eval_harness capture-oracle",
-        aggregation.name(),
+        aggregation.into(),
         &results,
         &queries,
         fixture_hash,
@@ -1102,7 +1097,7 @@ fn run_replay_first_search_with<E: Embed, R: Rerank>(
     let snapshot = build_baseline_snapshot(
         BaselineKind::FirstSearchReplay,
         "eval_harness replay-first-search",
-        AGGREGATION_NONE.to_owned(),
+        AggregationKind::NotApplicable,
         &results,
         &queries,
         fixture_hash,
@@ -1129,7 +1124,7 @@ fn run_replay_first_search_with<E: Embed, R: Rerank>(
 fn build_baseline_snapshot(
     kind: BaselineKind,
     captured_with: &str,
-    aggregation: String,
+    aggregation: AggregationKind,
     results: &[QueryResult],
     queries: &[EvalQuery],
     fixture_hash: String,
@@ -1278,7 +1273,7 @@ fn run_verify_baseline_with<E: Embed, R: Rerank>(
     // its dispatch in one hop without re-splitting a merged arm.
     let pipeline_outcome: Result<Vec<QueryResult>, String> = match committed.kind {
         BaselineKind::Forward => {
-            let aggregation = match AggregationKind::from_name(&committed.aggregation) {
+            let aggregation = match AggregationSpec::try_from(committed.aggregation) {
                 Ok(a) => a,
                 Err(msg) => {
                     eprintln!("verify-baseline: {msg}");
@@ -1298,7 +1293,7 @@ fn run_verify_baseline_with<E: Embed, R: Rerank>(
             .map_err(|e| format!("{e}"))
         }
         BaselineKind::Oracle => {
-            let aggregation = match AggregationKind::from_name(&committed.aggregation) {
+            let aggregation = match AggregationSpec::try_from(committed.aggregation) {
                 Ok(a) => a,
                 Err(msg) => {
                     eprintln!("verify-baseline: {msg}");
@@ -2048,60 +2043,84 @@ mod tests {
         );
     }
 
-    // T-067-007: aggregation_kind_topk_average_roundtrips_through_name
+    // T-067-007: aggregation_kind_topk_average_roundtrips_through_storage_enum
     //
-    // A non-default `topk_k=` passed at
-    // capture time used to be silently downgraded to DEFAULT_TOPK_AVERAGE_K
-    // by `from_name` at verify time. Encode `k` in the serialised name and
-    // round-trip to keep the strategy bit-identical across capture/verify.
+    // A non-default `topk_k=` passed at capture time used to be silently
+    // downgraded to DEFAULT_TOPK_AVERAGE_K by `from_name` at verify time.
+    // `AggregationKind::TopKAverage(k)` now encodes `k` in the JSON wire form
+    // as `"topk-average:k"`, so a round-trip through serde keeps the strategy
+    // bit-identical across capture/verify.
     #[test]
-    fn aggregation_kind_topk_average_roundtrips_through_name() {
+    fn aggregation_kind_topk_average_roundtrips_through_storage_enum() {
         for k in [1, 3, 5, 100] {
-            let original = AggregationKind::TopKAverage(k);
-            let name = original.name();
+            let original_spec = AggregationSpec::TopKAverage(k);
+            let kind: AggregationKind = original_spec.into();
+            let json = serde_json::to_string(&kind).expect("serialise AggregationKind");
             assert_eq!(
-                name,
-                format!("topk-average:{k}"),
-                "TopKAverage({k}) must encode k in name"
+                json,
+                format!("\"topk-average:{k}\""),
+                "TopKAverage({k}) must serialise with k encoded in the wire form"
             );
-            let parsed =
-                AggregationKind::from_name(&name).expect("encoded topk-average must parse back");
+            let parsed_kind: AggregationKind =
+                serde_json::from_str(&json).expect("deserialise AggregationKind");
+            let parsed_spec =
+                AggregationSpec::try_from(parsed_kind).expect("storage→runtime bridge");
             assert_eq!(
-                parsed, original,
-                "round-trip lost k for TopKAverage({k}): {parsed:?}"
+                parsed_spec, original_spec,
+                "round-trip lost k for TopKAverage({k}): {parsed_spec:?}"
             );
         }
     }
 
-    // T-067-008: aggregation_kind_legacy_topk_average_falls_back_to_default
+    // T-067-008: aggregation_kind_legacy_bare_topk_average_is_rejected
     //
-    // Pre-fix baselines wrote bare "topk-average" without `k`. Verify-baseline
-    // must continue to parse those, falling back to DEFAULT_TOPK_AVERAGE_K so
-    // operators with committed snapshots aren't forced to recapture.
+    // Pre-fix baselines that wrote bare "topk-average" without `:k` are
+    // explicitly rejected at deserialise time. Silently falling back to
+    // DEFAULT_TOPK_AVERAGE_K would re-introduce the bug that the encoded
+    // form fixes — verify-baseline would dispatch at the default k instead
+    // of the captured k. No committed fixture uses the bare form, so the
+    // rejection has zero footprint.
     #[test]
-    fn aggregation_kind_legacy_topk_average_falls_back_to_default() {
-        let parsed = AggregationKind::from_name("topk-average")
-            .expect("legacy bare topk-average must still parse");
-        assert_eq!(parsed, AggregationKind::TopKAverage(DEFAULT_TOPK_AVERAGE_K));
+    fn aggregation_kind_legacy_bare_topk_average_is_rejected() {
+        let result = serde_json::from_str::<AggregationKind>("\"topk-average\"");
+        assert!(
+            result.is_err(),
+            "bare 'topk-average' must be rejected to prevent silent default-k fallback; \
+             got {result:?}"
+        );
     }
 
     // T-067-009: aggregation_kind_simple_variants_roundtrip
     //
-    // Identity / MaxChunk / Dedupe carry no `k` payload, but they share the
-    // round-trip contract — `name()` → `from_name()` must yield the original
-    // variant.
+    // Identity / MaxChunk / Dedupe / NotApplicable carry no `k` payload, but
+    // they share the round-trip contract through the storage enum.
     #[test]
     fn aggregation_kind_simple_variants_roundtrip() {
         for original in [
             AggregationKind::Identity,
             AggregationKind::MaxChunk,
             AggregationKind::Dedupe,
+            AggregationKind::NotApplicable,
         ] {
-            let name = original.name();
-            let parsed =
-                AggregationKind::from_name(&name).expect("simple variant name must round-trip");
+            let json = serde_json::to_string(&original).expect("serialise");
+            let parsed: AggregationKind = serde_json::from_str(&json).expect("deserialise");
             assert_eq!(parsed, original, "round-trip mismatch for {original:?}");
         }
+    }
+
+    // T-067-010: aggregation_kind_not_applicable_rejects_runtime_dispatch
+    //
+    // NotApplicable is the FirstSearchReplay-only marker. The
+    // `TryFrom<AggregationKind> for AggregationSpec` bridge must reject it
+    // so verify-baseline cannot accidentally dispatch a Stage 3 strategy
+    // on a replay baseline.
+    #[test]
+    fn aggregation_kind_not_applicable_rejects_runtime_dispatch() {
+        let result = AggregationSpec::try_from(AggregationKind::NotApplicable);
+        assert!(
+            result.is_err(),
+            "NotApplicable must not lower to a runtime AggregationSpec; got {result:?}"
+        );
     }
 
     // T-068-012: parse_merge_config_empty_kvs_returns_default
@@ -2279,7 +2298,7 @@ mod tests {
             model_revision: "rev".to_owned(),
             mlx_rs_version: "0.0.0".to_owned(),
             fixture_hash: "fnv1a64:0".to_owned(),
-            aggregation: "identity".to_owned(),
+            aggregation: AggregationKind::Identity,
             merge_config: HybridSearchConfig::default(),
             normalization: QueryNormalizationConfig::default(),
             global: vec![],
@@ -2313,7 +2332,7 @@ mod tests {
         build_baseline_snapshot(
             BaselineKind::FirstSearchReplay,
             "eval_harness replay-first-search",
-            AGGREGATION_NONE.to_owned(),
+            AggregationKind::NotApplicable,
             &results,
             &queries,
             "fnv1a64:0".to_owned(),
@@ -2369,9 +2388,10 @@ mod tests {
     fn replay_first_search_writes_aggregation_none() {
         let snap = build_test_replay_snapshot();
         assert_eq!(
-            snap.aggregation, "none",
+            snap.aggregation,
+            AggregationKind::NotApplicable,
             "BR-003: replay path's Stage 3 strategy is MaxChunkAggregator only \
-             (no ranking-aware aggregator) → aggregation marker is \"none\""
+             (no ranking-aware aggregator) → aggregation marker is NotApplicable"
         );
     }
 

--- a/src/eval/baseline.rs
+++ b/src/eval/baseline.rs
@@ -9,13 +9,14 @@
 //! [`BaselineSnapshot`] composes it directly so its own derive is sufficient.
 
 use std::collections::BTreeMap;
+use std::fmt;
 use std::fs::{self, File};
 use std::io::{self, Write};
 use std::path::Path;
 
 use rurico::retrieval::HybridSearchConfig;
 use rurico::storage::{QueryNormalizationConfig, pre_phase_5_disabled};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de};
 
 use crate::eval::metrics::MetricResult;
 
@@ -90,6 +91,85 @@ pub enum BaselineKind {
     FirstSearchReplay,
 }
 
+/// Stage 3 aggregation strategy recorded on a [`BaselineSnapshot`].
+///
+/// Closed wire-format contract — every reader must handle every variant
+/// (no `#[non_exhaustive]`) so a baseline produced by a newer harness
+/// fails to deserialise rather than silently dropping an unknown strategy.
+///
+/// The mapping to JSON strings is intentionally **not** `serde(rename_all)`-driven:
+/// `TopKAverage(k)` carries a parameter that has to round-trip through the
+/// wire form as `"topk-average:k"`. See the [`Serialize`] / [`Deserialize`]
+/// impls below for the exact mapping.
+///
+/// | Variant         | JSON wire form     | Notes                                  |
+/// | --------------- | ------------------ | -------------------------------------- |
+/// | `Identity`      | `"identity"`       | Pre-aggregation default                |
+/// | `MaxChunk`      | `"max-chunk"`      | Parent rollup, max child score         |
+/// | `Dedupe`        | `"dedupe"`         | Drop sibling chunks of the same parent |
+/// | `TopKAverage(k)`| `"topk-average:k"` | Average top-`k` chunks per parent      |
+/// | `NotApplicable` | `"none"`           | BR-003 marker for FirstSearchReplay    |
+///
+/// Bare `"topk-average"` (no `:k` suffix) is **rejected** during deserialise;
+/// pre-fix baselines that encoded the strategy without `k` would otherwise
+/// silently verify against a different `k` than they were captured at. No
+/// committed fixture uses the bare form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AggregationKind {
+    Identity,
+    MaxChunk,
+    Dedupe,
+    TopKAverage(usize),
+    /// BR-003 marker for [`BaselineKind::FirstSearchReplay`] — Stage 3 fixes
+    /// `MaxChunkAggregator` outside the parameterised set, so no aggregator
+    /// kind applies.
+    NotApplicable,
+}
+
+impl fmt::Display for AggregationKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Identity => f.write_str("identity"),
+            Self::MaxChunk => f.write_str("max-chunk"),
+            Self::Dedupe => f.write_str("dedupe"),
+            Self::TopKAverage(k) => write!(f, "topk-average:{k}"),
+            Self::NotApplicable => f.write_str("none"),
+        }
+    }
+}
+
+impl Serialize for AggregationKind {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for AggregationKind {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(de)?;
+        match s.as_str() {
+            "identity" => Ok(Self::Identity),
+            "max-chunk" => Ok(Self::MaxChunk),
+            "dedupe" => Ok(Self::Dedupe),
+            "none" => Ok(Self::NotApplicable),
+            "topk-average" => Err(de::Error::custom(
+                "legacy bare 'topk-average' aggregation marker without ':k' suffix \
+                 — recapture the baseline so the k parameter is preserved",
+            )),
+            other => match other.strip_prefix("topk-average:") {
+                Some(k_str) => k_str.parse::<usize>().map(Self::TopKAverage).map_err(|e| {
+                    de::Error::custom(format!(
+                        "topk-average:k parse error in baseline aggregation: {e}"
+                    ))
+                }),
+                None => Err(de::Error::custom(format!(
+                    "unknown aggregation marker {other:?}"
+                ))),
+            },
+        }
+    }
+}
+
 /// Frozen baseline produced by `eval_harness capture-baseline` and verified
 /// later by `eval_harness verify-baseline`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -119,10 +199,11 @@ pub struct BaselineSnapshot {
     /// Stage 3 aggregation strategy used for capture.
     ///
     /// Pre-aggregation baselines lack this field; `serde(default)` resolves
-    /// it to `"identity"` so existing committed baselines round-trip.
-    /// `verify-baseline` reads it back to dispatch the same aggregator.
+    /// it to [`AggregationKind::Identity`] so existing committed baselines
+    /// round-trip. `verify-baseline` reads it back to dispatch the same
+    /// aggregator.
     #[serde(default = "default_aggregation_kind")]
-    pub aggregation: String,
+    pub aggregation: AggregationKind,
     /// Stage 2 hybrid scoring config used for capture.
     ///
     /// Pre-merge-config baselines lack this field; `serde(default)`
@@ -149,8 +230,8 @@ pub struct BaselineSnapshot {
     pub latency_p95_ms: f64,
 }
 
-fn default_aggregation_kind() -> String {
-    "identity".to_owned()
+fn default_aggregation_kind() -> AggregationKind {
+    AggregationKind::Identity
 }
 
 /// Errors surfaced when writing a [`BaselineSnapshot`].
@@ -459,7 +540,7 @@ mod tests {
             model_revision: "rev".to_owned(),
             mlx_rs_version: "0.0.0".to_owned(),
             fixture_hash: "fnv1a64:0".to_owned(),
-            aggregation: "none".to_owned(),
+            aggregation: AggregationKind::NotApplicable,
             merge_config: HybridSearchConfig::default(),
             normalization: pre_phase_5_disabled(),
             global: vec![],
@@ -472,8 +553,9 @@ mod tests {
         assert_eq!(parsed.kind, BaselineKind::FirstSearchReplay);
         assert_eq!(parsed.captured_with, "eval_harness replay-first-search");
         assert_eq!(
-            parsed.aggregation, "none",
-            "BR-003: aggregation marker is \"none\" for FirstSearchReplay"
+            parsed.aggregation,
+            AggregationKind::NotApplicable,
+            "BR-003: aggregation marker is NotApplicable for FirstSearchReplay"
         );
     }
 
@@ -517,6 +599,44 @@ mod tests {
             assert_eq!(
                 parsed.kind, expected_kind,
                 "{name} kind must be {expected_kind:?}"
+            );
+        }
+    }
+
+    // T-081-002: aggregation_kind_roundtrips_committed_fixtures
+    //
+    // Issue #81 Code fix #10: lock in that the typed [`AggregationKind`] enum
+    // deserialises every committed baseline fixture to the expected variant
+    // **and** re-serialises to a byte-equivalent JSON literal. Catches the
+    // most likely regression on this PR — a serde wire-form change that
+    // silently rewrites the meaning of historical baselines.
+    #[test]
+    fn aggregation_kind_roundtrips_committed_fixtures() {
+        let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/eval");
+        for (name, expected_kind) in [
+            ("baseline.json", AggregationKind::Identity),
+            ("oracle_baseline.json", AggregationKind::Identity),
+            (
+                "first_search_replay_baseline.json",
+                AggregationKind::NotApplicable,
+            ),
+        ] {
+            let path = fixture_dir.join(name);
+            let text = fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            let snap: BaselineSnapshot = serde_json::from_str(&text)
+                .unwrap_or_else(|e| panic!("{name} must deserialise: {e}"));
+            assert_eq!(
+                snap.aggregation, expected_kind,
+                "{name}: aggregation must deserialise to {expected_kind:?}"
+            );
+            let reserialized = serde_json::to_value(snap.aggregation)
+                .unwrap_or_else(|e| panic!("{name}: serialise aggregation: {e}"));
+            let original: serde_json::Value = serde_json::from_str(&text)
+                .unwrap_or_else(|e| panic!("{name}: parse as Value: {e}"));
+            assert_eq!(
+                reserialized, original["aggregation"],
+                "{name}: aggregation field must round-trip byte-equivalent JSON"
             );
         }
     }

--- a/src/eval/io.rs
+++ b/src/eval/io.rs
@@ -44,7 +44,9 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::eval::baseline::{BASELINE_SCHEMA_VERSION, BaselineKind, BaselineSnapshot};
+    use crate::eval::baseline::{
+        AggregationKind, BASELINE_SCHEMA_VERSION, BaselineKind, BaselineSnapshot,
+    };
 
     /// Build a minimal [`BaselineSnapshot`] with deterministic literal
     /// stub values. Only the round-trip shape is exercised, so each
@@ -59,7 +61,7 @@ mod tests {
             model_revision: "test-rev".to_owned(),
             mlx_rs_version: "0.0".to_owned(),
             fixture_hash: "fnv1a64:0".to_owned(),
-            aggregation: "identity".to_owned(),
+            aggregation: AggregationKind::Identity,
             merge_config: HybridSearchConfig::default(),
             normalization: pre_phase_5_disabled(),
             global: Vec::new(),

--- a/src/eval/oracle_gap.rs
+++ b/src/eval/oracle_gap.rs
@@ -219,8 +219,8 @@ fn enforce_pipeline_config_match(
     if baseline.aggregation != oracle.aggregation {
         return Err(OracleGapError::PipelineConfigMismatch {
             field: "aggregation",
-            baseline: baseline.aggregation.clone(),
-            oracle: oracle.aggregation.clone(),
+            baseline: baseline.aggregation.to_string(),
+            oracle: oracle.aggregation.to_string(),
         });
     }
     if baseline.merge_config != oracle.merge_config {

--- a/src/eval/oracle_gap/tests.rs
+++ b/src/eval/oracle_gap/tests.rs
@@ -8,7 +8,9 @@ use rurico::storage::pre_phase_5_disabled;
 use super::{
     Ac4Violation, MetricGap, OracleGapError, compute_gap, detect_ac4_violations, format_markdown,
 };
-use crate::eval::baseline::{BASELINE_SCHEMA_VERSION, BaselineKind, BaselineSnapshot};
+use crate::eval::baseline::{
+    AggregationKind, BASELINE_SCHEMA_VERSION, BaselineKind, BaselineSnapshot,
+};
 use crate::eval::metrics::MetricResult;
 
 /// Build a stub `MetricResult` for the given metric label and point estimate.
@@ -43,7 +45,7 @@ fn snapshot(
         model_revision: "rev".to_owned(),
         mlx_rs_version: "0.0.0".to_owned(),
         fixture_hash: fixture_hash.to_owned(),
-        aggregation: "identity".to_owned(),
+        aggregation: AggregationKind::Identity,
         merge_config: HybridSearchConfig::default(),
         normalization: pre_phase_5_disabled(),
         global,
@@ -121,8 +123,8 @@ fn compute_gap_rejects_fixture_hash_mismatch() {
 fn compute_gap_rejects_mismatched_aggregation() {
     let mut baseline = snapshot(BaselineKind::Forward, "fnv1a64:0", vec![], BTreeMap::new());
     let mut oracle = snapshot(BaselineKind::Oracle, "fnv1a64:0", vec![], BTreeMap::new());
-    baseline.aggregation = "identity".to_owned();
-    oracle.aggregation = "dedupe".to_owned();
+    baseline.aggregation = AggregationKind::Identity;
+    oracle.aggregation = AggregationKind::Dedupe;
     let result = compute_gap(&baseline, &oracle);
     assert!(
         matches!(


### PR DESCRIPTION
## 概要

Issue #81 Code fix #10。`BaselineSnapshot::aggregation` を `String` から typed `enum AggregationKind` に昇格し、`BaselineKind` との typed/untyped 非対称を解消する。stringly-typed のため compile-time に typo を検出できなかった問題を解決。

5 ファイル / +266/-122 lines (polish 込み)。`/audit-undocumented` で #56 として promotion 候補、ADR-0007 § Trade-offs で明示的に out of scope だった type 昇格 fix。

## 設計判断 (advisor 2 回確認)

`AggregationKind` を 2 つに分離:

| 場所 | 役割 | 例 |
| --- | --- | --- |
| **lib** (`baseline.rs`) | `AggregationKind` — storage / wire-form contract | `TopKAverage(k)` を `"topk-average:k"` で encode |
| **binary** (`eval_harness.rs`) | `AggregationSpec` — runtime dispatch (旧 AggregationKind を rename) | argv parse 用、`From` / `TryFrom` bridge |

`NotApplicable` variant は FirstSearchReplay marker (wire form `"none"`)。`TryFrom<AggregationKind> for AggregationSpec` で明示的 reject (runtime dispatch 不可)。

bare `"topk-average"` (no `:k` suffix) は **reject**: silent `DEFAULT_TOPK_AVERAGE_K` fallback の再導入を防ぐ。コミット済 fixture 内に bare 形なし (grep 確認済)。

## 変更内容

### lib (`src/eval/baseline.rs`)

- 新 `pub enum AggregationKind { Identity, MaxChunk, Dedupe, TopKAverage(usize), NotApplicable }`
- Closed wire-format contract (`#[non_exhaustive]` 付けない)
- Custom `Serialize` / `Deserialize` で wire form 維持
- `Display` impl で human-readable / wire form 同じ
- `BaselineSnapshot::aggregation: String` → `AggregationKind`

### binary (`src/bin/eval_harness.rs`)

- 既存 `AggregationKind` → `AggregationSpec` rename (responsibility 分離)
- `From<AggregationSpec> for AggregationKind` (binary → lib)
- `TryFrom<AggregationKind> for AggregationSpec` (lib → binary、NotApplicable reject)
- 削除: `AggregationSpec::name()` / `from_name()` / `AGGREGATION_NONE` 定数

### 他

- `oracle_gap.rs`: `format!("{:?}", ...)` → `.to_string()` (Display 経由、wire form 維持)
- `io.rs` / `oracle_gap/tests.rs`: stub helper / test の literal を enum 値に置換

## 追加テスト

- T-067-007: `TopKAverage(k)` round-trip via storage enum + wire form 検証
- T-067-008: bare `"topk-average"` deserialise 拒否
- T-067-009: simple variants round-trip (storage enum 経由)
- T-067-010: `NotApplicable` runtime dispatch reject (`TryFrom` 失敗)
- T-081-002: 3 committed fixture (baseline.json / oracle_baseline.json / first_search_replay_baseline.json) の round-trip + byte-equivalent JSON 検証

## Polish 適用

`/polish` Phase 1 (Codex / CodeRabbit / Gemini / simplify 3-agent) + Phase 2 (enhancer-code) 反映:
- CQ.4 / REUSE-002 / Gemini Minor (cross-confirmed): `oracle_gap.rs` を Display 経由に
- REUSE-001: `Serialize` impl を `Display.to_string()` に delegate
- Phase 2: `TopkAverage` → `TopKAverage` (rurico naming 整合) + redundant per-variant rustdoc 削減

## テスト計画

- [x] `cargo fmt --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test --all-features` 通過 (266 passed / 0 failed / 10 ignored expected MLX-gated)
- [x] T-081-002 で 3 committed fixture の round-trip + byte-equivalence 確認

## 下流への影響

下流 (sae / yomu / recall) は `eval-harness` feature 不使用、`BaselineSnapshot` grep ヒット 0 件。rev bump 不要。

## 残課題 (本 PR では扱わない)

- ADR-0007 § Implementation Guidelines テーブル例示 (`aggregation` を文字列リテラルで記述) の更新 — 別 follow-up
- 簡単な variant の bridge test (T-067-007 が `TopKAverage` のみ exercise) — 軽微、次の機会に

## 参考

- Issue: #81 (Code fix #10 of 5)
- Audit: `docs/audit/2026-05-14-undocumented-decisions.md` § Recommended Follow-up #12 / Promotion candidate #56
- ADR-0007: `docs/decisions/0007-pin-baselinesnapshot-serde-defaults-to-pre-existing-behavior.md` § Trade-offs
