### PR TITLE
chore(deps): openssl を 0.10.80 に bump (transitive)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1548,9 +1548,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## 概要

native-tls 経由で hf-hub → rurico に入る transitive dep の patch bump:

- openssl 0.10.79 → 0.10.80
- openssl-sys 0.9.115 → 0.9.116

Cargo.lock のみの変更で、direct dep / Cargo.toml には変更なし。

## 検証

- [x] cargo check --all-targets --all-features
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo test --all-features (1 passed, 9 ignored, 18 doctests pass)

## 補足

#108 (rurico bump) は rurico 側リポジトリの openssl bump を含むが、それは rurico の CI/build 向けで amici 側 Cargo.lock の openssl は更新されない。本 PR は amici の Cargo.lock に openssl 0.10.80 を反映するための独立 bump。