### PR TITLE
feat(cli/exit_code): Group 2 baseline に DATA_ERROR (65) を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,10 +245,10 @@ failures from a single value regardless of which Group 2 CLI emitted it.
 
 The `codes` module exposes two source ranges side-by-side:
 
-| Range  | Source                             | Codes                                                    |
-| ------ | ---------------------------------- | -------------------------------------------------------- |
-| 64–78  | sysexits.h                         | `USAGE`, `SOFTWARE`, `CANT_CREAT`, `IO_ERR`, `TEMP_FAIL` |
-| 80–119 | Project extension range (ADR-0066) | `UNKNOWN` (104)                                          |
+| Range  | Source                             | Codes                                                                  |
+| ------ | ---------------------------------- | ---------------------------------------------------------------------- |
+| 64–78  | sysexits.h                         | `USAGE`, `DATA_ERROR`, `SOFTWARE`, `CANT_CREAT`, `IO_ERR`, `TEMP_FAIL` |
+| 80–119 | Project extension range (ADR-0066) | `UNKNOWN` (104)                                                        |
 
 `codes::INTERNAL` is provided as an alias for `SOFTWARE` so call sites can use
 the name that ADR-0066's classification table uses — the numeric value is

--- a/src/cli/exit_code.rs
+++ b/src/cli/exit_code.rs
@@ -6,8 +6,8 @@
 //! - [`codes`] module — `u8` constants from two sources, kept side-by-side
 //!   so call sites do not need to import from two places:
 //!   1. [sysexits.h](https://man.openbsd.org/sysexits.3) (64–78). Standard
-//!      Unix exit categories — `USAGE`, `SOFTWARE`, `CANT_CREAT`, `IO_ERR`,
-//!      `TEMP_FAIL`.
+//!      Unix exit categories — `USAGE`, `DATA_ERROR`, `SOFTWARE`,
+//!      `CANT_CREAT`, `IO_ERR`, `TEMP_FAIL`.
 //!   2. Project extension range (80–119). Assigned per ADR-0066 when no
 //!      sysexits variant fits. Currently: `UNKNOWN` (104).
 //!
@@ -82,6 +82,9 @@ pub mod codes {
     pub const SUCCESS: u8 = 0;
     /// `EX_USAGE`. Bad command-line usage (missing arg, unknown flag, etc.).
     pub const USAGE: u8 = 64;
+    /// `EX_DATAERR`. Input data was malformed — query syntax invalid,
+    /// encoding error, etc. (per ADR-0066 Group 2 baseline).
+    pub const DATA_ERROR: u8 = 65;
     /// `EX_SOFTWARE`. Internal software error — invariant violated.
     pub const SOFTWARE: u8 = 70;
     /// `EX_CANTCREAT`. Cannot create a (user-visible) output file or path.
@@ -123,6 +126,7 @@ mod tests {
     fn codes_match_sysexits_constants() {
         assert_eq!(codes::SUCCESS, 0);
         assert_eq!(codes::USAGE, 64);
+        assert_eq!(codes::DATA_ERROR, 65);
         assert_eq!(codes::SOFTWARE, 70);
         assert_eq!(codes::CANT_CREAT, 73);
         assert_eq!(codes::IO_ERR, 74);


### PR DESCRIPTION
## 概要

- ADR-0066 Group 2 baseline の `codes` モジュールに `DATA_ERROR = 65` (sysexits `EX_DATAERR`) を追加
- module doc の sysexits 列挙と `codes_match_sysexits_constants` テストに反映
- 既存定数への影響なし。下流 (sae / yomu / recall / rurico) が rev bump 後に参照可能

## テスト計画

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --lib exit_code` (2 tests pass: codes_match_sysexits_constants / codes_match_pj_extension_constants)
- [x] `cargo test --doc` (18 passed)

Closes #102