### PR TITLE
test: 実装を言い換えただけのテストを除去し契約検証を実パスへ集約

### DIFF
--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -2357,10 +2357,25 @@ mod tests {
         let _exit = run_replay_first_search_with(&ctx, &output_path, &merge_config, &normalization);
 
         let snapshot = read_snapshot(&output_path).unwrap_or_else(|e| panic!("T-068-001: {e}"));
+        // Replay envelope contract, asserted against the real
+        // `run_replay_first_search_with` output rather than a builder fed
+        // hardcoded args: kind (proves the pipeline ran), captured_with
+        // (FR-019 provenance), and the BR-003 aggregation marker. Checking
+        // the live snapshot subsumes the former pass-through unit tests.
         assert_eq!(
             snapshot.kind,
             BaselineKind::FirstSearchReplay,
             "T-068-001: snapshot kind must be FirstSearchReplay (proves pipeline ran)"
+        );
+        assert_eq!(
+            snapshot.captured_with, "eval_harness replay-first-search",
+            "T-068-001: FR-019 — replay snapshot must record the subcommand in captured_with"
+        );
+        assert_eq!(
+            snapshot.aggregation,
+            AggregationKind::NotApplicable,
+            "T-068-001: BR-003 — replay runs MaxChunkAggregator only, so the \
+             aggregation marker must be NotApplicable"
         );
         assert_eq!(
             init_calls.load(Ordering::SeqCst),
@@ -2439,42 +2454,6 @@ mod tests {
                 .expect("first_search_replay kind must parse"),
             BaselineKind::FirstSearchReplay,
             "FR-016/FR-017: subcommand kind label must map to FirstSearchReplay"
-        );
-    }
-
-    // T-062-017: replay_first_search_writes_baseline_with_kind_first_search_replay
-    //
-    // FR-019: snapshot envelope kind == FirstSearchReplay so consumers can
-    // tell the file apart from forward / oracle baselines.
-    #[test]
-    fn replay_first_search_writes_baseline_with_kind_first_search_replay() {
-        let snap = build_test_replay_snapshot();
-        assert_eq!(snap.kind, BaselineKind::FirstSearchReplay);
-    }
-
-    // T-062-018: replay_first_search_writes_captured_with_replay_first_search
-    //
-    // FR-019: provenance string lets log readers tell which subcommand
-    // produced the file. Also doubles as the regenerate hint that
-    // `verify-baseline` emits on schema_version mismatch.
-    #[test]
-    fn replay_first_search_writes_captured_with_replay_first_search() {
-        let snap = build_test_replay_snapshot();
-        assert_eq!(snap.captured_with, "eval_harness replay-first-search");
-    }
-
-    // T-062-019: replay_first_search_writes_aggregation_none
-    //
-    // BR-003: replay path runs Stage 3 = MaxChunkAggregator only — no
-    // ranking-aware aggregator is invoked, so the field marker is "none".
-    #[test]
-    fn replay_first_search_writes_aggregation_none() {
-        let snap = build_test_replay_snapshot();
-        assert_eq!(
-            snap.aggregation,
-            AggregationKind::NotApplicable,
-            "BR-003: replay path's Stage 3 strategy is MaxChunkAggregator only \
-             (no ranking-aware aggregator) → aggregation marker is NotApplicable"
         );
     }
 

--- a/src/eval/annotation/tests.rs
+++ b/src/eval/annotation/tests.rs
@@ -121,16 +121,6 @@ fn validate_schema_version_rejects_mismatched_label() {
     );
 }
 
-// T-004a: annotation_schema_version_constant_equals_1_0
-// FR-002: ANNOTATION_SCHEMA_VERSION pub const equals "1.0".
-#[test]
-fn annotation_schema_version_constant_equals_1_0() {
-    assert_eq!(
-        ANNOTATION_SCHEMA_VERSION, "1.0",
-        "FR-002: ANNOTATION_SCHEMA_VERSION must equal \"1.0\""
-    );
-}
-
 // T-004b: entry_mode_is_reachable_as_block_mode_standard
 // FR-006: BlockMode::Standard is reachable as the sole Phase 1
 //         authoring strategy variant via `matches!`.
