### PR TITLE
docs(adr): ADR-0001/0004/0006/0007 の line ref drift を symbol ref へ格上げ

### DIFF
--- a/docs/decisions/0001-extract-shared-model-loading-and-cli-utilities-into-amici-crate.md
+++ b/docs/decisions/0001-extract-shared-model-loading-and-cli-utilities-into-amici-crate.md
@@ -72,7 +72,7 @@ amici/src/
 1. amiciに共通コードを実装し `rurico` を依存に追加する
 2. sae/yomuでローカル定義を削除しamiciからimportするように書き換える
 3. recallの `Spinner`（`Mutex<State>` 型）をamici版（`AtomicBool+Mutex<String>` 型）に差し替える
-4. recallの `try_load_embedder` を `ModelLoad` パターンに書き直す
+4. recallの `try_load_embedder` を `ModelLoad` パターン (amici の `try_load_embedder_with` / `try_load_embedder_default_logging`) に書き直す
 
 ## Rollback Plan
 

--- a/docs/decisions/0004-annotation-framework.md
+++ b/docs/decisions/0004-annotation-framework.md
@@ -18,7 +18,7 @@ ADR-0001 は amici の charter を「shared model-loading + CLI utilities」、A
 - charter clarity: authoring tool が ADR で説明可能な状態を維持し、新規 contributor が charter scope を `docs/decisions/` から判断できる
 - provenance discipline: queries.jsonl 拡張に session-level provenance (annotator id / session id / fixture hash) を attach する型基盤を public API として提供
 - envelope discipline: `ANNOTATION_SCHEMA_VERSION` 定数を canonical reference として固定し、schema version mismatch を runtime で typed error として検出可能にする (`oracle_gap.rs::OracleGapError::SchemaVersionMismatch` precedent)
-- naming collision avoidance: 既存 `EvalQuery.annotation: String` field (`src/eval/fixture.rs:34-36`、`REQUIRED_QUERY_FIELDS:132`) と命名衝突せず両者を同一 test scope 内で参照可能にする
+- naming collision avoidance: 既存 `EvalQuery.annotation: String` field (`src/eval/fixture.rs` の `EvalQuery::annotation`、`REQUIRED_QUERY_FIELDS:132`) と命名衝突せず両者を同一 test scope 内で参照可能にする
 - 168 行 queries.jsonl の breaking change を避ける: 既存 fixture を rename / migration 不要のまま foundation を land する
 
 ## Considered Options
@@ -91,7 +91,7 @@ Option 1 を採用する。
 - amici Issue #62 (first-search replay subcommand — PR-C blocking)
 - `src/eval/baseline.rs` (`BASELINE_SCHEMA_VERSION` envelope precedent)
 - `src/eval/oracle_gap.rs` (`OracleGapError::SchemaVersionMismatch` typed error precedent)
-- `src/eval/fixture.rs:34-36` (existing `EvalQuery.annotation` field that motivates module-path namespacing)
+- `src/eval/fixture.rs` `EvalQuery::annotation` (existing field that motivates module-path namespacing)
 
 ## Downstream consumers (this ADR を前提として動く後続)
 

--- a/docs/decisions/0006-pin-pipelinek10-as-part-of-baseline-schema-contract.md
+++ b/docs/decisions/0006-pin-pipelinek10-as-part-of-baseline-schema-contract.md
@@ -8,7 +8,7 @@
 
 ## Context and Problem Statement
 
-`src/bin/eval_harness.rs:L99` の `const PIPELINE_K: usize = 10;` は ADR-0002 の評価方法論で前提とする「上位 k 件」の `k` 値を決定する。bootstrap seed (`SHUFFLE_SEED=42`, `BOOTSTRAP_SEED=42`) と並んで、baseline.json 出力 (`recall@10`, `mrr@10`, `ndcg@10`) の意味を決める load-bearing constant である。
+`src/bin/eval_harness.rs` の `const PIPELINE_K: usize = 10;` は ADR-0002 の評価方法論で前提とする「上位 k 件」の `k` 値を決定する。bootstrap seed (`SHUFFLE_SEED=42`, `BOOTSTRAP_SEED=42`) と並んで、baseline.json 出力 (`recall@10`, `mrr@10`, `ndcg@10`) の意味を決める load-bearing constant である。
 
 ADR-0002 は方法論 (fixture 規約、Bootstrap CI、tolerance envelope) を定めるが PIPELINE_K の具体値は固定しない。すなわち value を変えても ADR-0002 の方法論には違反しないが、`tests/fixtures/eval/baseline.json` 等に記録された値の意味は変わる (recall@10 と recall@20 は semantic に別物)。失敗モードは silent — テストは通り、CI も通り、レビューでも見落とされうる。
 
