### PR TITLE
test(model): ProbeFailed(None) の caller-level カバレッジを追加

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -648,4 +648,38 @@ mod tests {
             "Some(detail) must embed the detail in the wording"
         );
     }
+
+    // T-035: new_fn_corrupt_returns_probe_failed_none
+    #[test]
+    fn new_fn_corrupt_returns_probe_failed_none() {
+        let delete_attempted = Cell::new(false);
+        let delete_error_seen = Cell::new(false);
+        let result = try_download_and_verify_with_fns::<_, MockEmbedder, String>(
+            || Ok::<_, String>(()),
+            |_| delete_error_seen.set(true),
+            |_| Ok(ProbeStatus::Available),
+            |_| {
+                Err(ModelInitError::ModelCorrupt {
+                    reason: "weights corrupt".into(),
+                })
+            },
+            |_| {
+                delete_attempted.set(true);
+                Err(io::Error::other("disk full"))
+            },
+            || {},
+        );
+        assert!(
+            matches!(result, Err(ModelDownloadError::ProbeFailed(None))),
+            "ModelCorrupt must map to ProbeFailed(None) (detail not captured), got {result:?}"
+        );
+        assert!(
+            delete_attempted.get(),
+            "ModelCorrupt must attempt artifact deletion"
+        );
+        assert!(
+            delete_error_seen.get(),
+            "delete failure must reach on_delete_error"
+        );
+    }
 }


### PR DESCRIPTION
## 概要

#120 で `ModelDownloadError::ProbeFailed` を `Option<String>` 化した follow-up (audit COV-001 / #130)。`ModelCorrupt` が `try_download_and_verify_with_fns` を通って `ProbeFailed(None)` を生む caller-level 経路を pin する。Closes #130.

## 変更点

- T-035 `new_fn_corrupt_returns_probe_failed_none`: new_fn が `ModelCorrupt` を返し delete が失敗する経路で、`ProbeFailed(None)` への map + delete 試行 + `on_delete_error` 到達を検証

## 設計判断

防御アーム (`panic!`/`unreachable!`) を使わず全 callback が実行される形にし、diff coverage gate の test-code blind spot を踏まずに変更行 100% カバー。delete-failure は `on_delete_error` を発火させるための形 (`ProbeFailed(None)` 自体は delete 成否に依らない)。

## 監査

`/audit` 実施 (6 test-quality reviewer + challenger / verifier / causation): 機能健全 (rust clean, diff-cover 100%)。test 名を new_fn arm 明示へ rename のみ反映。COV-001 (probe_fn arm の model.rs layer test) と DSGN-001 (delete-failure 結合の除去) は gate blind spot 由来のため #127 (test 分離 + ci.yml exclude) 後に再構成 (今 split すると gate 再 fail = patch-on-patch)。