### PR TITLE
docs(audit): 2026-05-14 drift report に Resolution closure note 追加

### DIFF
--- a/docs/audit/2026-05-14-adr-drift.md
+++ b/docs/audit/2026-05-14-adr-drift.md
@@ -211,3 +211,19 @@ L priority drift (ADR-0001 系 #1〜#3) は ADR の next-touch 時に Implementa
 - Date pinned via `date -u +%Y-%m-%d` (UTC, ISO format) per skill spec; this differs from local clock (2026-05-15) by 1 day depending on timezone.
 - `reviewer-design` (background agent `a755631112ca5dcc5`) が ADR-0001 charter scope (観点 A) と ADR-0005 boundary semantic (観点 B) を独立 review。観点 A で Finding A1 (本 report #10) を新規同定、観点 B で B1/B2 を accept 判定 (本 report ADR-0005 セクションへ統合済み)。
 - `reviewer-rust` was skipped to keep scan turnaround tractable; the symbol verification table per ADR already covers Rust-specific semantic checks (`#[non_exhaustive]`, serde default discipline, `MetricSpec::ALL` soundness anchor, `LazyReranker` placement).
+
+## Resolution (2026-05-15)
+
+scan 翌日に M priority finding 全 7 件を 5 PR series で close。本 report の §Summary 表と §Follow-up Issue Candidates checklist は 2026-05-14 scan timepoint の snapshot として未変更で保持。
+
+| Finding                    | Resolved by   | 内容                                                                                                                                                                                              |
+| -------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ADR-0007 #6 #7             | PR #92 (PR-A) | aggregation 文字列リテラル例示 → `AggregationKind::Identity` enum 表記、Reassessment Trigger 第 3 項 fired                                                                                         |
+| ADR-0007 #8 #9             | PR #93 (PR-B) | `src/eval/baseline.rs` module-doc に "# serde default discipline" 段落追加、historical-fixture test (`pre_serde_defaults.json` + round-trip assert) land                                          |
+| ADR-0006 #4 #5             | PR #94 (PR-C) | `PIPELINE_K` 定義に change protocol 4 step を inline 化した `///` doc comment、`validate_committed_baseline_envelope` に K mismatch gate (`MetricResult.k` ≠ `MetricSpec.k()` で `EXIT_REGRESSION`) |
+| ADR-0006/0007 Reassessment | PR #95 (PR-D) | 両 ADR を proposed → accepted に promote、fired triggers を strike-through + fired-and-resolved marker で更新                                                                                      |
+| ADR-0001 #10               | PR #96 (PR-E) | Implementation Plan section の preamble に 1 行 footnote 追加 (ADR-0005 judgment table への pointer)、Success Criteria は frozen verification record として未変更                                  |
+
+L priority drift (ADR-0001 #1〜#3) は本 report §Notes 記載の方針通り ADR の next-touch 時に historical intent として吸収する candidate として残存。即時対応不要。
+
+External ADR Dependencies (ADR-0066 / 0037 / 0021) は本シリーズ scope 外。promote / supersede locally の判断は本 report §External ADR Dependencies のまま open。


### PR DESCRIPTION
## 概要

drift remediation 5 PR シリーズ (#92 PR-A / #93 PR-B / #94 PR-C / #95 PR-D / #96 PR-E) で全 M priority finding (7 件) を close したのを受けて、`docs/audit/2026-05-14-adr-drift.md` の末尾に `## Resolution (2026-05-15)` section を追加し、PR ごとに何を close したかの履歴を可視化する。

## 変更内容

### Resolution section を末尾に追加 (16 lines)

PR ごとの finding close mapping を表で記載:

- ADR-0007 #6 #7 → PR #92 (PR-A)
- ADR-0007 #8 #9 → PR #93 (PR-B)
- ADR-0006 #4 #5 → PR #94 (PR-C)
- ADR-0006/0007 Reassessment → PR #95 (PR-D)
- ADR-0001 #10 → PR #96 (PR-E)

加えて scope 外 (L priority drift #1〜#3、External ADR Dependencies) の open 状態も明示。

### snapshot 不変性の維持

§Summary 表と §Follow-up Issue Candidates checklist は **未変更で保持**。理由:

- scan timepoint (2026-05-14) の予測・候補一覧は当時の判断記録であり、事後改竄すると履歴トレース性が損なわれる
- 事後の事実 (履歴) は独立 §Resolution section に分離することで、当時の予測と事後の結果を比較可能にする

これは PR-D (#95) で確立した \"drift report は scan timepoint snapshot として frozen\" 方針の延長 — 同方針下でも追記 (append-only) は許容される。

## テスト計画

- [x] `git diff --stat`: 1 file changed, 16 insertions(+) のみ (append-only)
- [x] §Summary 表 (line 6-22)、§Per-ADR Findings (line 24-178)、§External ADR Dependencies (line 179-189)、§Follow-up Issue Candidates (line 191-207)、§Notes (line 209-213) すべて未変更を確認
- [x] §Resolution は最末尾 (line 215-) に独立 section として追加

## 関連

- drift remediation シリーズ完走: #92 (PR-A) → #93 (PR-B) → #94 (PR-C) → #95 (PR-D) → #96 (PR-E)
- drift report: `docs/audit/2026-05-14-adr-drift.md`