### PR TITLE
ci: diff coverage gate 失敗時に diff-cover report を artifact として残す (#134)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,15 +100,33 @@ jobs:
         run: cargo llvm-cov --all-features --lcov --output-path lcov.info --ignore-filename-regex '/tests\.rs$'
 
       - name: Diff coverage gate (changed lines >= 95%)
+        id: diff_coverage
         run: |
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           # diff-cover is a Python tool; isolate it in a venv to avoid PEP 668
           # (externally-managed environments) regardless of the runner's Python.
           python3 -m venv /tmp/diff-cover-venv
           /tmp/diff-cover-venv/bin/pip install --quiet diff-cover
+          # diff-cover writes the HTML report before applying --fail-under, so the
+          # report exists for the upload step below even when this gate fails.
+          # (--html-report is deprecated in diff-cover 10.x; use --format html:.)
           /tmp/diff-cover-venv/bin/diff-cover lcov.info \
             --compare-branch=origin/main \
+            --format html:diff-cover-report.html \
             --fail-under=95
+
+      - name: Upload diff coverage report
+        # On gate failure the report pinpoints which changed lines are uncovered,
+        # so a reviewer need not open the raw job log (#134). Scoped to the gate
+        # step's own failure so an upstream failure (e.g. lcov generation) does not
+        # trigger an empty upload; if-no-files-found:error then asserts the report
+        # really was written.
+        if: ${{ failure() && steps.diff_coverage.conclusion == 'failure' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: diff-coverage-report
+          path: diff-cover-report.html
+          if-no-files-found: error
 
   security:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 target/
 workspace/
 
-# Coverage artifacts (cargo llvm-cov)
+# Coverage artifacts (cargo llvm-cov / diff-cover)
 *.profraw
 /lcov.info
+/diff-cover-report.html


### PR DESCRIPTION
## 概要

CI の coverage job で diff coverage gate (`diff-cover`) が失敗した際、構造化された HTML report を artifact として retain し、どの変更行が uncovered かを raw job log を開かずに確認できるようにする。PR #133 (#127) の `/audit` で OPS-001 として検出した follow-up。

## 変更点

- gate step に `--format html:diff-cover-report.html` を追加し HTML report を生成 (`--html-report` は diff-cover 10.x で deprecated のため `--format html:` を採用)
- gate step に `id: diff_coverage` を付与し、`if: ${{ failure() && steps.diff_coverage.conclusion == 'failure' }}` の upload step を追加。upload を gate 自身の失敗に限定し、上流 step (lcov 生成) 失敗時の空 upload を回避
- `actions/upload-artifact` を v7.0.1 (`043fb46…`) で SHA pin (yomu / recall と一致)。`if-no-files-found: error` で report 書き出しを invariant として表明
- `.gitignore` に `/diff-cover-report.html` を追加

## テスト

- diff-cover 10.3.0 のソース読解 + 合成 lcov の e2e で、report は `--fail-under` の exit 判定より**前**に書き出される (coverage 25% < 95% → exit 1、かつ report 6132 bytes 生成) ことを実証。`if: failure()` の upload step でファイルを掴める
- `actionlint .github/workflows/ci.yml`: no issues
- `zizmor .github/workflows/ci.yml`: No findings to report
- console summary は `--format html:` 併用時も stdout に出続けるため、既存の stdout triage は維持

## スコープ

amici 単体で完結 (CI workflow のみ)。下流 (sae / yomu / recall) への影響なし。

Closes #134