### PR TITLE
ci: cargo test → cargo nextest run に移行 (doctest 別建て)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,7 @@
+[profile.default]
+fail-fast = false
+
+[profile.ci]
+fail-fast = false
+slow-timeout = { period = "120s", terminate-after = 2 }
+final-status-level = "flaky"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,19 @@ jobs:
       - name: Check
         run: cargo check
 
+      - name: Install nextest
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
+        with:
+          tool: cargo-nextest
+
       - name: Test
-        run: cargo test
+        run: cargo nextest run --profile ci
 
       - name: Test (all features)
-        run: cargo test --all-features
+        run: cargo nextest run --all-features --profile ci
+
+      - name: Doctests
+        run: cargo test --doc --all-features
 
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/justfile
+++ b/justfile
@@ -17,7 +17,8 @@ default:
 check: test lint fmt-check
 
 test:
-    cargo test --all-features
+    cargo nextest run --all-features
+    cargo test --doc --all-features
 
 lint:
     cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
## 概要

- `thkt/rurico` の `cargo test` → `cargo nextest run` 移行 ([rurico@17c10f5](https://github.com/thkt/rurico/commit/17c10f5)) を amici に横展開
- `.github/workflows/ci.yml` の `Test` / `Test (all features)` を `cargo nextest run --profile ci` 系へ置換、nextest 非対応の doctest は `cargo test --doc --all-features` 専用 step として独立
- `.config/nextest.toml` を rurico と同形で新規追加 (default / ci profile, ci profile は `slow-timeout = 120s` + `terminate-after = 2`)
- `justfile` の `test` recipe も `cargo nextest run --all-features` + `cargo test --doc --all-features` の 2 本立てへ

Closes #99

## 受け入れ条件

- [x] `cargo nextest run --all-features --profile ci` が CI で green (ローカル先行確認では 251 tests passed / 9 skipped)
- [x] `cargo test --doc --all-features` が CI で green (ローカル先行確認では 18 passed / 1 ignored, 計 19 doctest)
- [x] CONTRIBUTING.md / README.md の `cargo test` 例を置換 → 該当箇所なし (`CONTRIBUTING.md` 未存在、`README.md` も `cargo test` 表記なし) のため対象外

## 補足

- Issue 本文では「doctest が 8 ファイル / 8 doctest」と記載されているが、現状の amici は 10 ファイル / 19 doctest (Issue 起票後に doctest が追加されたため)。ローカルで `cargo test --doc --all-features -- --list` 実行済
- nextest インストールは `taiki-e/install-action@v2` (SHA pin `184183c2401be73c3bf42c2e61268aa5855379c1`) を経由し、rurico の install step と同 SHA で揃えてある

## 動作確認

- [x] `cargo nextest run --profile ci` (default features) → 135 tests passed
- [x] `cargo nextest run --all-features --profile ci` → 251 tests passed, 9 skipped
- [x] `cargo test --doc --all-features` → 18 passed, 1 ignored
- [ ] CI green (push 後にこの PR で確認)