@@ -38,7 +38,7 @@ Chosen option: "PIPELINE_K=10 を baseline schema contract の一部として本
    - (b) `tests/fixtures/eval/*.json` 全 baseline の recapture 必須 (`just eval-baseline` / `just eval-reverse` / `just eval-oracle`)
    - (c) ADR-0002 § Reassessment Triggers に "PIPELINE_K change" 行追加
    - (d) 本 ADR を supersede する新 ADR を起票
-3. **コード側マーカー** (実装 follow-up): `src/bin/eval_harness.rs:L99` の `PIPELINE_K` 定義に本 ADR を参照するコメント追加
+3. **コード側マーカー** (実装 follow-up): `src/bin/eval_harness.rs` の `PIPELINE_K` 定義に本 ADR を参照するコメント追加
 4. **検証マーカー** (実装 follow-up): `verify-baseline` で baseline.json の `recall@k` 等のキー名から `k` を逆引きし、`PIPELINE_K` と一致しない baseline は reject
 
 ### Consequences
@@ -50,7 +50,7 @@ Chosen option: "PIPELINE_K=10 を baseline schema contract の一部として本
 
 ### Confirmation
 
-- `git grep "PIPELINE_K"` で定義点が `src/bin/eval_harness.rs:L99` の 1 か所のみであることを継続確認
+- `git grep "PIPELINE_K"` で定義点が `src/bin/eval_harness.rs` の 1 か所のみであることを継続確認
 - `BASELINE_SCHEMA_VERSION` を bump する PR が本 ADR を参照していることをレビューチェックリストに組み込む
 - 上記 4 の `verify-baseline` 検証マーカーが land 後は CI が自動で gate
 
@@ -103,6 +103,6 @@ Chosen option: "PIPELINE_K=10 を baseline schema contract の一部として本
 - ADR-0002: Search Quality Evaluation Methodology (§ Decision Outcome / § Reassessment Triggers)
 - ADR-0003: Add pgr-style First-Search Offline Retrieval Benchmark (§ Reassessment Triggers, `Hit@k` 追加 precedent)
 - audit report `docs/audit/2026-05-14-undocumented-decisions.md` § Three Strongest #1 / § ADR Promotion Candidates #6
-- `src/bin/eval_harness.rs:L99` (`PIPELINE_K` 定義箇所)
+- `src/bin/eval_harness.rs` (`PIPELINE_K` 定義箇所)
 - `src/eval/metrics.rs` (`recall_at_k` / `mrr_at_k` / `ndcg_at_k` / `hit_at_k` — k を消費する metric 関数群)
 - `tests/fixtures/eval/baseline.json` (固定対象 baseline)

--- a/docs/decisions/0007-pin-baselinesnapshot-serde-defaults-to-pre-existing-behavior.md
+++ b/docs/decisions/0007-pin-baselinesnapshot-serde-defaults-to-pre-existing-behavior.md
@@ -8,9 +8,9 @@
 
 ## Context and Problem Statement
 
-`BaselineSnapshot` (`src/eval/baseline.rs:L86-L150`) は新しいフィールド追加を `#[serde(default = ...)]` で吸収する設計で、historical な baseline.json を field 追加後も deserialize で round-trip できるようにしている。
+`BaselineSnapshot` (`src/eval/baseline.rs::BaselineSnapshot`) は新しいフィールド追加を `#[serde(default = ...)]` で吸収する設計で、historical な baseline.json を field 追加後も deserialize で round-trip できるようにしている。
 
-このとき重要なのは **default が指す値の意味**である。`normalization` フィールド (L132-141) のコメントが明示しているように:
+このとき重要なのは **default が指す値の意味**である。`normalization` フィールドのコメントが明示しているように:
 
 > Pre-normalization baselines lack this field; the serde-default points at `pre_phase_5_disabled` (all OFF), **not** at runtime `QueryNormalizationConfig::default` (all ON), so historical files replay under the behaviour they were captured with.
 
@@ -87,7 +87,7 @@ Chosen option: "Module-doc + ADR で規律を明文化、新規フィールド�
 
 ### Trade-offs
 
