### PR TITLE
refactor(storage): filter.rs の未使用 pub helper を pub(crate) に narrow

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -3,9 +3,8 @@ pub mod fts;
 pub mod query_helpers;
 
 pub use filter::{
-    anon_placeholders, append_date_string_cutoff_filter, append_eq_filter, append_exclude_ids,
-    append_in_filter, append_include_ids, append_like_prefix_filter,
-    append_timestamp_cutoff_filter, append_timestamp_day_cutoff_filter, as_sql_params, escape_like,
-    in_placeholders, like_prefix_match,
+    anon_placeholders, append_eq_filter, append_exclude_ids, append_in_filter, append_include_ids,
+    append_like_prefix_filter, append_timestamp_cutoff_filter, append_timestamp_day_cutoff_filter,
+    as_sql_params, escape_like, in_placeholders,
 };
 pub use query_helpers::{collect_rows, fetch_by_in_clause};

--- a/src/storage/filter.rs
+++ b/src/storage/filter.rs
@@ -101,7 +101,8 @@ pub fn escape_like(s: &str) -> String {
 ///
 /// Use this on the Rust side when post-filtering rows already narrowed by a
 /// `LIKE ? ESCAPE '\'` clause, so that SQL and Rust agree on case semantics.
-pub fn like_prefix_match(value: &str, prefix: &str) -> bool {
+#[allow(dead_code)] // SQL filter utility kept for future amici-internal callers.
+pub(crate) fn like_prefix_match(value: &str, prefix: &str) -> bool {
     value
         .as_bytes()
         .get(..prefix.len())
@@ -313,7 +314,8 @@ pub fn append_timestamp_cutoff_filter(
 /// timestamps and the caller wants a day-inclusive `before`.
 ///
 /// See [`append_eq_filter`] for the `column` security contract.
-pub fn append_date_string_cutoff_filter(
+#[allow(dead_code)] // SQL filter utility kept for future amici-internal callers.
+pub(crate) fn append_date_string_cutoff_filter(
     sql: &mut String,
     params: &mut Vec<Box<dyn ToSql>>,
     column: &'static str,


### PR DESCRIPTION
## 概要

Issue #81 Code fix #7。`src/storage/filter.rs` の 13 pub fn のうち downstream (sae / yomu / recall) で **未使用** の 2 件を `pub(crate)` に narrow。LANG.md "Prefer `pub(super)` over `pub(crate)` over `pub`" 規律 (Minimum required visibility) に近づける。

2 files / +7/-6 lines。下流 grep 完了、build 影響なし。

## Downstream grep 結果

| fn | sae | yomu | recall | 判定 |
| --- | :---: | :---: | :---: | --- |
| `in_placeholders` | ✓ | ✓ | - | keep `pub` |
| `anon_placeholders` | ✓ | ✓ | ✓ | keep `pub` |
| `as_sql_params` | ✓ | ✓ | - | keep `pub` |
| `append_eq_filter` | ✓ | - | ✓ | keep `pub` |
| `escape_like` | - | - | ✓ | keep `pub` |
| `like_prefix_match` | - | - | - | **narrow `pub(crate)`** |
| `append_like_prefix_filter` | - | ✓ | ✓ | keep `pub` |
| `append_in_filter` | ✓ | ✓ | - | keep `pub` |
| `append_exclude_ids` | - | ✓ | - | keep `pub` |
| `append_include_ids` | - | ✓ | - | keep `pub` |
| `append_timestamp_cutoff_filter` | - | - | ✓ | keep `pub` |
| `append_date_string_cutoff_filter` | - | - | - | **narrow `pub(crate)`** |
| `append_timestamp_day_cutoff_filter` | ✓ | - | - | keep `pub` |

## 変更内容

- `src/storage/filter.rs`:
  - `pub fn like_prefix_match` → `pub(crate) fn`
  - `pub fn append_date_string_cutoff_filter` → `pub(crate) fn`
  - 両 fn に `#[allow(dead_code)]` 付与 (amici 内部 production code 未使用、tests のみ使用、SQL utility として保持)
- `src/storage.rs`:
  - `pub use filter::{...}` re-export 一覧から該当 2 fn 削除
  - amici crate 内部からは `crate::storage::filter::FN` 経由のみアクセス可、下流不可視

## 設計判断

- `pub(super)` まで narrow しなかった理由: 将来 amici 内別 module から使う可能性、`pub(crate)` が安全
- `#[allow(dead_code)]` の理由: production code で未使用だが SQL filter utility として保持、deletion は Issue 指示 scope 外
- 該当 fn を完全削除する選択もあったが、Issue body は "narrow" を指示しているため scope-creep 回避

## テスト計画

- [x] `cargo fmt --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過 (dead_code warning 抑止後)
- [x] `cargo test --lib` 通過 (135 passed / 0 failed)
- [x] 既存テスト T-021..T-024 (like_prefix_match) / T-046..T-049 (append_date_string_cutoff_filter) 全 pass

## 下流への影響

下流 (sae / yomu / recall) は両 fn とも grep ヒット 0 件、cross-crate 公開を断っても build 影響なし。rev bump 不要。

## 参考

- Issue: #81 (Code fix #7 of 5、Suggested ordering Step 5)
- Audit: `docs/audit/2026-05-14-undocumented-decisions.md` § Recommended Follow-up #9
- LANG.md: "Module Structure > Visibility — Minimum required"
