### PR TITLE
chore(deps): rurico rev を bb25a06 に bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=087dc4a#087dc4a82f29ce78264fdb87cd6d6e9a6adda7ec"
+source = "git+https://github.com/thkt/rurico?rev=bb25a06#bb25a06cd32b5e83df291d6a7cf251de738ac7bb"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=087dc4a#087dc4a82f29ce78264fdb87cd6d6e9a6adda7ec"
+source = "git+https://github.com/thkt/rurico?rev=bb25a06#bb25a06cd32b5e83df291d6a7cf251de738ac7bb"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ required-features = ["eval-harness"]
 bytemuck           = "1"
 rand               = "0.10"
 rand_chacha        = "0.10"
-rurico             = { git = "https://github.com/thkt/rurico", rev = "087dc4a" }
+rurico             = { git = "https://github.com/thkt/rurico", rev = "bb25a06" }
 rusqlite           = { version = "0.39", features = ["bundled"] }
 serde              = { version = "1", features = ["derive"] }
 serde_json         = "1"
@@ -29,7 +29,7 @@ tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico   = { git = "https://github.com/thkt/rurico", rev = "087dc4a", features = ["test-support"] }
+rurico   = { git = "https://github.com/thkt/rurico", rev = "bb25a06", features = ["test-support"] }
 tempfile = "3"
 
 [lints.rust]


### PR DESCRIPTION
## 概要

`rurico` rev を `087dc4a` → `bb25a06` に bump。

rurico リポジトリ側 087dc4a → bb25a06 で取り込まれた変更:
- taiki-e/install-action SHA pin を v2.78.2 に同期
- redhat-plumbers-in-action/advanced-issue-labeler 3.2.4
- zizmorcore/zizmor-action 0.5.4
- dependabot cooldown (default-days: 7) 設定追加
- openssl 0.10.79 → 0.10.80 (rurico 側 Cargo.lock のみ)

amici 側の変更は Cargo.toml の rev 文字列と Cargo.lock の rurico/rurico-ffi source 行のみ。openssl の amici 側 Cargo.lock 反映は #109 で別途対応。

## 検証

- [x] cargo check --all-targets --all-features
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo test --all-features (1 passed, 9 ignored, 18 doctests pass)