### PR TITLE
docs(adr-0007): serde default 規律と historical fixture を pin (#8 #9)

### DIFF
--- a/src/eval/baseline.rs
+++ b/src/eval/baseline.rs
@@ -7,6 +7,28 @@
 //! [`MetricResult`] reuses the [`serde::Serialize`] / [`serde::Deserialize`]
 //! derive added on the same type in `metrics.rs`; this module's
 //! [`BaselineSnapshot`] composes it directly so its own derive is sufficient.
+//!
+//! # serde default discipline (ADR-0007)
+//!
+//! 新フィールドを [`BaselineSnapshot`] に追加するとき、`#[serde(default = "fn_name")]`
+//! を必ず付与し、その default 関数は **そのフィールドが存在しなかった時点での実質挙動
+//! (pre-existing behavior)** を返す。runtime default (e.g. `Foo::default()`) を割り
+//! 当てる場合は、それが historical baseline の実質挙動と一致する根拠を PR 説明または
+//! コード上で示すか、[`BASELINE_SCHEMA_VERSION`] を bump する。
+//!
+//! 既存 3 フィールドは本規律に従う:
+//!
+//! - `aggregation`: [`AggregationKind::Identity`] を返す ([`default_aggregation_kind`])
+//! - `merge_config`: `HybridSearchConfig::default()` 同等 (pre-merge-config 時代と一致、`#[serde(default)]`)
+//! - `normalization`: [`pre_phase_5_disabled`] (all OFF、runtime `QueryNormalizationConfig::default` の all ON とは **異なる** historical 側採用)
+//!
+//! 規律は historical baseline (3 フィールド欠落) を `tests/fixtures/eval/historical/`
+//! 配下に pin した unit test (`historical_baseline_resolves_serde_defaults_to_pre_existing_behavior`)
+//! で、default 経由の deserialize が pre-existing behavior と一致することを CI で gate する。
+//!
+//! 規律の根拠と新フィールド追加手順は ADR-0007
+//! (`docs/decisions/0007-pin-baselinesnapshot-serde-defaults-to-pre-existing-behavior.md`)
+//! 参照。
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -656,6 +678,50 @@ mod tests {
         assert!(
             !dir.path().join(".artifact.json.tmp").exists(),
             "temp file must be renamed away"
+        );
+    }
+
+    // ADR-0007 #9: historical_baseline_resolves_serde_defaults_to_pre_existing_behavior
+    //
+    // §Decision Outcome 4 + §Implementation Guidelines step 4: field-less
+    // historical baseline (`aggregation` / `merge_config` / `normalization` 3
+    // フィールドすべて欠落) を deserialize し、各 serde default が
+    // pre-existing behavior と等価な値に解決されることを pin。本 test が fail =
+    // 既存 default 関数のいずれかが pre-existing behavior と乖離した = 規律違反、
+    // ADR-0007 の bump policy 前提が崩れる。
+    #[test]
+    fn historical_baseline_resolves_serde_defaults_to_pre_existing_behavior() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/eval/historical/pre_serde_defaults.json");
+        let text =
+            fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        let parsed: BaselineSnapshot = serde_json::from_str(&text).unwrap_or_else(|e| {
+            panic!(
+                "historical fixture must deserialise via serde defaults (3 missing \
+                 fields each resolved by their `#[serde(default = ...)]`): {e}"
+            )
+        });
+
+        assert_eq!(
+            parsed.aggregation,
+            AggregationKind::Identity,
+            "ADR-0007: pre-aggregation historical baseline must resolve `aggregation` \
+             via `default_aggregation_kind` to `AggregationKind::Identity` \
+             (== pre-existing behavior, NOT a runtime default that drifted)"
+        );
+        assert_eq!(
+            parsed.merge_config,
+            HybridSearchConfig::default(),
+            "ADR-0007: pre-merge-config historical baseline must resolve `merge_config` \
+             via `#[serde(default)]` to `HybridSearchConfig::default()` \
+             (rrf_k=60, fts/vector weights=1.0 — pre-merge-config 時代の実質挙動)"
+        );
+        assert_eq!(
+            parsed.normalization,
+            pre_phase_5_disabled(),
+            "ADR-0007: pre-normalization historical baseline must resolve `normalization` \
+             via `pre_phase_5_disabled` to all-OFF \
+             (NOT runtime `QueryNormalizationConfig::default` which is all-ON)"
         );
     }
 }