@@ -142,19 +132,6 @@ fn entry_mode_is_reachable_as_block_mode_standard() {
         "FR-006: Entry.mode must be reachable as BlockMode::Standard; \
          got: {:?}",
         session.entries[0].mode
-    );
-}
-
-// T-004c: annotation_error_empty_session_variant_is_reachable
-// FR-001: AnnotationError pub-exports the EmptySession variant
-//         reachable via `matches!`.
-#[test]
-fn annotation_error_empty_session_variant_is_reachable() {
-    let err: AnnotationError = AnnotationError::EmptySession;
-    assert!(
-        matches!(err, AnnotationError::EmptySession),
-        "FR-001: AnnotationError::EmptySession variant must be reachable via matches!; \
-         got: {err:?}"
     );
 }
 

--- a/src/eval/baseline.rs
+++ b/src/eval/baseline.rs
@@ -581,19 +581,6 @@ mod tests {
         );
     }
 
-    // T-062-013: baseline_schema_version_is_1_3
-    //
-    // FR-014: BASELINE_SCHEMA_VERSION bumped to "1.3" so verify-baseline
-    // refuses 1.2 stamps via EXIT_REGRESSION (silent skip would mask
-    // FirstSearchReplay readiness).
-    #[test]
-    fn baseline_schema_version_is_1_3() {
-        assert_eq!(
-            BASELINE_SCHEMA_VERSION, "1.3",
-            "FR-014: schema must be 1.3 to gate stale 1.2 baselines"
-        );
-    }
-
     // T-062-014: committed_baselines_deserialize_under_schema_1_3
     //
     // FR-014 / AC-6: every committed baseline file (forward / oracle /


### PR DESCRIPTION
## 概要

テストスイートから「実装をただ言い換えただけのテスト」を除去する。今回該当したのは次の2系統のみ:

- **トートロジー**(定数の定義リテラルを再現): `assert_eq!(CONST, "<その定数の値>")`
- **builder pass-through**: 無変換の builder に固定値を渡し、同じ値が出力に乗ることを確認するだけ

削除で失われる契約は、実 subcommand 出力を検証する既存テストへ畳み込んで保持した。production の挙動は不変、削除のみ(+ 1 テスト強化)。

## 削除したテストと残る契約の所在

| テスト | パターン | 契約の保持先 |
|--------|---------|-------------|
| baseline `T-062-013` (`BASELINE_SCHEMA_VERSION == "1.3"`) | ②tautology | schema gate 実挙動 = `T-062-022` (`"1.2"→EXIT_REGRESSION`)、committed fixture version = `T-062-014` |
| annotation `T-004a` (`ANNOTATION_SCHEMA_VERSION == "1.0"`) | ②tautology | `T-003` が `validate_schema_version` の `expected=="1.0"` を behavioral に検証 |
| annotation `T-004c` (`EmptySession` variant reachability) | ④vacuous variant 確認 | construct→`matches!` のみで挙動なし。`EmptySession` は production 未構築の forward-compat `pub` variant |
| eval_harness `T-062-017/018/019` (replay snapshot の builder pass-through) | ②tautology | 強化した `T-068-001` — 実 `run_replay_first_search_with` 出力に対し kind / captured_with / aggregation を検証 |

`build_baseline_snapshot` は kind/captured_with/aggregation を無変換 pass-through するため、固定値を渡して読み返す 017/018/019 は実装をなぞるだけだった。実パスを走らせる `T-068-001` に畳み込むことで、builder の素通しではなく subcommand の実出力で契約を pin する。

## 保持した contract pin(対比)

- `exit_code::codes::*`(`USAGE==64` 等): シェル/ダッシュボードと共有する**クロスプロセス wire 契約**で、const がその唯一の表面 → 保持。schema version は単調増加 counter かつ fixture 側に実体があり、const リテラルの pin は冗長という違い。
- `T-032/T-033`(merged arm)・`T-004b`(`BlockMode::Standard`、production 使用あり)など behavioral な内容を持つものは保持。

## 制約の遵守

- mock 定義(test-support 公開)は無変更。
- ADR/docs から参照されるテスト名(`T-014` / `T-001` / `T-021`、baseline serde-default fn 等)は削除対象に含まれない(doc grep で確認済み)。
- ブランチは main から分岐し、無関係な ci commit を含まない。Cargo.lock はコミット対象外。

## 検証

| ゲート | 結果 |
|--------|------|
| `cargo nextest run` (feature なし) | 141 passed |
| `cargo nextest run --features eval-harness` | 251 passed, 9 skipped (MLX 必須 `#[ignore]`) |
| `cargo clippy --all-targets --all-features -- -D warnings` | 緑 |

(266 テスト − 6 削除 = 260 = 251 run + 9 ignored で整合)
