### PR TITLE
fix(ci): taiki-e/install-action の version comment を v2.78.1 に修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: cargo check
 
       - name: Install nextest
-        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
         with:
           tool: cargo-nextest
 


### PR DESCRIPTION
## 概要

- zizmor `ref-version-mismatch` (code-scanning #3) を解消
- hash `184183c2` は実 tag `v2.78.1` を指してるが comment は `# v2` (floating tag `v2` は別 commit `3771e22a` を指す) で mismatch していた
- comment のみ `# v2.78.1` に揃え、hash 自体は据え置き (dependabot に upgrade は任せる)

## 動作確認

- [x] `zizmor .github/workflows/ci.yml` で `No findings to report`
- [ ] CI (zizmor.yml) が PR でも pass

Closes #3 (code-scanning alert)