### PR TITLE
chore(cargo): publish = false を Cargo.toml に明示し crates.io 誤公開を防ぐ

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = "1.95"
 description = "Shared model-loading, storage helpers, and CLI utilities for the sae/yomu/recall toolchain"
 license = "MIT"
 repository = "https://github.com/thkt/amici"
+publish = false
 
 [features]
 test-support = []


### PR DESCRIPTION
## 概要

- `[package]` セクションに `publish = false` を追加 (1 行)
- OUTCOME.md Constraints「配布は git rev pin のみ。crates.io 公開およびリリースタグ運用は採用しない」と Cargo.toml を機械的に整合
- 副作用ゼロ (現在も誰も publish していない)。preventive な変更

## テスト計画

- [x] `cargo metadata --no-deps --format-version 1` で `"publish":[]` を確認 (空配列 = publish 不可状態)
- [x] `cargo publish --dry-run --allow-dirty` で `error: amici cannot be published` を確認
- [x] `.githooks/pre-commit` (cargo fmt + cargo clippy --all-targets --all-features -- -D warnings) pass

Closes #113