### PR TITLE
refactor(model): degraded_reason_user_note を EmbedderDegraded::user_note へ移し reranker 流用を型で禁止 (#122)

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -42,24 +42,32 @@ impl fmt::Display for DegradedReason {
     }
 }
 
-/// Returns a short user-facing note for a degraded embedder,
-/// or `None` if no message should be shown (e.g. the caller explicitly disabled the model).
+/// A degraded embedder, wrapping the [`DegradedReason`] that caused it.
 ///
-/// `download_cmd` is interpolated into the [`DegradedReason::NotInstalled`] note so the
-/// caller can surface the binary-specific recovery action (e.g. `"yomu model download"`).
-/// Other variants ignore `download_cmd` because their cause is not addressable by
-/// re-downloading the model.
-///
-/// The wording is embedder-specific. Reranker callers should not reuse this fn;
-/// no reranker-degraded note helper exists yet because no consumer needs one.
-pub fn degraded_reason_user_note(reason: DegradedReason, download_cmd: &str) -> Option<String> {
-    match reason {
-        DegradedReason::Disabled => None,
-        DegradedReason::NotInstalled => Some(format!(
-            "embedding model not installed; run `{download_cmd}` to enable semantic search"
-        )),
-        DegradedReason::BackendUnavailable | DegradedReason::ProbeFailed => {
-            Some("embedding model unavailable; results from text search only".into())
+/// The Newtype moves the "embedder-specific, do not reuse for a reranker" contract from a
+/// doc comment into the type: [`EmbedderDegraded::user_note`] is reachable only from an
+/// `EmbedderDegraded`, so a reranker caller holding a bare [`DegradedReason`] cannot invoke
+/// it. No reranker-degraded equivalent exists yet because no consumer needs one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EmbedderDegraded(pub DegradedReason);
+
+impl EmbedderDegraded {
+    /// Returns a short user-facing note for this degraded embedder,
+    /// or `None` if no message should be shown (e.g. the caller explicitly disabled the model).
+    ///
+    /// `download_cmd` is interpolated into the [`DegradedReason::NotInstalled`] note so the
+    /// caller can surface the binary-specific recovery action (e.g. `"yomu model download"`).
+    /// Other variants ignore `download_cmd` because their cause is not addressable by
+    /// re-downloading the model.
+    pub fn user_note(self, download_cmd: &str) -> Option<String> {
+        match self.0 {
+            DegradedReason::Disabled => None,
+            DegradedReason::NotInstalled => Some(format!(
+                "embedding model not installed; run `{download_cmd}` to enable semantic search"
+            )),
+            DegradedReason::BackendUnavailable | DegradedReason::ProbeFailed => {
+                Some("embedding model unavailable; results from text search only".into())
+            }
         }
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -44,10 +44,12 @@ impl fmt::Display for DegradedReason {
 
 /// A degraded embedder, wrapping the [`DegradedReason`] that caused it.
 ///
-/// The Newtype moves the "embedder-specific, do not reuse for a reranker" contract from a
-/// doc comment into the type: [`EmbedderDegraded::user_note`] is reachable only from an
-/// `EmbedderDegraded`, so a reranker caller holding a bare [`DegradedReason`] cannot invoke
-/// it. No reranker-degraded equivalent exists yet because no consumer needs one.
+/// The Newtype keeps the embedder-specific note ([`EmbedderDegraded::user_note`]) from being
+/// reused for a reranker by accident: `user_note` lives only on `EmbedderDegraded`, so a bare
+/// [`DegradedReason`] (e.g. one returned by the reranker loader) cannot call it without an
+/// explicit, greppable `EmbedderDegraded(..)` wrap. The inner field is public because
+/// downstream constructs the value, so this is a visible opt-in, not a hard compile-time
+/// barrier. No reranker-degraded equivalent exists yet because no consumer needs one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EmbedderDegraded(pub DegradedReason);
 

--- a/src/model/embedder.rs
+++ b/src/model/embedder.rs
@@ -5,7 +5,7 @@ use rurico::embed::{Artifacts, Embed, Embedder, ModelId, cached_artifacts};
 use rurico::model_init::ModelInitError;
 use rurico::model_probe::ProbeStatus;
 
-pub use super::{DegradedReason, degraded_reason_user_note};
+pub use super::{DegradedReason, EmbedderDegraded};
 
 /// Try to load the embedding model.
 ///

--- a/src/model/tests.rs
+++ b/src/model/tests.rs
@@ -247,20 +247,21 @@ fn record_degraded_emits_warn_with_context() {
     );
 }
 
-// T-030: degraded_reason_user_note_returns_none_for_disabled
+// T-030: user_note_returns_none_for_disabled
 #[test]
-fn degraded_reason_user_note_returns_none_for_disabled() {
+fn user_note_returns_none_for_disabled() {
     assert_eq!(
-        degraded_reason_user_note(DegradedReason::Disabled, "any cmd"),
+        EmbedderDegraded(DegradedReason::Disabled).user_note("any cmd"),
         None,
         "Disabled is caller opt-out; suppress the note"
     );
 }
 
-// T-031: degraded_reason_user_note_injects_download_cmd_for_not_installed
+// T-031: user_note_injects_download_cmd_for_not_installed
 #[test]
-fn degraded_reason_user_note_injects_download_cmd_for_not_installed() {
-    let note = degraded_reason_user_note(DegradedReason::NotInstalled, "yomu model download")
+fn user_note_injects_download_cmd_for_not_installed() {
+    let note = EmbedderDegraded(DegradedReason::NotInstalled)
+        .user_note("yomu model download")
         .expect("NotInstalled must produce a note");
     assert!(
         note.contains("`yomu model download`"),
@@ -272,12 +273,12 @@ fn degraded_reason_user_note_injects_download_cmd_for_not_installed() {
     );
 }
 
-// T-032: degraded_reason_user_note_ignores_download_cmd_for_backend_unavailable
+// T-032: user_note_ignores_download_cmd_for_backend_unavailable
 #[test]
-fn degraded_reason_user_note_ignores_download_cmd_for_backend_unavailable() {
-    let note =
-        degraded_reason_user_note(DegradedReason::BackendUnavailable, "recall model download")
-            .expect("BackendUnavailable must produce a note");
+fn user_note_ignores_download_cmd_for_backend_unavailable() {
+    let note = EmbedderDegraded(DegradedReason::BackendUnavailable)
+        .user_note("recall model download")
+        .expect("BackendUnavailable must produce a note");
     assert!(
         !note.contains("recall model download"),
         "download_cmd must not leak into BackendUnavailable note, got: {note}"
@@ -288,10 +289,11 @@ fn degraded_reason_user_note_ignores_download_cmd_for_backend_unavailable() {
     );
 }
 
-// T-033: degraded_reason_user_note_ignores_download_cmd_for_probe_failed
+// T-033: user_note_ignores_download_cmd_for_probe_failed
 #[test]
-fn degraded_reason_user_note_ignores_download_cmd_for_probe_failed() {
-    let note = degraded_reason_user_note(DegradedReason::ProbeFailed, "sae model download")
+fn user_note_ignores_download_cmd_for_probe_failed() {
+    let note = EmbedderDegraded(DegradedReason::ProbeFailed)
+        .user_note("sae model download")
         .expect("ProbeFailed must produce a note");
     assert!(
         !note.contains("sae model download"),


### PR DESCRIPTION
## 概要

「embedder 専用、reranker 流用禁止」という契約を doc コメントから型へ移す。free fn `degraded_reason_user_note(reason: DegradedReason, download_cmd)` を、新設 Newtype `EmbedderDegraded(pub DegradedReason)` のメソッド `EmbedderDegraded::user_note(self, download_cmd)` へ移設する。bare な `DegradedReason` (reranker loader が返す等) は `user_note` を直接呼べず、明示的で greppable な `EmbedderDegraded(..)` wrap が必要になる。返す文字列・挙動は不変。

## 変更点

- `src/model.rs`: `EmbedderDegraded(pub DegradedReason)` Newtype + `user_note` メソッドを新設 (derives は sibling の `DegradedReason` に揃える)
- `src/model/embedder.rs`: re-export を `EmbedderDegraded` へ更新 (free fn 削除)
- `src/model/tests.rs`: T-030〜T-033 を Newtype 経由の呼び出しへ追従、test 名も `user_note_*` へ
- doc: 保証を「明示オプトイン」と精密化 (下記 監査 参照)

## スコープ / BREAKING

amici 単体で完結。下流 yomu (`tools/embedder.rs` の import, `tools/search.rs` の呼び出し) は **別セッションの amici rev bump で追従** する (後方互換 shim は入れない方針)。この PR の時点で amici は standalone でコンパイル・テスト green、yomu は rev bump まで壊れる — documented な期待挙動。sae / recall は当該シンボル未使用。

## テスト

- `cargo nextest run --all-features`: 253 passed / 0 failed (9 skipped)
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt -- --check`: clean
- `cargo test --doc --all-features`: 20 passed / 0 failed
- diff coverage gate (CI 同一コマンド): `src/model.rs` 変更行 100% (`#[derive]` 行も uncovered 扱いされないことを実測確認)

## 監査

`/audit --focus=all` 実施 (reviewer 10 + challenger/critic-audit + verifier/critic-evidence)。Wave 1 で 12 findings が出たが challenger が全件 dismiss、verifier の具体エビデンス (amici standalone green / CI pass / test assertion は main と不変 / yomu deferral は意図的) が各 dismiss を裏付け。

実質的インサイト 1 点を doc に反映 (commit `88f789f`): `pub` field のため reranker caller でも明示 wrap すれば `user_note` を呼べる。したがって本 Newtype の保証は「コンパイル時の流用禁止」ではなく「暗黙流用の防止 / 明示的で greppable なオプトイン」。`pub` field は下流が値を構築するため必須。doc が enforcement を過大に示唆しないよう wording を実態へ揃えた。

`#[must_use]` 追加・test assertion の full-string 化は、それぞれ CI 非ブロッカー (pedantic) / pre-existing スコープ外として意図的に見送り。

Closes #122