### PR TITLE
chore(deps): cargo update と rurico bb25a06 → a573655 の同期

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1442,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=bb25a06#bb25a06cd32b5e83df291d6a7cf251de738ac7bb"
+source = "git+https://github.com/thkt/rurico?rev=a573655#a573655f0a811deeae96f87640d28fcd117dec7b"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=bb25a06#bb25a06cd32b5e83df291d6a7cf251de738ac7bb"
+source = "git+https://github.com/thkt/rurico?rev=a573655#a573655f0a811deeae96f87640d28fcd117dec7b"
 dependencies = [
  "mlx-sys",
  "rusqlite",
@@ -2531,9 +2531,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["eval-harness"]
 bytemuck           = "1"
 rand               = "0.10"
 rand_chacha        = "0.10"
-rurico             = { git = "https://github.com/thkt/rurico", rev = "bb25a06" }
+rurico             = { git = "https://github.com/thkt/rurico", rev = "a573655" }
 rusqlite           = { version = "0.39", features = ["bundled"] }
 serde              = { version = "1", features = ["derive"] }
 serde_json         = "1"
@@ -30,7 +30,7 @@ tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico   = { git = "https://github.com/thkt/rurico", rev = "bb25a06", features = ["test-support"] }
+rurico   = { git = "https://github.com/thkt/rurico", rev = "a573655", features = ["test-support"] }
 tempfile = "3"
 
 [lints.rust]


### PR DESCRIPTION
## 概要

- `num-conv` 0.2.1 → 0.2.2 / `tower-http` 0.6.10 → 0.6.11 (lockfile patch)。
- `rurico` rev `bb25a06` → `a573655` ([thkt/rurico#186](https://github.com/thkt/rurico/pull/186) で同じ cargo update を取り込み済み)。
- 上流 (rurico) / 下流 (amici) で Cargo.lock の `num-conv` / `tower-http` バージョンを揃え、git dep の rev pin を最新化。

## 動作確認

- [x] `cargo build`
- [x] `cargo nextest run` (141 passed, 0 failed)
- [x] `cargo test --doc` (20 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] pre-commit hook (fmt + clippy)