### PR TITLE
feat(adr-0006): PIPELINE_K に ADR ref + envelope validator に K mismatch gate (#4 #5)

### DIFF
--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -96,6 +96,22 @@ fn production_context()
     })
 }
 
+/// Load-bearing constant for the baseline.json schema contract (ADR-0006).
+/// The `*_at_k` metric names (`recall@10`, `mrr@10`, `ndcg@10`) and the
+/// committed `MetricResult.k` values for those metrics all derive from this
+/// value, so any bump silently invalidates every `tests/fixtures/eval/*.json`
+/// baseline.
+///
+/// Change protocol (ADR-0006 § Decision Outcome 2):
+/// - (a) bump `BASELINE_SCHEMA_VERSION`
+/// - (b) recapture every `tests/fixtures/eval/*.json` baseline
+/// - (c) append "PIPELINE_K change" row to ADR-0002 § Reassessment Triggers
+/// - (d) supersede ADR-0006 with a new ADR documenting the new value
+///
+/// `validate_committed_baseline_envelope` rejects a committed baseline whose
+/// recorded `MetricResult.k` disagrees with what `MetricSpec` declares for
+/// that metric name, so a stale baseline fails fast before model load
+/// (ADR-0006 § Implementation Guidelines 第 2 項).
 const PIPELINE_K: usize = 10;
 const SHUFFLE_SEED: u64 = 42;
 const BOOTSTRAP_RESAMPLES: usize = 1000;
@@ -1211,6 +1227,22 @@ fn validate_committed_baseline_envelope(
             committed.schema_version, BASELINE_SCHEMA_VERSION
         );
         return Err(EXIT_REGRESSION);
+    }
+    for metric in &committed.global {
+        if let Some(spec) = MetricSpec::ALL.iter().find(|s| s.name() == metric.name)
+            && metric.k != spec.k()
+        {
+            eprintln!(
+                "verify-baseline: failed — committed metric {:?} has k={} but \
+                 MetricSpec defines k={} (ADR-0006 schema contract); K mismatch \
+                 invalidates baseline semantics — regenerate via \
+                 {{capture-baseline | capture-oracle | replay-first-search}} before verifying",
+                metric.name,
+                metric.k,
+                spec.k()
+            );
+            return Err(EXIT_REGRESSION);
+        }
     }
     if let Some(expected_kind_raw) = kvs.get("kind") {
         let expected_kind = match parse_baseline_kind(expected_kind_raw) {
@@ -2496,6 +2528,33 @@ mod tests {
             result,
             Err(EXIT_REGRESSION),
             "FR-023/NFR-005: stale 1.2 baseline must EXIT_REGRESSION"
+        );
+    }
+
+    // T-ADR0006-005: verify_baseline_rejects_committed_metric_with_k_mismatch
+    //
+    // ADR-0006 § Implementation Guidelines 第 2 項: committed metric の
+    // `MetricResult.k` が `MetricSpec` で宣言された k と一致しない場合は
+    // PIPELINE_K bump 由来の stale baseline として `EXIT_REGRESSION`。
+    // 実装は ADR 本文 ("recall@k キー名から逆引き") ではなく `.k` field 直読 +
+    // `MetricSpec.k()` 比較 (string parse 不要、rename も downstream で別途検出)。
+    #[test]
+    fn verify_baseline_rejects_committed_metric_with_k_mismatch() {
+        let mut snap = snapshot_for_envelope_test(BASELINE_SCHEMA_VERSION, BaselineKind::Forward);
+        snap.global.push(MetricResult {
+            name: "recall@10".to_owned(),
+            k: 5,
+            point_estimate: 0.0,
+            ci_lower: 0.0,
+            ci_upper: 0.0,
+            uninformative: false,
+        });
+        let kvs = HashMap::new();
+        let result = validate_committed_baseline_envelope(&snap, &kvs);
+        assert_eq!(
+            result,
+            Err(EXIT_REGRESSION),
+            "ADR-0006: MetricSpec.k() と committed metric.k の不一致は EXIT_REGRESSION"
         );
     }
 


### PR DESCRIPTION
## 概要

`/audit-adr-drift` (2026-05-14) で検出された ADR-0006 drift #4 + #5 を close。

- **#4**: `const PIPELINE_K: usize = 10;` (eval_harness.rs:L99) に ADR-0006 reference の `///` doc comment が無く、change protocol が code-side に visible でなかった
- **#5**: ADR-0006 § Implementation Guidelines 第 2 項が指定する verify-baseline の K 逆引き gate が実装されておらず、PIPELINE_K bump 由来の stale baseline が `MetricSpec::ALL` name lookup の副作用でしか弾かれなかった

PR-A (#92) → PR-B (#93) に続く drift remediation 3 PR シリーズの第 3 弾。

## 変更内容

### #4: PIPELINE_K に doc comment 追加 (eval_harness.rs:L99)

ADR-0006 への reference と change protocol 4 step (schema bump / recapture / ADR-0002 trigger 行追加 / ADR supersede) を inline 化。

### #5: K mismatch gate を validate_committed_baseline_envelope に追加

`schema_version` check の直後に追加。`committed.global` を iterate し、各 `MetricResult.name` を `MetricSpec::ALL` で逆引きして `MetricResult.k` が `MetricSpec.k()` と一致しない場合は `EXIT_REGRESSION`。fail-fast — model load 前に弾く。

### ADR 本文と実装の差

ADR-0006 § Implementation Guidelines 第 2 項は **\"`recall@k` キー名から K を逆引き\"** と記述するが、本実装は:

- `MetricResult.k` field を直読 (string parse 不要)
- `MetricSpec.k()` と比較 (`PIPELINE_K` blanket 比較ではない)

理由: `MetricSpec::ALL` は k=1 (hit@1), k=3 (hit@3), k=5 (recall@5), k=10 (recall@10/mrr@10/ndcg@10) が **mixed** なので、`PIPELINE_K` (=10) との単純比較は HitAt1/HitAt3/RecallAt5 を不当に reject する。`MetricSpec.k()` 比較なら spec が宣言する k 値ごとに正しく gate される。

string parse 不要で robust、metric rename も downstream の `MetricSpec::ALL` iterator (Issue #61) で別途検出される。未知 metric 名は本 gate を silent pass するが同 downstream gate で捕捉。

本 interpretation gap は **ADR-0006 follow-up footnote 候補** として記録。

## テスト計画

- [x] `cargo test --features eval-harness --bin eval_harness` (28 test pass、新規 `verify_baseline_rejects_committed_metric_with_k_mismatch` 含む)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` (warnings ゼロ)
- [x] 既存 4 envelope test (schema_version / kind_mismatch / replay_kind / iterates_metric_spec_all) 全 pass

## 関連

- drift report: `docs/audit/2026-05-14-adr-drift.md`
- ADR-0006: `docs/decisions/0006-pin-pipelinek10-as-part-of-baseline-schema-contract.md`
- 関連 PR: #92 (PR-A: ADR-0007 aggregation enum), #93 (PR-B: ADR-0007 module-doc + fixture)