-`BaselineKind` (closed enum, `#[serde(rename_all = "snake_case")]`) と `aggregation` フィールドの typed/untyped 非対称は **PR #86 で resolved** — `aggregation` は `AggregationKind` typed enum に昇格し、wire form (`identity` / `max-chunk` / `dedupe` / `topk-average:k` / `none`) は manual `Serialize` / `Deserialize` impl で controlled (`src/eval/baseline.rs:117-171`)。audit report #56 で別途 type-system fix 候補と記録していた gap は閉じた。本 ADR は default **値の選び方** に関する規律のみを定める。
+`BaselineKind` (closed enum, `#[serde(rename_all = "snake_case")]`) と `aggregation` フィールドの typed/untyped 非対称は **PR #86 で resolved** — `aggregation` は `AggregationKind` typed enum に昇格し、wire form (`identity` / `max-chunk` / `dedupe` / `topk-average:k` / `none`) は manual `Serialize` / `Deserialize` impl で controlled (`src/eval/baseline.rs::AggregationKind` + 同 file の `impl Serialize` / `impl<'de> Deserialize<'de>`)。audit report #56 で別途 type-system fix 候補と記録していた gap は閉じた。本 ADR は default **値の選び方** に関する規律のみを定める。
 
 ### Implementation Guidelines
 
@@ -119,7 +119,7 @@ Chosen option: "Module-doc + ADR で規律を明文化、新規フィールド�
 - ADR-0003: Add pgr-style First-Search Offline Retrieval Benchmark (§ Decision Outcome 3 — `BASELINE_SCHEMA_VERSION` を 1.2 → 1.3 bump した precedent)
 - ADR-0004: Annotation Framework Foundation (§ Considered Options 2 — `BaselineSnapshot` envelope precedent を Provenance 型で踏襲)
 - audit report `docs/audit/2026-05-14-undocumented-decisions.md` § Three Strongest #2 / § ADR Promotion Candidates #55
-- `src/eval/baseline.rs:L52` (`BASELINE_SCHEMA_VERSION="1.3"` 定義)
-- `src/eval/baseline.rs:L124-141` (3 つの `#[serde(default = ...)]` 用例)
+- `src/eval/baseline.rs::BASELINE_SCHEMA_VERSION` (現値 "1.3" 定義)
+- `src/eval/baseline.rs::BaselineSnapshot` (3 つの `#[serde(default = ...)]` 用例: `aggregation` / `merge_config` / `normalization` field)
 - `src/eval/baseline.rs::pre_phase_5_disabled` (historical-behavior fn の precedent)
 - `src/eval/baseline.rs::default_aggregation_kind` (historical-behavior fn の precedent)


### PR DESCRIPTION
## 概要

- /probe (2026-05-19) で検出された ADR drift 4 件を 1 PR で修正
- line ref (`:L99` 等) を symbol ref (`PIPELINE_K` 等) に格上げして再 drift を構造的に防止
- doc のみ、実装には触らない

## 修正箇所

| ADR | 内容 |
| --- | ---- |
| 0001 | Migration Strategy step 4: `try_load_embedder` を `try_load_embedder_with` / `try_load_embedder_default_logging` の 2 名併記に |
| 0004 | L21 / L94: `src/eval/fixture.rs:34-36` → `EvalQuery::annotation` |
| 0006 | L11 / L41 / L53 / L106: `src/bin/eval_harness.rs:L99` の `:L99` を削除 |
| 0007 | L11 / L13 / L90 / L122 / L123: `BaselineSnapshot` / `AggregationKind` / `BASELINE_SCHEMA_VERSION` / serde defaults 3 例を symbol ref に |

## 方針

issue 提案 3 案のうち「symbol ref への格上げ」を採用。`:Lxx` 表記は code 変更で容易に drift するが、symbol 名は rename されない限り再 drift しない。

scope は issue が指摘した drift 4 件のみ。同ファイル内に残る他の line ref (`REQUIRED_QUERY_FIELDS:132` / `eval_harness.rs:L450-470`) は今回 touch せず、次回 drift 時に対応。

## 動作確認

- [x] `git diff --stat`: 12+/12- (doc-only)
- [x] `git grep` で書き換え後の symbol 全件実在確認:
  - `try_load_embedder_with` / `try_load_embedder_default_logging` (src/model/embedder.rs)
  - `PIPELINE_K` (src/bin/eval_harness.rs)
  - `BaselineSnapshot` / `AggregationKind` / `BASELINE_SCHEMA_VERSION` (src/eval/baseline.rs)
  - `EvalQuery::annotation` (src/eval/fixture.rs)
- [x] pre-commit hook (`cargo fmt --check` / `clippy`) 通過 — doc のみで影響なし

Closes #112