### PR TITLE
feat(eval-harness): MLX_DEPENDENT_MODES partition を compile-time guard 化

### DIFF
--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -533,10 +533,27 @@ impl MetricSpec {
     }
 }
 
+/// Every subcommand label accepted by `main()` after argv parsing.
+///
+/// Source of truth for the seatbelt-sandbox classification: the compile-time
+/// `const _: () = assert!(...)` below fails the build unless every entry is
+/// assigned to either [`MLX_DEPENDENT_MODES`] or [`NON_MLX_MODES`], so a new
+/// subcommand cannot silently bypass the gate.
+const ALL_SUBCOMMANDS: &[&str] = &[
+    "evaluate",
+    "capture-baseline",
+    "capture-reverse-baseline",
+    "capture-oracle",
+    "replay-first-search",
+    "oracle-gap",
+    "verify-baseline",
+    "compare-baselines",
+    "annotate",
+];
+
 /// Modes that load MLX models and would crash under the Codex seatbelt
-/// sandbox. `exit_if_seatbelt` fires for these only — read-only modes
-/// like `oracle-gap` and `compare-baselines` parse committed JSON and
-/// have no MLX dependency, so they should run inside the sandbox.
+/// sandbox. `exit_if_seatbelt` fires for these only; the complement
+/// [`NON_MLX_MODES`] runs inside the sandbox.
 const MLX_DEPENDENT_MODES: &[&str] = &[
     "evaluate",
     "capture-baseline",
@@ -546,18 +563,26 @@ const MLX_DEPENDENT_MODES: &[&str] = &[
     "verify-baseline",
 ];
 
+/// Modes that run safely inside the seatbelt sandbox (no MLX load).
+const NON_MLX_MODES: &[&str] = &["oracle-gap", "compare-baselines", "annotate"];
+
+const _: () = assert!(MLX_DEPENDENT_MODES.len() + NON_MLX_MODES.len() == ALL_SUBCOMMANDS.len());
+
 fn main() -> ExitCode {
     rurico::handle_probe_if_needed();
 
     let args: Vec<String> = env::args().skip(1).collect();
     let Some(mode) = args.first() else {
         eprintln!(
-            "usage: eval_harness <evaluate|capture-baseline|capture-reverse-baseline|\
-             capture-oracle|replay-first-search|oracle-gap|verify-baseline|compare-baselines> \
-             [key=value...]"
+            "usage: eval_harness <{}> [key=value...]",
+            ALL_SUBCOMMANDS.join("|")
         );
         return ExitCode::from(EXIT_USAGE);
     };
+    if !ALL_SUBCOMMANDS.contains(&mode.as_str()) {
+        eprintln!("unknown mode: {mode}");
+        return ExitCode::from(EXIT_USAGE);
+    }
     if MLX_DEPENDENT_MODES.contains(&mode.as_str()) {
         exit_if_seatbelt(env!("CARGO_BIN_NAME"));
     }
@@ -576,10 +601,10 @@ fn main() -> ExitCode {
         "verify-baseline" => run_verify_baseline(&kvs),
         "compare-baselines" => run_compare_baselines(&kvs),
         "annotate" => run_annotate(&kvs),
-        other => {
-            eprintln!("unknown mode: {other}");
-            ExitCode::from(EXIT_USAGE)
-        }
+        // ALL_SUBCOMMANDS gate above rejects unknown modes; any label that
+        // reaches here is in ALL_SUBCOMMANDS but missing a dispatch arm — a
+        // build-time editing mistake that the gate cannot catch.
+        other => unreachable!("ALL_SUBCOMMANDS entry {other:?} has no dispatch arm"),
     }
 }
 
@@ -2006,6 +2031,32 @@ fn run_annotate(kvs: &HashMap<String, String>) -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // T-081-003: subcommand_sets_partition_all_subcommands
+    //
+    // Issue #81 Code fix #9: ALL_SUBCOMMANDS must be the disjoint union of
+    // MLX_DEPENDENT_MODES and NON_MLX_MODES. The compile-time `const_assert_eq!`
+    // on lengths is necessary but not sufficient — it permits a swap (one entry
+    // moved from MLX to non-MLX with another entry going the other way). This
+    // runtime check pins set equality and disjointness so a misclassified
+    // subcommand cannot silently bypass the seatbelt-sandbox gate.
+    #[test]
+    fn subcommand_sets_partition_all_subcommands() {
+        let mlx: HashSet<&str> = MLX_DEPENDENT_MODES.iter().copied().collect();
+        let non_mlx: HashSet<&str> = NON_MLX_MODES.iter().copied().collect();
+        let all: HashSet<&str> = ALL_SUBCOMMANDS.iter().copied().collect();
+        assert!(
+            mlx.is_disjoint(&non_mlx),
+            "MLX-dependent and non-MLX sets must be disjoint; \
+             overlap means a subcommand is both gated and ungated. mlx={mlx:?} non_mlx={non_mlx:?}"
+        );
+        let union: HashSet<&str> = mlx.union(&non_mlx).copied().collect();
+        assert_eq!(
+            union, all,
+            "MLX ∪ non-MLX must equal ALL_SUBCOMMANDS; \
+             missing entries can silently bypass the seatbelt classification"
+        );
+    }
 
     // T-004: tty_reject_message_contains_fr_011_substring
     // FR-011: TTY_REJECT_MESSAGE must literally contain


### PR DESCRIPTION
## 概要

Issue #81 最終 Code fix #9。`src/bin/eval_harness.rs` で subcommand classification (MLX-dependent vs sandbox-safe) を std `const _: () = assert!(...)` (Rust 1.57+) で compile-time guard 化。新規 subcommand 追加時の `MLX_DEPENDENT_MODES` 更新漏れで seatbelt sandbox を silently 通過する hazard を mechanical に塞ぐ。

1 file / +61/-10 lines、依存追加ゼロ。

## 変更内容

### 新規 const

- `ALL_SUBCOMMANDS`: argv parsing 後 main() が受ける全 9 subcommand label (source of truth)
- `NON_MLX_MODES`: sandbox-safe な 3 subcommand (`oracle-gap` / `compare-baselines` / `annotate`)

### Compile-time partition guard

```rust
const _: () =
    assert!(MLX_DEPENDENT_MODES.len() + NON_MLX_MODES.len() == ALL_SUBCOMMANDS.len());
```

新 subcommand を `ALL_SUBCOMMANDS` に追加 → `MLX or NON_MLX` のどちらかへの追加を **compile-time** で強制。片方忘れ → build fail。

### 追加 guard

- **argv-time gate**: `if !ALL_SUBCOMMANDS.contains(&mode.as_str())` で unknown mode を早期 reject (`EXIT_USAGE`)
- **match arm fallback**: `other => unreachable!(...)` に変更。ALL_SUBCOMMANDS 追加 + dispatch arm 追加忘れを runtime panic で発見
- **usage banner derive**: `eprintln!` を `ALL_SUBCOMMANDS.join("|")` 駆動に変更。**bug fix 同時**: 旧 banner に `annotate` モードが missing だった問題も auto-sync で解消

### Runtime 補強 test (T-081-003)

集合論的整合性を pin: `MLX ∩ NON_MLX == ∅` (disjoint) + `MLX ∪ NON_MLX == ALL` (set equality)。const assert は len() のみ guard、swap (MLX ↔ NON_MLX 同時入れ替え) は検出不可、本 test で misclassification swap も封じる。

## 設計判断

| 選択肢 | 内容 | 採用 |
| --- | --- | --- |
| A | closed enum で全 subcommand 表現、exhaustive match | scope-creep |
| B | std `const _: () = assert!(...)` | **採用** |
| C | `static_assertions::const_assert!` | polish 結果で REUSE-001 (high) として B に置換 |
| D | test だけで覆う | compile-time でない |

Issue body は `static_assertions::const_assert!` を例示していたが、polish の reuse review で `const _: () = assert!(...)` が std (Rust 1.57+) で同等機能を提供することが指摘され (MSRV 1.95 に余裕)、LANG.md "Prefer std over crate" 規律 (`LazyLock` over `lazy_static!` 等) に整合させて std を採用。依存追加ゼロ。

## Polish 適用

`/polish` Phase 1 + Phase 2 反映済:
- **REUSE-001 (high)**: `static_assertions` → std `const _: () = assert!(...)`、dep 削除
- **CQ-1 (high)**: ALL_SUBCOMMANDS argv-time gate + `unreachable!()` で match arm drift も guard
- **CQ-3 (medium)**: rustdoc WHAT 重複削減
- **Phase 2**: usage banner derive (+annotate missing bug 修正) / stale rustdoc 修正

## テスト計画

- [x] `cargo fmt --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test --all-features` 通過 (267 passed / 0 failed)
- [x] 新 test T-081-003 が集合論的整合性 (disjoint + set equality) を pin

## 下流への影響

`eval_harness` は internal evaluation tooling、production CLI ではない。下流 (sae / yomu / recall) への影響なし。

## 参考

- Issue: #81 (Code fix #9 of 5、最終 Code fix)
- Audit: `docs/audit/2026-05-14-undocumented-decisions.md` § Recommended Follow-up #11
- LANG.md: "Idioms > Avoid" → `LazyLock` over `lazy_static!`、std assert! over `static_assertions`
