### PR TITLE
chore(deps): rurico rev を 087dc4a に bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=bd637c2#bd637c2bf69296be9bc3f3d9cb6e59f0334bd5f0"
+source = "git+https://github.com/thkt/rurico?rev=087dc4a#087dc4a82f29ce78264fdb87cd6d6e9a6adda7ec"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=bd637c2#bd637c2bf69296be9bc3f3d9cb6e59f0334bd5f0"
+source = "git+https://github.com/thkt/rurico?rev=087dc4a#087dc4a82f29ce78264fdb87cd6d6e9a6adda7ec"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ required-features = ["eval-harness"]
 bytemuck           = "1"
 rand               = "0.10"
 rand_chacha        = "0.10"
-rurico             = { git = "https://github.com/thkt/rurico", rev = "bd637c2" }
+rurico             = { git = "https://github.com/thkt/rurico", rev = "087dc4a" }
 rusqlite           = { version = "0.39", features = ["bundled"] }
 serde              = { version = "1", features = ["derive"] }
 serde_json         = "1"
@@ -29,7 +29,7 @@ tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico   = { git = "https://github.com/thkt/rurico", rev = "bd637c2", features = ["test-support"] }
+rurico   = { git = "https://github.com/thkt/rurico", rev = "087dc4a", features = ["test-support"] }
 tempfile = "3"
 
 [lints.rust]


### PR DESCRIPTION
## 概要

amici が pin している rurico の rev を `bd637c2` → `087dc4a` (rurico main HEAD, 2026-05-17) に更新する。

## 差分の中身

bd637c2..087dc4a の 11 commit は **すべて CI / dependabot 系** で、`src` / `crates` 配下の変更は 0 件。

| PR | 内容 |
| --- | --- |
| rurico#182 | install-action SHA pin を v2.78.2 (v2 floating tag 最新) に同期 |
| rurico#181 | Dependabot に cooldown を設定し supply-chain alert を解消 |
| rurico#180 | advanced-issue-labeler 3.2.4 |
| rurico#179 | zizmor-action 0.5.4 |

ランタイム影響なし。Cargo.lock も `cargo update -p rurico` で source URL の rev のみ書き換わる。

## 動作確認

- [x] `cargo update -p rurico` で lock 再生成
- [x] `cargo check --all-features` 通過
- [x] pre-commit (fmt / clippy --all-targets --all-features -D warnings) 通過
- [ ] CI で `cargo nextest run --all-features` / `cargo test --doc --all-features` pass

## 関連

- ci.yml の zizmor `ref-version-mismatch` 修正は別 PR #106 (scope 分割)