### PR TITLE
docs(adr): align ADR-0007 aggregation 例示 with AggregationKind enum

### DIFF
--- a/docs/audit/2026-05-14-adr-drift.md
+++ b/docs/audit/2026-05-14-adr-drift.md
@@ -1,0 +1,213 @@
+# ADR Drift Scan: 2026-05-14
+
+`/audit-adr-drift` skill run, scanning ADR-0001 〜 ADR-0007 in `docs/decisions/`
+against the current `amici` Rust crate (Cargo.toml workspace).
+
+## Summary
+
+| Metric            | Value |
+| ----------------- | ----- |
+| ADRs scanned      | 7     |
+| Drift findings    | 10    |
+| H priority        | 0     |
+| M priority        | 7     |
+| L priority        | 3     |
+| Unverifiable ADRs | 0     |
+
+ADR status breakdown:
+- Accepted: 0001, 0002, 0003, 0005
+- Proposed: 0004, 0006, 0007
+
+No superseded ADRs found locally; external ADR cross-checks live in the
+[External ADR Dependencies](#external-adr-dependencies) section.
+
+## Per-ADR Findings
+
+### ADR-0001: Extract Shared Model-Loading and CLI Utilities into amici Crate
+
+Status: accepted (2026-04-13)
+
+Decision symbol verification:
+
+| Symbol                  | Code location              | Status        |
+| ----------------------- | -------------------------- | ------------- |
+| `Spinner`               | `src/cli/spinner.rs:12`    | present       |
+| `try_expand_shorthand`  | `src/cli/shorthand.rs:12`  | present       |
+| `ModelLoad<T>`          | `src/model.rs:143`         | present       |
+| `try_load_reranker_with`| `src/model/reranker.rs:28` | present       |
+| `try_load_model_with`   | (not found, see #1 below)  | **renamed**   |
+| `in_placeholders`       | `src/storage/filter.rs:35` | present       |
+| `anon_placeholders`     | `src/storage/filter.rs:48` | present       |
+| `as_sql_params`         | `src/storage/filter.rs:53` | present       |
+| `append_eq_filter`      | `src/storage/filter.rs:67` | present       |
+
+Findings:
+
+| # | File:Line                                   | Description                                                                                                                                                                                                                                                                                                                                  | Direction  | Priority |
+| - | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | -------- |
+| 1 | `docs/decisions/0001-extract-shared-model-loading-and-cli-utilities-into-amici-crate.md:48` & `:65` | ADR-0001 Decision Outcome §Positive Consequences は `try_load_model_with<A,M>` 単一汎用関数を意図しているが、実装は `try_load_embedder_with_fns` (`src/model/embedder.rs:91`) と `try_load_reranker_with_fns` (`src/model/reranker.rs:43`) の 2 関数に分割。両者は cache→probe→new フローを共通骨格で持つが API は分離している | adr-update | L        |
+| 2 | `docs/decisions/0001-*.md:56-66` (Implementation Plan)                                              | Implementation Plan 図は `model/mod.rs` 記法だが、現状は LANG.md "sub.rs + sub/child.rs 規約" 準拠で `src/model.rs` + `src/model/{embedder,reranker}.rs`                                                                                                                                                                                  | adr-update | L        |
+| 3 | `docs/decisions/0001-*.md:56-66` (Implementation Plan)                                              | Implementation Plan は `storage.rs` 単一ファイルを意図したが、現状は `src/storage.rs` (re-export hub) + `src/storage/{filter,fts,query_helpers}.rs` に展開。`fts.rs` / `query_helpers.rs` の責務は ADR で予期されていなかった                                                                                                              | adr-update | L        |
+| 10 | `src/logging.rs:1-98` + `src/migration.rs:1-89` + `src/testing.rs:1-7` + `src/testing/hybrid.rs`   | ADR-0001 Implementation Plan は "5 カテゴリ" 明示 (cli/spinner, cli/shorthand, model/mod, model/reranker, storage)。現状の `lib.rs` は加えて `logging` (tracing subscriber wiring) / `migration` (`notify_schema_change` shared warn shape) / `testing` (test-support feature、`assert_filter_symmetric` symmetry contract) を export。すべて ADR-0001 Decision Drivers "バックポート作業ゼロ" と同じ outcome axis に沿った追加であり behavioural drift は無いが、ADR 文面 (Success Criteria "抽出した 5 カテゴリ" を含む) が現状を反映していない | adr-update | M        |
+
+Note: #1〜#3 は L priority の adr-update — Implementation Plan は ADR 起票時点の最小構成を示すものであり、現状の自然な成長 (LANG.md 規約準拠、追加ヘルパー) は ADR-0001 の charter (薄い共通基盤) を破っていない。
+
+#10 は M priority — `logging` / `migration` / `testing` の追加は ADR-0001 の outcome axis 上にあるが、ADR Decision Drivers が "5 カテゴリ" framing で書かれていることで future reader が silent scope creep と誤読する余地がある。修正は ADR-0001 Implementation Plan セクションに「Implementation Plan は initial extraction set を示す。後続の追加は ADR-0005 の judgment table (line 50-56) に従って判断する」の 1 行 footnote、あるいは別 ADR で charter 拡張を明示。reviewer-design (agent `a755631112ca5dcc5`) が独立に同定 (Finding A1)。
+
+### ADR-0002: Search Quality Evaluation Methodology
+
+Status: accepted (2026-04-27)
+
+Decision symbol verification:
+
+| Symbol / Concept                | Code location                                       | Status   |
+| ------------------------------- | --------------------------------------------------- | -------- |
+| `clean_for_trigram`             | `src/storage/fts.rs` (presence verified by use)     | present  |
+| 4-part methodology              | `src/eval/pipeline.rs` + `src/bin/eval_harness.rs`  | present  |
+| Fixture corpus (≥50 docs, ≥140 queries × 7 cat × ≥20) | `tests/fixtures/eval/{documents,queries}.jsonl` | present (LICENSES.md present) |
+| Known-answer fixtures (identity / reverse / single_doc) | `tests/fixtures/eval/known_answers.jsonl` | present  |
+| Bootstrap CI (n=1000, seed=42)  | `src/eval/metrics.rs::bootstrap_ci` (line 131)      | present  |
+| `MetricSpec::tolerance`         | `src/bin/eval_harness.rs:469` (referenced by L517)  | present  |
+| `BaselineSnapshot` envelope     | `src/eval/baseline.rs:176`                          | present  |
+| `Oracle Mode` (Pattern A)       | `src/eval/oracle_pipeline.rs` + `src/eval/oracle_gap.rs` | present |
+
+Findings: **no drift**. ADR-0002 の方法論はコードに完全に反映されている。Reassessment Triggers 内のリンク (rurico ADR 0006 等) は外部参照のため本 scan の cross-check 範囲外。
+
+### ADR-0003: Add pgr-style First-Search Offline Retrieval Benchmark
+
+Status: accepted (2026-05-08)
+
+Decision symbol verification:
+
+| Symbol / Concept                  | Code location                                         | Status  |
+| --------------------------------- | ----------------------------------------------------- | ------- |
+| `hit_at_k`                        | `src/eval/metrics.rs:113`                             | present |
+| `MetricSpec::HitAt1` / `HitAt3`   | `src/bin/eval_harness.rs:469-470` (via `MetricSpec::ALL` ordering test L2229-2240) | present |
+| `BaselineKind::FirstSearchReplay` | `src/eval/baseline.rs:91`                             | present |
+| `replay-first-search` subcommand  | `src/bin/eval_harness.rs:1046` (referenced)           | present |
+| `BASELINE_SCHEMA_VERSION = "1.3"` | `src/eval/baseline.rs:53`                             | present |
+| Parent rollup via `MaxChunkAggregator` (BR-003)  | `src/eval/baseline.rs:82-91` (FirstSearchReplay doc) + `AggregationKind::NotApplicable` (L122-126) | present |
+
+Findings: **no drift**. ADR-0003 第 1-4 deliverable はコード側で完成済み。`BASELINE_SCHEMA_VERSION` 1.2→1.3 bump も実施され、committed `first_search_replay_baseline.json` も存在する (`tests/fixtures/eval/first_search_replay_baseline.json`)。
+
+### ADR-0004: Annotation Framework Foundation
+
+Status: proposed (2026-05-08, awaiting PR-B / PR-C land for promote)
+
+Decision symbol verification:
+
+| Symbol / Concept                       | Code location                       | Status  |
+| -------------------------------------- | ----------------------------------- | ------- |
+| `eval::annotation` module              | `src/eval/annotation.rs`            | present |
+| `Session` / `Entry` / `BlockMode` / `Provenance` | `src/eval/annotation.rs:36-95` | present |
+| `ANNOTATION_SCHEMA_VERSION = "1.0"`    | `src/eval/annotation.rs:29`         | present |
+| `AnnotationError` (`#[non_exhaustive]` + `thiserror`) | `src/eval/annotation.rs:137-164` | present |
+| Phase 1 で `model_id`/`mlx_rs_version` 欠落 | `src/eval/annotation.rs:42-63` (`Provenance` 定義に存在しない) | present (intentional) |
+| `EvalQuery.annotation: String` との naming 分離 | `src/eval/fixture.rs:35` + `src/eval/annotation.rs:81-82` (`annotation_note`) | present |
+
+Findings: **no drift**. Phase 1 sub-PR-A foundation はコード側で完成済み。Status: proposed は ADR 本文記載の通り PR-B / PR-C land 待ち。FR-030/031/032 の test invariant (`tests/eval_annotation.rs:416-447`) も present。
+
+### ADR-0005: Place Model Wiring in rurico, Keep amici as Thin Composition Base
+
+Status: accepted (2026-05-11)
+
+Decision symbol verification:
+
+| Symbol / Concept                | Code location                                                                              | Status  |
+| ------------------------------- | ------------------------------------------------------------------------------------------ | ------- |
+| `LazyReranker` (rurico-side)    | `src/bin/eval_harness.rs:90` (`LazyReranker::new(init_reranker)`); definition lives in `rurico` rev `b4f27da` | external use |
+| `production_context()`          | `src/bin/eval_harness.rs:87`                                                               | present |
+| `Rerank` trait wrapping skip path | `src/bin/eval_harness.rs:2293` (T-068-001 LazyReranker init must not fire when replay path runs) | present |
+
+Findings: **no drift**. reviewer-design (`a755631112ca5dcc5`) が独立に確認:
+
+- B1 (`src/bin/eval_harness.rs:87-97`): `LazyReranker::new(init_reranker)` は 1 行 composition。amici 内に `OnceLock` / `OnceCell` / `LazyLock` / `RefCell<Option<…>>` が `src/` 配下 (test 除く) 0 件で、lazy semantics の local 再実装は **無し**。ADR-0005 line 51 (`Embed`/`Rerank` trait wrapper → rurico) に厳密準拠
+- B2 (`src/model/embedder.rs:91-134`): `try_load_embedder_with_fns` は rurico-owned primitives 4 件 (`cached_artifacts` / `Embedder::probe` / `Embedder::new` / `Artifacts::delete_files`) の state-machine composition。amici 固有の追加は `DegradedReason` enum mapping + corrupt-artifact deletion flow + `on_delete_error` / `on_probe_err` callback の 3 点で、これらは CLI-presentation concern (ADR-0005 line 54 "上記 primitives を組み合わせた業務 facets → amici" に該当)
+
+ADR-0001 (先行) → ADR-0005 (responsibility judgment 明文化) の時系列で、ADR-0005 が既存実装を retroactively 検証した構造。boundary は code 側で清く保たれている。
+
+### ADR-0006: Pin PIPELINE_K=10 as part of baseline schema contract
+
+Status: proposed (2026-05-14)
+
+Decision symbol verification:
+
+| Symbol / Concept                | Code location                                  | Status              |
+| ------------------------------- | ---------------------------------------------- | ------------------- |
+| `PIPELINE_K = 10` 定義          | `src/bin/eval_harness.rs:99`                   | present             |
+| ADR-0006 reference comment in code | (not present)                              | **missing**         |
+| `verify-baseline` の K 逆引き検証 | (not present)                                | **missing**         |
+| `MetricSpec::ALL` soundness anchor | `src/bin/eval_harness.rs:1743`               | present             |
+
+Findings:
+
+| # | File:Line                                | Description                                                                                                                                                                                                                                                       | Direction | Priority |
+| - | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | -------- |
+| 4 | `src/bin/eval_harness.rs:99`             | ADR-0006 §Decision Outcome 3 "コード側マーカー (実装 follow-up)": `PIPELINE_K` 定義に ADR-0006 を参照するコメントを追加する指示が **未実装**。現状コメントなし。`SHUFFLE_SEED`/`BOOTSTRAP_SEED` と同列の load-bearing constant であることが visible でない | code-fix  | M        |
+| 5 | `src/bin/eval_harness.rs:1378-1403` (run_verify_baseline_with) | ADR-0006 §Decision Outcome 4 / §Implementation Guidelines 第 2 項 "検証マーカー (実装 follow-up)": `verify-baseline` で committed baseline.json の `recall@k` キー名から K を逆引きし `PIPELINE_K` と不一致なら `EXIT_REGRESSION` で fail する **明示的** な検証は **未実装**。現状は `MetricSpec::ALL` iterate で「現在の harness が要求する metric 名 (= `PIPELINE_K` で組み立てた `recall@10` 等) が committed に無い」エラーが `EXIT_REGRESSION` を返す**副作用として K 不一致が捕捉される** (L1386-1391 "committed baseline lacks {name}; regenerate via capture-baseline") 構造で、silent invalidation には至っていない。一方 ADR-0006 が宣言する「キー名から K を逆引き」する意図的 marker は無い | code-fix  | M        |
+
+Note: #5 は ADR-0006 §Context "failure mode が silent" の懸念に対し、現実装では `MetricSpec::ALL` (line 1378) と name lookup (line 1386) の副作用で K 不一致が `EXIT_REGRESSION` に到達するため silent **ではない**。ADR-0006 が指示する **明示的** な逆引きマーカーが未実装なだけ。priority は M (副作用 gate が存在するので H ではない、ADR Implementation Guidelines 第 2 項の指示は残存タスク)。逆引き marker が land すれば ADR-0006 §Reassessment Triggers 第 4 項 (ADR の自然消滅 or Implementation Guidelines への縮退) が発火する。
+
+### ADR-0007: Pin BaselineSnapshot serde defaults to pre-existing behavior
+
+Status: proposed (2026-05-14)
+
+Decision symbol verification:
+
+| Symbol / Concept                 | Code location                                      | Status                 |
+| -------------------------------- | -------------------------------------------------- | ---------------------- |
+| `BaselineSnapshot` struct        | `src/eval/baseline.rs:176-231`                     | present                |
+| 3 つの `#[serde(default = ...)]` | `aggregation` L205 / `merge_config` L213 / `normalization` L221 | present  |
+| `default_aggregation_kind` fn    | `src/eval/baseline.rs:233-235`                     | present                |
+| `pre_phase_5_disabled` (rurico)  | `src/eval/baseline.rs:18` (import) + L221 (use)    | present                |
+| `BASELINE_SCHEMA_VERSION = "1.3"` | `src/eval/baseline.rs:53`                         | present                |
+| `AggregationKind` enum (PR #86)  | `src/eval/baseline.rs:117-127`                     | present (post-PR #86)  |
+| module-doc に "# serde default discipline" | `src/eval/baseline.rs:1-10`            | **missing**            |
+| historical-fixture test          | `tests/fixtures/eval/historical/`                  | **missing** (directory absent) |
+
+Findings:
+
+| # | File:Line                                                                | Description                                                                                                                                                                                                                                            | Direction  | Priority |
+| - | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------- | -------- |
+| 6 | `docs/decisions/0007-pin-baselinesnapshot-serde-defaults-to-pre-existing-behavior.md:19` | "default が指す値の意味" 段落で `aggregation = "identity"` と文字列リテラル表記。PR #86 (`ce7d2b0 feat(eval): aggregation を typed AggregationKind enum に昇格`) で typed enum 化 landed なので `AggregationKind::Identity` 表記が現状の真。**PR-A 実行時に scan 取りこぼしを発見 → line 90 (Trade-offs `aggregation: String` 言及) と line 114 (Reassessment Triggers `aggregation: String` 昇格 trigger) も同種 drift。4 箇所すべて PR-A で同時修正済み (line 114 は strikethrough + "PR #86 fired" 注記の形)** | adr-update | M        |
+| 7 | `docs/decisions/0007-*.md:106` (Implementation Guidelines table の `aggregation` 行)     | 同 table の serde default 列で `aggregation = "identity"` の文字列リテラル例示。PR #86 後の状態 (typed `AggregationKind::Identity`) を反映できていない                                                                                                | adr-update | M        |
+| 8 | `src/eval/baseline.rs:1-10` (module-doc)                                 | ADR-0007 §Decision Outcome 2 "モジュールドキュメント追加 (実装 follow-up)": `//!` に "# serde default discipline" 段落を追加し ADR-0007 を参照する指示が **未実装**。現状の module-doc は `MetricResult` の derive 共有説明のみ                          | code-fix   | M        |
+| 9 | `tests/fixtures/eval/historical/` (該当ディレクトリ無し)                  | ADR-0007 §Decision Outcome 4 "テスト marker (実装 follow-up)": historical baseline (field-less) を fixture として pin し新フィールド追加時の default 経由 deserialize 結果が historical 時代の挙動と数値一致することを検証する unit test が **未実装** | code-fix   | M        |
+
+Note: #6 #7 はユーザーが事前に把握している ADR-0007 follow-up タスク (本 scan trigger と同じ)。#8 #9 は同 ADR の Decision Outcome に実装 follow-up と明記された残タスク。4 件を 1 PR にまとめるか #6 #7 (ADR 更新) と #8 #9 (実装) で分離するかは separate decision。
+
+## External ADR Dependencies
+
+以下は amici 内に local ADR が存在しないが code / ADR / test から参照されている ADR ID。
+
+| # | File:Line                                                                                                                  | External ADR ref              | Recommended action                                                          |
+| - | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | --------------------------------------------------------------------------- |
+| 1 | `src/cli/exit_code.rs:11,21,23,53,72,96,105,135` + `src/bin/eval_harness.rs:142,149` + `README.md:236,238,251,254`         | ADR-0066 (not local)          | shared dotclaude / scout-local ADR と推定。`amici` repo に promote / supersede locally して可視化するか、参照に "external" マーカーを足すか |
+| 2 | `docs/decisions/0001-*.md:18` (Decision Drivers)                                                                           | ADR-0037 (not local, ADR内引用) | ADR-0001 起票時の historical context。supersede 不要だが promote 候補ではある |
+| 3 | `tests/eval_annotation.rs:443` (forbidden citation list)                                                                   | ADR-0021 (not local, FR-032 forbidden) | 引用禁止リストとしての参照 (NFR-003)。policy 的に意図的なので drift ではない |
+
+ADR-0066 は exit code classification の baseline として code 側 8 箇所以上で active に参照されており、source-of-truth が `amici` 外にある状態は long-term には maintainability 上のリスク。
+
+## Follow-up Issue Candidates
+
+H priority drift: **none** (#5 was downgraded H→M after verifying `run_verify_baseline_with` body — silent invalidation is already prevented by `MetricSpec::ALL` name-lookup as a side-effect, see ADR-0006 finding note).
+
+M priority drift から発生する follow-up (Issue 化 optional、別 PR で fold 可):
+
+- [ ] **ADR-0006 #5**: `src/bin/eval_harness.rs:1378-1403` で committed baseline.json の `recall@k` メトリック名から K を逆引きし `PIPELINE_K` と不一致なら明示的に `EXIT_REGRESSION` で reject する gate を追加 (現状は name-lookup の副作用で捕捉されているが、ADR-0006 §Implementation Guidelines 第 2 項の明示的マーカーは未実装)
+- [ ] **ADR-0006 #4**: `src/bin/eval_harness.rs:99` `PIPELINE_K` 定義に ADR-0006 を参照する `///` コメント追加 (上記 #5 の PR にまとめても良い)
+- [ ] **ADR-0007 #6 / #7**: ADR-0007 本文の aggregation 文字列リテラル例示を `AggregationKind::Identity` 等の typed enum 表記に更新 (PR #86 後の状態反映)
+- [ ] **ADR-0007 #8**: `src/eval/baseline.rs` module-doc に "# serde default discipline" 段落追加し ADR-0007 を参照
+- [ ] **ADR-0007 #9**: `tests/fixtures/eval/historical/` 配下に field-less baseline fixture を pin し deserialize round-trip test を追加
+
+追加 M priority follow-up (reviewer-design Finding A1 経由):
+
+- [ ] **ADR-0001 #10**: ADR-0001 Implementation Plan セクションに「Implementation Plan は initial extraction set を示す。後続の追加は ADR-0005 の judgment table (line 50-56) に従って判断する」の footnote を 1 行追加。または、`logging` / `migration` / `testing` 追加経緯をまとめた supersede / amendment ADR を起票
+
+L priority drift (ADR-0001 系 #1〜#3) は ADR の next-touch 時に Implementation Plan を historical intent として明示する形で吸収する候補。即時 Issue 化は不要。
+
+## Notes
+
+- Date pinned via `date -u +%Y-%m-%d` (UTC, ISO format) per skill spec; this differs from local clock (2026-05-15) by 1 day depending on timezone.
+- `reviewer-design` (background agent `a755631112ca5dcc5`) が ADR-0001 charter scope (観点 A) と ADR-0005 boundary semantic (観点 B) を独立 review。観点 A で Finding A1 (本 report #10) を新規同定、観点 B で B1/B2 を accept 判定 (本 report ADR-0005 セクションへ統合済み)。
+- `reviewer-rust` was skipped to keep scan turnaround tractable; the symbol verification table per ADR already covers Rust-specific semantic checks (`#[non_exhaustive]`, serde default discipline, `MetricSpec::ALL` soundness anchor, `LazyReranker` placement).

--- a/docs/decisions/0007-pin-baselinesnapshot-serde-defaults-to-pre-existing-behavior.md
+++ b/docs/decisions/0007-pin-baselinesnapshot-serde-defaults-to-pre-existing-behavior.md
@@ -16,7 +16,7 @@
 
 すなわち serde default は「runtime default」ではなく「pre-existing-behavior (そのフィールドが存在しなかった時点での実質挙動)」を指す。runtime default を割り当てると、historical な baseline.json の意味が "そのフィールドが現在の default 設定で評価された" に silently rewrite される。
 
-この規律は 3 フィールド (`aggregation` = `"identity"`, `merge_config` = `HybridSearchConfig::default()`, `normalization` = `pre_phase_5_disabled`) で守られているが、module-level の規約として文書化されていない。`BASELINE_SCHEMA_VERSION` の bump policy (`pub const BASELINE_SCHEMA_VERSION: &str = "1.3";` のコメント参照) は「breaking change で bump」と定めるが、本規律 (= "default は pre-existing-behavior でなければ silently 意味が変わる") が崩れると bump policy 自体が機能しなくなる。
+この規律は 3 フィールド (`aggregation` = `AggregationKind::Identity`, `merge_config` = `HybridSearchConfig::default()`, `normalization` = `pre_phase_5_disabled`) で守られているが、module-level の規約として文書化されていない。`BASELINE_SCHEMA_VERSION` の bump policy (`pub const BASELINE_SCHEMA_VERSION: &str = "1.3";` のコメント参照) は「breaking change で bump」と定めるが、本規律 (= "default は pre-existing-behavior でなければ silently 意味が変わる") が崩れると bump policy 自体が機能しなくなる。
 
 将来 4 つ目のフィールドを追加する contributor が runtime default を割り当てれば、historical baseline は新しい意味で読み直され、regression gate が誤検知/見逃しを起こす。型・lint で防げず、テストも難しい (historical な field-less ファイル fixture を pin する必要がある)。
 
@@ -87,7 +87,7 @@ Chosen option: "Module-doc + ADR で規律を明文化、新規フィールド�
 
 ### Trade-offs
 
-`BaselineKind` (closed enum, `#[serde(rename_all = "snake_case")]`) と `aggregation: String` (open string + serde default) の typed/untyped 非対称は、本 ADR の射程外として残す (audit report #56 で別途 type-system fix 候補)。本 ADR は default **値の選び方** に関する規律のみを定める。
+`BaselineKind` (closed enum, `#[serde(rename_all = "snake_case")]`) と `aggregation` フィールドの typed/untyped 非対称は **PR #86 で resolved** — `aggregation` は `AggregationKind` typed enum に昇格し、wire form (`identity` / `max-chunk` / `dedupe` / `topk-average:k` / `none`) は manual `Serialize` / `Deserialize` impl で controlled (`src/eval/baseline.rs:117-171`)。audit report #56 で別途 type-system fix 候補と記録していた gap は閉じた。本 ADR は default **値の選び方** に関する規律のみを定める。
 
 ### Implementation Guidelines
 
@@ -103,7 +103,7 @@ Chosen option: "Module-doc + ADR で規律を明文化、新規フィールド�
 
 | フィールド (追加時の文脈) | serde default | runtime default | 採用 default |
 | ------------- | ------------- | --------------- | ------------ |
-| `aggregation` (pre-aggregation baseline 存在) | `"identity"` | `"identity"` | `"identity"` (両者一致、`default_aggregation_kind`) |
+| `aggregation` (pre-aggregation baseline 存在) | `AggregationKind::Identity` | `AggregationKind::Identity` | `AggregationKind::Identity` (両者一致、`default_aggregation_kind`) |
 | `merge_config` (pre-merge-config baseline 存在) | `HybridSearchConfig::default()` (`rrf_k=60`, weights=1.0) | 同上 | runtime default 同等 (`#[serde(default)]`) |
 | `normalization` (pre-normalization baseline 存在) | `pre_phase_5_disabled` (all OFF) | `QueryNormalizationConfig::default` (all ON) | `pre_phase_5_disabled` (両者異なる、historical 側採用) |
 
@@ -111,7 +111,7 @@ Chosen option: "Module-doc + ADR で規律を明文化、新規フィールド�
 
 - `BaselineSnapshot` を struct 廃止し schema-bound serializer (e.g. `prost`/`schemars`-driven) に切り替える場合 → 規律の射程が変わる
 - historical fixture-based test が CI gate として land し、規律が機械的強制になった場合 → ADR の役割が縮退、Implementation Guidelines のみに統合再評価
-- `aggregation: String` が typed enum に昇格した場合 → 本 ADR の例示更新
+- ~~`aggregation: String` が typed enum に昇格した場合 → 本 ADR の例示更新~~ — **PR #86 で fired、本 ADR の line 19 / 90 / 106 例示更新済み (2026-05-14 adr-drift scan PR-A)**
 
 ## References
 


### PR DESCRIPTION
## 概要

- ADR-0007 文書内の `aggregation` 文字列リテラル例示 (合計 4 箇所) を `AggregationKind::Identity` 等の typed enum 表記に更新。PR #86 (`ce7d2b0 feat(eval): aggregation を typed AggregationKind enum に昇格`) で landed した状態を ADR-0007 文書に反映する
- `/audit-adr-drift` skill 実行 output (`docs/audit/2026-05-14-adr-drift.md`) を同梱。ADR-0001〜0007 を symbol verification + reviewer-design semantic check で検証、10 findings (H:0 / M:7 / L:3) を記録

## 変更内容

| Line | Section | 修正 |
| ---- | ------- | ---- |
| 19  | Context 段落 | `` `aggregation` = `"identity"` `` → `` `aggregation` = `AggregationKind::Identity` `` |
| 90  | More Information § Trade-offs | `aggregation: String` の typed/untyped 非対称言及 → "PR #86 で resolved" + `AggregationKind` enum 化 + manual `Serialize`/`Deserialize` impl 言及に書き換え |
| 106 | Implementation Guidelines table | serde default 列の `"identity"` → `AggregationKind::Identity` |
| 114 | Reassessment Triggers | `aggregation: String` 昇格 trigger を strikethrough + "PR #86 で fired、本 ADR の例示更新済み" 注記 |

当初 drift scan は #6 (line 19) と #7 (line 106) の 2 箇所を識別したが、PR-A 実行時の再走査で line 90 と line 114 も同種 drift と判明。`docs/audit/2026-05-14-adr-drift.md` の #6 description に取りこぼし注記を追加済み。

## テスト計画

- [ ] ADR-0007 が markdown として正しく rendering される (line 114 の `~~strikethrough~~` 含む)
- [ ] drift report の cross-reference が ADR-0007 と整合している
- [ ] referenced PR #86 (`ce7d2b0`) が正しい commit を指している

## 関連

- 引き継ぎ事項: ADR-0007 follow-up (aggregation 文字列リテラル例示 → enum 表記、別 PR で実施)
- Drift findings: `docs/audit/2026-05-14-adr-drift.md` ADR-0007 #6 #7 (+ PR-A 実行時発見の line 90 / 114)
- Follow-up PR シリーズ:
  - PR-B: ADR-0007 #8 #9 (module-doc に "# serde default discipline" 段落追加 + historical-fixture test)
  - PR-C: ADR-0006 #4 #5 (`PIPELINE_K` ADR reference comment + `verify-baseline` K 逆引き明示 gate)
  - 別途: ADR-0001 #10 charter extension 議論 (logging/migration/testing の Implementation Plan 整合)