--- a/tests/fixtures/eval/historical/pre_serde_defaults.json
+++ b/tests/fixtures/eval/historical/pre_serde_defaults.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.3",
+  "kind": "forward",
+  "captured_with": "test-historical-fixture (ADR-0007 #9)",
+  "timestamp": "epoch:0",
+  "model_id": "test/model",
+  "model_revision": "rev",
+  "mlx_rs_version": "0.0.0",
+  "fixture_hash": "fnv1a64:0",
+  "global": [],
+  "per_category": {},
+  "latency_p50_ms": 0.0,
+  "latency_p95_ms": 0.0
+}


### PR DESCRIPTION
## 概要

- ADR-0007 §Decision Outcome 2 + 4 の "実装 follow-up" を land。drift findings `docs/audit/2026-05-14-adr-drift.md` ADR-0007 #8 #9 に対応
- #8 module-doc: 規律明文化、#9 historical-fixture test: pre-existing behavior 一致を CI gate
- ADR-0007 Status: proposed のまま維持。Reassessment Triggers 第 2 項 (`historical fixture-based test が CI gate として land → ADR の役割が縮退、Implementation Guidelines のみに統合再評価`) の trigger 発火後の判断 (縮退 / 統合 / accepted) は別 PR で議論

## 変更内容

| ファイル | 内容 |
| -------- | ---- |
| `src/eval/baseline.rs` (module-doc) | "# serde default discipline (ADR-0007)" 段落を冒頭 module-doc に追加。新フィールド追加時の規律 + 既存 3 フィールド (`aggregation` / `merge_config` / `normalization`) の根拠を明文化 |
| `src/eval/baseline.rs` (`#[cfg(test)] mod tests`) | `historical_baseline_resolves_serde_defaults_to_pre_existing_behavior` test 追加。deserialize 後の 3 フィールドが `AggregationKind::Identity` / `HybridSearchConfig::default()` / `pre_phase_5_disabled()` と一致することを `assert_eq!` で gate |
| `tests/fixtures/eval/historical/pre_serde_defaults.json` (新規) | 3 フィールド (`aggregation` / `merge_config` / `normalization`) 欠落の field-less baseline fixture を pin。schema_version は現行 "1.3"、kind は forward |

`historical_*` test は default 関数のいずれかが pre-existing behavior と乖離する変更が入ったときに fail し、ADR-0007 の bump policy 前提 (= "default は pre-existing behavior でなければ silently 意味が変わる") を CI gate として強制する。

## テスト計画

- [x] `cargo test --features eval-harness historical_baseline_resolves_serde_defaults` で新規 test pass
- [x] `cargo test --features eval-harness` 全 pass (regression check)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] pre-commit hook (`cargo fmt --check` + `cargo clippy`) pass
- [ ] CI で merge gate (主要 OS / feature combination) 通過

## 関連

- 引き継ぎ: PR #92 (PR-A、ADR-0007 aggregation enum 表記化) merge 後の続き、PR-B として実施
- Drift findings: `docs/audit/2026-05-14-adr-drift.md` ADR-0007 #8 #9
- Follow-up PR シリーズ:
  - PR-C: ADR-0006 #4 #5 (`PIPELINE_K` ADR reference comment + `verify-baseline` K 逆引き明示 gate)
  - 別途: ADR-0001 #10 charter extension 議論 (`logging` / `migration` / `testing` Implementation Plan 整合)
  - 別途: ADR-0007 Status promote / 縮退 / 統合 議論 (Reassessment Triggers 第 2 項 trigger fire 後)