### PR TITLE
chore(deps): rurico d757670 → bd637c2 (nextest 追従)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=d757670#d757670f2018cc8850171072a181c2e29e44f866"
+source = "git+https://github.com/thkt/rurico?rev=bd637c2#bd637c2bf69296be9bc3f3d9cb6e59f0334bd5f0"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=d757670#d757670f2018cc8850171072a181c2e29e44f866"
+source = "git+https://github.com/thkt/rurico?rev=bd637c2#bd637c2bf69296be9bc3f3d9cb6e59f0334bd5f0"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ required-features = ["eval-harness"]
 bytemuck           = "1"
 rand               = "0.10"
 rand_chacha        = "0.10"
-rurico             = { git = "https://github.com/thkt/rurico", rev = "d757670" }
+rurico             = { git = "https://github.com/thkt/rurico", rev = "bd637c2" }
 rusqlite           = { version = "0.39", features = ["bundled"] }
 serde              = { version = "1", features = ["derive"] }
 serde_json         = "1"
@@ -29,7 +29,7 @@ tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico   = { git = "https://github.com/thkt/rurico", rev = "d757670", features = ["test-support"] }
+rurico   = { git = "https://github.com/thkt/rurico", rev = "bd637c2", features = ["test-support"] }
 tempfile = "3"
 
 [lints.rust]


### PR DESCRIPTION
## 概要

- amici #100 で nextest 移行したのに rurico 側 (rurico #178 / `bd637c2`) の同 nextest 移行への rev 追従が漏れていたので合わせる。
- 内容は `Cargo.toml` の rurico rev を `d757670` → `bd637c2` に上げて `cargo update -p rurico` するだけ。

## テスト計画

- [x] `cargo nextest run --all-features` → 251 passed / 9 skipped
- [x] pre-commit (`cargo fmt --check` / `cargo clippy --all-targets --all-features -- -D warnings`) 通過