### PR TITLE
feat(model)!: degraded_reason_user_note に download_cmd 引数を追加

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -42,16 +42,24 @@ impl fmt::Display for DegradedReason {
     }
 }
 
-/// Returns a short user-facing note for a degraded model (embedder or reranker),
+/// Returns a short user-facing note for a degraded embedder,
 /// or `None` if no message should be shown (e.g. the caller explicitly disabled the model).
-pub fn degraded_reason_user_note(reason: DegradedReason) -> Option<&'static str> {
+///
+/// `download_cmd` is interpolated into the [`DegradedReason::NotInstalled`] note so the
+/// caller can surface the binary-specific recovery action (e.g. `"yomu model download"`).
+/// Other variants ignore `download_cmd` because their cause is not addressable by
+/// re-downloading the model.
+///
+/// The wording is embedder-specific. Reranker callers should not reuse this fn;
+/// no reranker-degraded note helper exists yet because no consumer needs one.
+pub fn degraded_reason_user_note(reason: DegradedReason, download_cmd: &str) -> Option<String> {
     match reason {
         DegradedReason::Disabled => None,
-        DegradedReason::NotInstalled => {
-            Some("embedding model not installed; results from text search only")
-        }
+        DegradedReason::NotInstalled => Some(format!(
+            "embedding model not installed; run `{download_cmd}` to enable semantic search"
+        )),
         DegradedReason::BackendUnavailable | DegradedReason::ProbeFailed => {
-            Some("embedding model unavailable; results from text search only")
+            Some("embedding model unavailable; results from text search only".into())
         }
     }
 }
@@ -568,6 +576,62 @@ mod tests {
         assert!(
             captured.contains("seed inference"),
             "missing context: {captured}"
+        );
+    }
+
+    // T-030: degraded_reason_user_note_returns_none_for_disabled
+    #[test]
+    fn degraded_reason_user_note_returns_none_for_disabled() {
+        assert_eq!(
+            degraded_reason_user_note(DegradedReason::Disabled, "any cmd"),
+            None,
+            "Disabled is caller opt-out; suppress the note"
+        );
+    }
+
+    // T-031: degraded_reason_user_note_injects_download_cmd_for_not_installed
+    #[test]
+    fn degraded_reason_user_note_injects_download_cmd_for_not_installed() {
+        let note = degraded_reason_user_note(DegradedReason::NotInstalled, "yomu model download")
+            .expect("NotInstalled must produce a note");
+        assert!(
+            note.contains("`yomu model download`"),
+            "download_cmd must appear backtick-quoted, got: {note}"
+        );
+        assert!(
+            note.contains("not installed"),
+            "note must explain the cause, got: {note}"
+        );
+    }
+
+    // T-032: degraded_reason_user_note_ignores_download_cmd_for_backend_unavailable
+    #[test]
+    fn degraded_reason_user_note_ignores_download_cmd_for_backend_unavailable() {
+        let note =
+            degraded_reason_user_note(DegradedReason::BackendUnavailable, "recall model download")
+                .expect("BackendUnavailable must produce a note");
+        assert!(
+            !note.contains("recall model download"),
+            "download_cmd must not leak into BackendUnavailable note, got: {note}"
+        );
+        assert!(
+            note.contains("text search only"),
+            "note must explain the fallback, got: {note}"
+        );
+    }
+
+    // T-033: degraded_reason_user_note_ignores_download_cmd_for_probe_failed
+    #[test]
+    fn degraded_reason_user_note_ignores_download_cmd_for_probe_failed() {
+        let note = degraded_reason_user_note(DegradedReason::ProbeFailed, "sae model download")
+            .expect("ProbeFailed must produce a note");
+        assert!(
+            !note.contains("sae model download"),
+            "download_cmd must not leak into ProbeFailed note, got: {note}"
+        );
+        assert!(
+            note.contains("text search only"),
+            "note must explain the fallback, got: {note}"
         );
     }
 }


### PR DESCRIPTION
## 概要

- `degraded_reason_user_note(DegradedReason) -> Option<&'static str>` を `degraded_reason_user_note(DegradedReason, &str) -> Option<String>` に破壊的変更
- `NotInstalled` note に consumer (sae / yomu / recall) の download command を inject
- 下流の自前 hint 構築 (recall:166-170 / 261) を amici 側に集約できる経路を提供

Closes #110

## 設計差分 (Issue 提案からの変更)

| 項目        | Issue 提案                           | 採用案                                                 | 理由                                                                  |
| ----------- | ------------------------------------ | ------------------------------------------------------ | --------------------------------------------------------------------- |
| API 方針    | `_for` suffix で別 fn 追加 + 既存 keep | 既存シグネチャを破壊的変更                              | OUTCOME.md「破壊的変更を rev bump で展開」に整合。API 二重化を回避    |
| ProbeFailed | (言及なし。generic note のまま)      | generic note のまま                                    | 原因が download とは限らない (corrupt artifacts 削除後の再 download は副作用)。曖昧化を避ける |
| Disabled    | (現状維持 `None`)                    | `None` 維持                                            | caller opt-out の意味を保つ。recall の Disabled hint は consumer 側で対応 |

## 破壊的変更の影響

下流 (sae / yomu / recall) は rev bump 時に呼び出し側の追従が必要:

| crate  | 場所                       | 追従内容                                                       |
| ------ | -------------------------- | -------------------------------------------------------------- |
| yomu   | `src/tools.rs:296`         | `degraded_reason_user_note(*reason, \"yomu model download\")` に変更 |
| recall | `src/main.rs:166-170, 261` | 自前 hint 文字列を fn 呼び出しに置き換え                       |
| sae    | (使ってない)               | 影響なし                                                       |

下流 bump は別 PR / 別セッションで対応。

## 検証手順

- [x] `cargo test --all-features` 全 pass (新規 4 test 追加: T-030〜T-033)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] doctest 全 pass (`degrade_with_warn` / `record_degraded` のシグネチャに依存していないこと確認済み)