### PR TITLE
chore(deps): cargo update と rurico b4f27da → d757670 の同期

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=b4f27da#b4f27dae11965dd4fe1f0041425745cdbcb2e38e"
+source = "git+https://github.com/thkt/rurico?rev=d757670#d757670f2018cc8850171072a181c2e29e44f866"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=b4f27da#b4f27dae11965dd4fe1f0041425745cdbcb2e38e"
+source = "git+https://github.com/thkt/rurico?rev=d757670#d757670f2018cc8850171072a181c2e29e44f866"
 dependencies = [
  "mlx-sys",
  "rusqlite",
@@ -3078,9 +3078,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ required-features = ["eval-harness"]
 bytemuck           = "1"
 rand               = "0.10"
 rand_chacha        = "0.10"
-rurico             = { git = "https://github.com/thkt/rurico", rev = "b4f27da" }
+rurico             = { git = "https://github.com/thkt/rurico", rev = "d757670" }
 rusqlite           = { version = "0.39", features = ["bundled"] }
 serde              = { version = "1", features = ["derive"] }
 serde_json         = "1"
@@ -29,7 +29,7 @@ tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico   = { git = "https://github.com/thkt/rurico", rev = "b4f27da", features = ["test-support"] }
+rurico   = { git = "https://github.com/thkt/rurico", rev = "d757670", features = ["test-support"] }
 tempfile = "3"
 
 [lints.rust]


### PR DESCRIPTION
## 概要

- `winnow` 1.0.2 → 1.0.3 (lockfile patch)。
- `rurico` rev `b4f27da` → `d757670` ([thkt/rurico#177](https://github.com/thkt/rurico/pull/177) で同じ winnow 更新を取り込み済み)。
- 上流 (rurico) / 下流 (amici) で Cargo.lock の winnow バージョンを揃え、git dep の rev pin を最新化。

## 動作確認

- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` (135 passed, 0 failed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] pre-commit hook (fmt + clippy)