### PR TITLE
refactor(model): ProbeFailed inner を Option<String> 化し空文字 sentinel を除去

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -210,9 +210,10 @@ pub enum ModelDownloadError {
     /// The hardware/OS backend (e.g. MLX) is not available on this machine.
     BackendUnavailable,
     /// The downloaded model files could not be loaded.
-    /// The inner `String` carries the probe error string; it is empty when
-    /// model-file corruption prevented error capture (see `ModelCorrupt` handling).
-    ProbeFailed(String),
+    /// The inner `Option<String>` carries the probe error detail; it is `None`
+    /// when model-file corruption prevented error capture (see
+    /// [`ModelInitError::ModelCorrupt`] handling).
+    ProbeFailed(Option<String>),
 }
 
 impl fmt::Display for ModelDownloadError {
@@ -228,10 +229,10 @@ impl fmt::Display for ModelDownloadError {
                 f,
                 "MLX backend unavailable; requires Apple Silicon with macOS 14 or later"
             ),
-            Self::ProbeFailed(detail) if detail.is_empty() => {
+            Self::ProbeFailed(None) => {
                 write!(f, "model probe failed; try again or re-download the model")
             }
-            Self::ProbeFailed(detail) => write!(
+            Self::ProbeFailed(Some(detail)) => write!(
                 f,
                 "model probe failed: {detail}; try again or re-download the model"
             ),
@@ -317,9 +318,7 @@ where
     .map(|_| ())
     .map_err(|reason| match reason {
         DegradedReason::BackendUnavailable => ModelDownloadError::BackendUnavailable,
-        DegradedReason::ProbeFailed => {
-            ModelDownloadError::ProbeFailed(probe_detail.unwrap_or_default())
-        }
+        DegradedReason::ProbeFailed => ModelDownloadError::ProbeFailed(probe_detail),
         DegradedReason::NotInstalled | DegradedReason::Disabled => {
             unreachable!(
                 "loader with cache=Some cannot produce NotInstalled; Disabled is caller-only"
@@ -471,7 +470,7 @@ mod tests {
             || {},
         );
         match result {
-            Err(ModelDownloadError::ProbeFailed(detail)) => assert!(
+            Err(ModelDownloadError::ProbeFailed(Some(detail))) => assert!(
                 detail.contains("backend down"),
                 "probe_detail should carry error message, got {detail:?}"
             ),
@@ -515,7 +514,7 @@ mod tests {
             || {},
         );
         match result {
-            Err(ModelDownloadError::ProbeFailed(detail)) => assert!(
+            Err(ModelDownloadError::ProbeFailed(Some(detail))) => assert!(
                 detail.contains("alloc failed"),
                 "probe_detail should carry new_fn error message, got {detail:?}"
             ),
@@ -632,6 +631,21 @@ mod tests {
         assert!(
             note.contains("text search only"),
             "note must explain the fallback, got: {note}"
+        );
+    }
+
+    // T-034: probe_failed_display_distinguishes_detail_presence
+    #[test]
+    fn probe_failed_display_distinguishes_detail_presence() {
+        assert_eq!(
+            ModelDownloadError::ProbeFailed(None).to_string(),
+            "model probe failed; try again or re-download the model",
+            "None must render the no-detail wording"
+        );
+        assert_eq!(
+            ModelDownloadError::ProbeFailed(Some("hash mismatch".into())).to_string(),
+            "model probe failed: hash mismatch; try again or re-download the model",
+            "Some(detail) must embed the detail in the wording"
         );
     }
 }


### PR DESCRIPTION
## 概要

`ModelDownloadError::ProbeFailed(String)` の inner を `Option<String>` に変更し、空文字列を「詳細なし」とする sentinel 設計を解消。詳細あり/なしを型で表現する。Closes #120.

## 変更点

- enum: `ProbeFailed(String)` → `ProbeFailed(Option<String>)`
- Display: `if detail.is_empty()` 実行時分岐を `None` / `Some(detail)` の match に置換
- 呼び出し箇所: `unwrap_or_default()` の往復を削除し `probe_detail: Option<String>` を直接渡す
- doc: `None` 原因の cross-reference を [`ModelInitError::ModelCorrupt`] に明確化

## テスト

- T-024 / T-026: `Some(detail)` 受けに追従
- T-034: Display 両 arm の wording を exact pin（diff coverage gate 対応）

## 設計判断

公開 wording は維持（詳細なし / 詳細あり 両方）。`ModelInitError` の両 variant は固定 prefix を持つため `Some("")` は発生せず、`None` / `Some` 2分岐は旧 `is_empty()` 判定と等価。

## 下流影響

sae / yomu / recall は production で `ProbeFailed(_)` と inner を捨てて受けるため影響なし。各テストのみ rev bump 時に `Some(...)` 追従が必要（別セッション）。

## 監査

`/audit` 実施 (11 reviewer + challenger / verifier / causation): critical/high なし。READ-001 (doc) は反映済み。COV-001 (`ProbeFailed(None)` の caller-level テスト) は diff coverage gate の test-code blind spot を踏むため #130 に defer。検討事項 (ENC-001 NonEmptyString 化, TEST-002/003 contains→exact) は YAGNI / 脆い結合回避のため見送り。