### PR TITLE
docs(adr-0001): Implementation Plan に charter extension footnote 追加 (#10)

### DIFF
--- a/docs/decisions/0001-extract-shared-model-loading-and-cli-utilities-into-amici-crate.md
+++ b/docs/decisions/0001-extract-shared-model-loading-and-cli-utilities-into-amici-crate.md
@@ -53,6 +53,8 @@ Chosen option: Option 1（amiciクレートの新設）。バックポート作�
 
 ## Implementation Plan
 
+Implementation Plan は initial extraction set を示す。後続の追加は ADR-0005 の judgment table (line 50-56) に従って判断する。
+
 ```text
 amici/src/
 ├── lib.rs


### PR DESCRIPTION
## 概要

`/audit-adr-drift` (2026-05-14) で検出された ADR-0001 #10 (M priority) を close。drift remediation 4 PR シリーズ (#92 PR-A / #93 PR-B / #94 PR-C / #95 PR-D) の最終 PR。

ADR-0001 の Implementation Plan は initial extraction set (`cli/spinner`, `cli/shorthand`, `model/mod`, `model/reranker`, `storage` の 5 file group) を示すが、その後 ADR-0002 で `eval/`、ADR 起票無しで `logging` / `migration` / `testing` が `lib.rs` に追加されている。behavioural drift は無いが、future reader が "5 カテゴリ" framing を silent scope creep と誤読する余地がある。

## 変更内容

`## Implementation Plan` section の preamble に 1 行 footnote 追加:

> Implementation Plan は initial extraction set を示す。後続の追加は ADR-0005 の judgment table (line 50-56) に従って判断する。

### Option A (footnote) を採用、Option B (ADR-0008 起票) を不採用

- ADR-0005 §Decision Outcome (line 50-56) が既に amici 拡張の judgment table を publish 済み。ADR-0001 から pointer が無いだけで、新 ADR に追加する judgment substance 無し
- `logging` / `migration` / `testing` は thin (tracing wiring / shared warn shape / test-support feature)。3 modules とも ADR-0005 row 4 \"primitives を組み合わせた業務 facets\" に trivially 該当

### Success Criteria は触らない理由

Success Criteria (line 79-83) は frozen verification record — migration 時点 (2026-04-13) で観測済みの \"抽出した 5 カテゴリのローカルコピーが各 PJ から削除されている\" は当時の事実として正しい。retroactive 編集すると過去の検証記録が改竄される。Implementation Plan section の preamble に footnote 配置のみで future reader の読み方を補正する。

## テスト計画

- [x] `git diff --stat`: 1 file changed, 2 insertions(+) のみ (docs only)
- [x] footnote 内容が drift report Follow-up Issue Candidates の提案 (line 205) と完全一致
- [x] ADR-0005 line 50-56 reference が現状 ADR-0005 (PR #95 merge 後の状態) でも resolve することを確認
- [x] Success Criteria section 未変更を確認

## 関連

- drift remediation シリーズ: #92 (PR-A) → #93 (PR-B) → #94 (PR-C) → #95 (PR-D)
- drift report: `docs/audit/2026-05-14-adr-drift.md` (#10 finding)
- ADR-0001: `docs/decisions/0001-extract-shared-model-loading-and-cli-utilities-into-amici-crate.md`
- ADR-0005: `docs/decisions/0005-model-wiring-belongs-to-rurico.md` (judgment table 参照先)