### PR TITLE
refactor(storage): append_in_clause op を typed enum Op に昇格

### DIFF
--- a/src/storage/filter.rs
+++ b/src/storage/filter.rs
@@ -147,17 +147,38 @@ pub fn append_like_prefix_filter(
     }
 }
 
+/// Whether [`append_in_clause`] builds an `IN` or `NOT IN` predicate.
+///
+/// Closed enum (rather than `op: &str`) so the SQL keyword set stays bound at
+/// compile time. Matches the module's `column: &'static str` discipline — every
+/// literal piece of SQL syntax is fixed at compile time, never threaded
+/// through a runtime string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Op {
+    In,
+    NotIn,
+}
+
+impl Op {
+    fn as_sql(self) -> &'static str {
+        match self {
+            Self::In => "IN",
+            Self::NotIn => "NOT IN",
+        }
+    }
+}
+
 /// Appends `" AND {column} {op} (?, ?, ...)"` and boxes each item as a param.
 ///
 /// Private shared tail for the public `append_in_filter` / `append_include_ids`
 /// / `append_exclude_ids` helpers. Each public helper handles its own
 /// `None` / empty-set contract before delegating here, so this function
-/// assumes `iter` is non-empty. `op` is used verbatim ("IN" or "NOT IN").
+/// assumes `iter` is non-empty.
 fn append_in_clause<I>(
     sql: &mut String,
     params: &mut Vec<Box<dyn ToSql>>,
     column: &'static str,
-    op: &str,
+    op: Op,
     iter: I,
 ) where
     I: IntoIterator,
@@ -168,7 +189,7 @@ fn append_in_clause<I>(
     sql.push_str(" AND ");
     sql.push_str(column);
     sql.push(' ');
-    sql.push_str(op);
+    sql.push_str(op.as_sql());
     sql.push_str(" (");
     sql.push_str(&anon_placeholders(iter.len()));
     sql.push(')');
@@ -204,7 +225,7 @@ pub fn append_in_filter<T>(
         sql.push_str(" AND 1 = 0");
         return;
     }
-    append_in_clause(sql, params, column, "IN", values.iter().cloned());
+    append_in_clause(sql, params, column, Op::In, values.iter().cloned());
 }
 
 /// Appends `" AND {column} NOT IN (?, ?, ...)"` when `exclude_ids` is non-empty.
@@ -224,7 +245,7 @@ pub fn append_exclude_ids(
     if exclude_ids.is_empty() {
         return;
     }
-    append_in_clause(sql, params, column, "NOT IN", exclude_ids.iter().copied());
+    append_in_clause(sql, params, column, Op::NotIn, exclude_ids.iter().copied());
 }
 
 /// Appends an `AND` clause restricting `column` to `include_ids`.
@@ -253,7 +274,7 @@ pub fn append_include_ids(
         sql.push_str(" AND 1 = 0");
         return;
     }
-    append_in_clause(sql, params, column, "IN", include_ids.iter().copied());
+    append_in_clause(sql, params, column, Op::In, include_ids.iter().copied());
 }
 
 /// Appends `" AND {column} >= ?"` binding `cutoff_ms` when `Some`.


### PR DESCRIPTION
## 概要

Issue #81 Code fix #6。`src/storage/filter.rs::append_in_clause` の `op: &str` を closed `enum Op { In, NotIn }` に型強化し、module の `column: &'static str` 規律 (literal-only SQL syntax を compile-time に固定) と非対称だった stringly-typed flag を typed enum に揃える。

1 file / +27/-6 lines、private fn のため downstream 影響なし。

## 変更内容

- 新 `enum Op { In, NotIn }` (private、`#[derive(Debug, Clone, Copy, PartialEq, Eq)]`)
- `Op::as_sql(self) -> &'static str` で `"IN"` / `"NOT IN"` を返す
- `append_in_clause` の signature: `op: &str` → `op: Op`
- callsite 3 つ更新:
  - `append_in_filter`: `"IN"` → `Op::In`
  - `append_exclude_ids`: `"NOT IN"` → `Op::NotIn`
  - `append_include_ids`: `"IN"` → `Op::In`
- rustdoc 更新: 旧 `op` doc の文字列言及を削除 (enum 自体が closed contract)

## 設計

LANG.md "API Design Patterns > Avoid" の `String for every identifier → Newtype` 規律に整合。`column: &'static str` 規律 (compile-time 固定の SQL syntax) と並んで、`op` も同じ強度で型固定する。

`Op::as_sql` は `&'static str` 戻り値で zero-cost (`Copy` 1-byte enum + register-sized discriminant、compiler が conditional-move に folding)。

## テスト計画

- [x] `cargo fmt --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test --lib` 通過 (135 passed / 0 failed)
- [x] 既存テスト T-030..T-042 (append_in_filter / append_exclude_ids / append_include_ids) 全部 pass — API 不変

## Polish 適用

`/polish` Phase 1 (CodeRabbit 0 / Gemini positive / Codex usage limit / simplify 3-agent: reuse 0, readability 2 keep-as-is, efficiency 0) + Phase 2 (enhancer-code: 0 changes、already clean) を実施。findings はあったが全て "no action / ship as-is" 判定。

## 下流への影響

`append_in_clause` は private fn、`Op` enum も private。downstream (sae / yomu / recall) への影響なし。

## 参考

- Issue: #81 (Code fix #6 of 5、Suggested ordering Step 4)
- Audit: `docs/audit/2026-05-14-undocumented-decisions.md` § Recommended Follow-up #8
- LANG.md: "API Design Patterns" / "Naming Conventions C-CONV"
