### PR TITLE
refactor(model): emit_load_hint を cli::message helper 経由に揃える

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,6 @@ mod spinner;
 
 pub use config::env_lookup;
 pub use exit_code::CliError;
-pub use message::{deprecation_warn, exit_error, hint_arrow, info, progress_step};
+pub use message::{deprecation_warn, exit_error, hint, hint_arrow, info, progress_step, warning};
 pub use shorthand::try_expand_shorthand;
 pub use spinner::{Spinner, done, embed_with_spinners, with_spinner};

--- a/src/cli/message.rs
+++ b/src/cli/message.rs
@@ -52,6 +52,23 @@ fn format_hint_arrow<S: AsRef<str>>(items: &[S]) -> String {
     format!("→ {joined}")
 }
 
+/// Prints a recovery hint to stderr.
+///
+/// Use when an operation degraded to a fallback and the user has a concrete
+/// next step (e.g. "run `<binary> model download` to enable semantic search").
+/// Output is prefixed with `Hint: ` so consumers can `grep` for hints separately
+/// from `warning:` / `error:` lines.
+///
+/// # Examples
+///
+/// ```no_run
+/// amici::cli::hint("run `yomu model download` to enable semantic search");
+/// // stderr: Hint: run `yomu model download` to enable semantic search
+/// ```
+pub fn hint(msg: &str) {
+    eprintln!("Hint: {msg}");
+}
+
 /// Prints `msg` to stderr as an informational notice.
 ///
 /// Replaces `println!` usages where the text is CLI guidance rather than the
@@ -79,6 +96,23 @@ pub fn info(msg: &str) {
 /// ```
 pub fn deprecation_warn(old: &str, new: &str) {
     eprintln!("warning: {old} is deprecated, use {new} instead");
+}
+
+/// Prints a generic warning to stderr.
+///
+/// Use when a CLI surface encounters a recoverable anomaly that the user
+/// should be aware of (e.g. a model failed to load and search continues
+/// with text-only fallback). Output is prefixed with `warning: ` to match
+/// [`exit_error`] (`error: `) and [`deprecation_warn`] (`warning: ...`).
+///
+/// # Examples
+///
+/// ```no_run
+/// amici::cli::warning("embedding model not available (probe failed)");
+/// // stderr: warning: embedding model not available (probe failed)
+/// ```
+pub fn warning(msg: &str) {
+    eprintln!("warning: {msg}");
 }
 
 /// Prints a two-space-indented progress line to stderr.
@@ -151,10 +185,22 @@ mod tests {
         info("some guidance");
     }
 
+    // T-124: hint_does_not_panic
+    #[test]
+    fn hint_does_not_panic() {
+        hint("run `yomu model download` to enable semantic search");
+    }
+
     // T-050: deprecation_warn_does_not_panic
     #[test]
     fn deprecation_warn_does_not_panic() {
         deprecation_warn("--old", "--new");
+    }
+
+    // T-125: warning_does_not_panic
+    #[test]
+    fn warning_does_not_panic() {
+        warning("model not available");
     }
 
     // T-051: format_progress_step_joins_with_em_dash_and_indents

--- a/src/model.rs
+++ b/src/model.rs
@@ -11,7 +11,7 @@ use rurico::model_init::ModelInitError;
 use rurico::model_probe::ProbeStatus;
 
 use self::embedder::try_load_embedder_with_fns;
-use crate::cli::with_spinner;
+use crate::cli::{hint, warning, with_spinner};
 
 /// Reason a model could not be loaded.
 ///
@@ -180,13 +180,13 @@ impl<T> ModelLoad<T> {
 
     /// Prints a user-facing hint or warning to stderr when the model is not ready.
     ///
-    /// - [`Absent`](ModelLoad::Absent): prints `"Hint: {absent_hint}"`
-    /// - [`Failed`](ModelLoad::Failed): prints `"Warning: {model_label} not available ({error})"`
+    /// - [`Absent`](ModelLoad::Absent): prints `"Hint: {absent_hint}"` via [`crate::cli::hint`]
+    /// - [`Failed`](ModelLoad::Failed): prints `"warning: {model_label} not available ({error})"` via [`crate::cli::warning`]
     /// - [`Ready`](ModelLoad::Ready): no-op
     pub fn emit_load_hint(&self, absent_hint: &str, model_label: &str) {
         match self {
-            Self::Absent => eprintln!("Hint: {absent_hint}"),
-            Self::Failed(e) => eprintln!("Warning: {model_label} not available ({e})"),
+            Self::Absent => hint(absent_hint),
+            Self::Failed(e) => warning(&format!("{model_label} not available ({e})")),
             Self::Ready(_) => {}
         }
     }


### PR DESCRIPTION
## 概要

- `ModelLoad::emit_load_hint` が `eprintln!` 直書きで `cli::message::*` helper を bypass していた self-inconsistency を解消
- `cli::message` に `hint(msg)` / `warning(msg)` helper を追加し、`emit_load_hint` 内部から呼び出すよう変更
- amici 自身が「下流 CLI に CLI 慣習を揃えさせる」立場 (OUTCOME.md B1) を保つための整合性修正

検出ソース: `/probe` (2026-05-19) Issue-5

## 破壊的変更 (user-visible) ⚠️

`ModelLoad::Failed` 時の stderr prefix が変更:

- Before: `Warning: {model_label} not available ({e})`
- After: `warning: {model_label} not available ({e})`

理由: 既存の `exit_error` (`error: `) / `deprecation_warn` (`warning: ...`) の小文字 prefix 慣習と一貫させるため。下流 (sae / yomu / recall) で `"Warning: "` を pin している test や grep は 0 件確認済み。

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `src/cli/message.rs` | `hint(msg: &str)` + `warning(msg: &str)` helper + doctest + panic-only test T-124/T-125 |
| `src/cli.rs` | re-export に `hint`, `warning` を alphabetical 追加 |
| `src/model.rs` | `emit_load_hint` の `eprintln!` 2 行を `hint()` / `warning()` 経由に置換、rustdoc を同期 |

## レビュー結果 (/polish)

| Reviewer | Findings |
| --- | --- |
| simplify-reuse | 0 |
| simplify-readability | 4 (test ID T-049/T-050a → T-124/T-125 renumber のみ採用。doc trim は既存 helper 整合性で reject) |
| simplify-efficiency | 0 |
| codex | 0 |
| coderabbit | 0 |
| gemini-2.5-flash | 0 actionable |
| enhancer-code (Phase 2) | 0 changes (clean within preservation envelope) |

## 検証手順

- [x] `cargo test --lib`: 141 / 141 pass (T-124/T-125 含む)
- [x] `cargo test --doc`: 20 / 20 pass (`cli::message::hint` / `cli::message::warning` doctest 含む)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: 通過
- [x] `cargo fmt --check`: 通過 (pre-commit hook)
- [x] 下流 grep: amici / sae / yomu / recall で `"Warning: "` pin 依存ゼロ確認

Closes #114