### PR TITLE
chore(ci): dependabot に cooldown (default-days: 7) を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - ci
@@ -15,6 +17,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - rust


### PR DESCRIPTION
## 概要

- zizmor の `dependabot-cooldown` 警告 2 件を解消 (alert #1: github-actions / alert #2: cargo)
- 各 update entry に `cooldown: default-days: 7` を追加
- リリース直後の不安定版や供給網侵害版を Dependabot が自動取り込みするリスクを抑制

## 動作確認

- [x] `zizmor .github/dependabot.yml` ローカルで `No findings to report` を確認
- [x] pre-commit (cargo fmt / clippy) pass
- [ ] CI の zizmor.yml job pass を確認
- [ ] alert #1, #2 が close されるのを確認

参考:
- https://github.com/thkt/amici/security/code-scanning/1
- https://github.com/thkt/amici/security/code-scanning/2
- https://docs.zizmor.sh/audits/#dependabot-cooldown