### PR TITLE
docs: README の model API 表を #122 に同期 (degraded_reason_user_note → EmbedderDegraded)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,19 +4,19 @@ sae/yomu/recall ツールチェーンで共有するモデルローディング�
 
 ## モジュール
 
-| Module | Contents |
-| ------ | -------- |
-| `model` | `DegradedReason`, `degraded_reason_user_note`, `degrade_with_warn`, `record_degraded`, `ModelLoad<T>`, `ModelDownloadError`, `download_and_verify_model` |
-| `model::embedder` | `try_load_embedder_with`, `try_load_embedder_default_logging` — エンベディングモデルをロード |
-| `model::reranker` | `try_load_reranker_with` — リランキングモデルをロード |
-| `storage::filter` | `in_placeholders`, `anon_placeholders`, `as_sql_params`, `append_eq_filter`, … — SQL `WHERE` 句とパラメータの構築ヘルパー |
-| `storage::query_helpers` | `collect_rows`, `fetch_by_in_clause` — `Connection` を取って行を回収する実行系ヘルパー（コレクション型・エラー型を generic にサポート） |
-| `storage::fts` | `clean_for_trigram` — `rurico::storage::MatchFtsQuery` を FTS5 `trigram` トークナイザ向けに整形 |
-| `cli` | `Spinner`, `with_spinner`, `embed_with_spinners`, `done`, `try_expand_shorthand`, `env_lookup`, `CliError`, `exit_code::codes`, `exit_error`, `hint_arrow`, `info`, `deprecation_warn`, `progress_step` |
-| `migration` | `notify_schema_change` — スキーマクリア通知用の `tracing::warn!` 統一実装 |
-| `logging` | `init_subscriber` — `RUST_LOG` 対応の `tracing_subscriber::fmt` 初期化（CLI `main.rs` 用） |
-| `eval` *(feature `eval-harness`)* | `rurico` プリミティブと合成した検索評価ハーネス。`eval_harness` バイナリの裏側 (ADR 0002)。 |
-| `testing::hybrid` *(feature `test-support`)* | ハイブリッド検索における FTS↔vec 対称性のコントラクトアサーション。 |
+| Module                                       | Contents                                                                                                                                                                                                |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `model`                                      | `DegradedReason`, `EmbedderDegraded`, `degrade_with_warn`, `record_degraded`, `ModelLoad<T>`, `ModelDownloadError`, `download_and_verify_model`                                                         |
+| `model::embedder`                            | `try_load_embedder_with`, `try_load_embedder_default_logging` — エンベディングモデルをロード                                                                                                            |
+| `model::reranker`                            | `try_load_reranker_with` — リランキングモデルをロード                                                                                                                                                   |
+| `storage::filter`                            | `in_placeholders`, `anon_placeholders`, `as_sql_params`, `append_eq_filter`, … — SQL `WHERE` 句とパラメータの構築ヘルパー                                                                               |
+| `storage::query_helpers`                     | `collect_rows`, `fetch_by_in_clause` — `Connection` を取って行を回収する実行系ヘルパー（コレクション型・エラー型を generic にサポート）                                                                 |
+| `storage::fts`                               | `clean_for_trigram` — `rurico::storage::MatchFtsQuery` を FTS5 `trigram` トークナイザ向けに整形                                                                                                         |
+| `cli`                                        | `Spinner`, `with_spinner`, `embed_with_spinners`, `done`, `try_expand_shorthand`, `env_lookup`, `CliError`, `exit_code::codes`, `exit_error`, `hint_arrow`, `info`, `deprecation_warn`, `progress_step` |
+| `migration`                                  | `notify_schema_change` — スキーマクリア通知用の `tracing::warn!` 統一実装                                                                                                                               |
+| `logging`                                    | `init_subscriber` — `RUST_LOG` 対応の `tracing_subscriber::fmt` 初期化（CLI `main.rs` 用）                                                                                                              |
+| `eval` _(feature `eval-harness`)_            | `rurico` プリミティブと合成した検索評価ハーネス。`eval_harness` バイナリの裏側 (ADR 0002)。                                                                                                             |
+| `testing::hybrid` _(feature `test-support`)_ | ハイブリッド検索における FTS↔vec 対称性のコントラクトアサーション。                                                                                                                                     |
 
 ## 使い方
 
@@ -27,9 +27,9 @@ amici = { git = "https://github.com/thkt/amici", rev = "<rev>" }
 
 ## Features
 
-| Feature | 効果 |
-| ------- | ---- |
-| `eval-harness` | `amici::eval` と `eval_harness` バイナリをビルド。`just eval-*` レシピが要求。 |
+| Feature        | 効果                                                                                                                         |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `eval-harness` | `amici::eval` と `eval_harness` バイナリをビルド。`just eval-*` レシピが要求。                                               |
 | `test-support` | `amici::testing::hybrid` を公開。下流 crate が `[dev-dependencies]` でハイブリッド検索のコントラクトヘルパーを再利用できる。 |
 
 ## 開発

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@ Shared model-loading, storage helpers, and CLI utilities for the sae/yomu/recall
 
 ## Modules
 
-| Module | Contents |
-| ------ | -------- |
-| `model` | `DegradedReason`, `degraded_reason_user_note`, `degrade_with_warn`, `record_degraded`, `ModelLoad<T>`, `ModelDownloadError`, `download_and_verify_model` |
-| `model::embedder` | `try_load_embedder_with`, `try_load_embedder_default_logging` — loads the embedding model |
-| `model::reranker` | `try_load_reranker_with` — loads the reranking model |
-| `storage::filter` | `in_placeholders`, `anon_placeholders`, `as_sql_params`, `append_eq_filter`, … — SQL `WHERE` clause and parameter builders |
-| `storage::query_helpers` | `collect_rows`, `fetch_by_in_clause` — `Connection`-bound row collectors and IN-clause bulk fetch (generic over collection and error type) |
-| `storage::fts` | `clean_for_trigram` — adapts `rurico::storage::MatchFtsQuery` for an FTS5 `trigram` tokenizer |
-| `cli` | `Spinner`, `with_spinner`, `embed_with_spinners`, `done`, `try_expand_shorthand`, `env_lookup`, `CliError`, `exit_code::codes`, `exit_error`, `hint_arrow`, `info`, `deprecation_warn`, `progress_step` |
-| `migration` | `notify_schema_change` — unified `tracing::warn!` for schema-clear notices |
-| `logging` | `init_subscriber` — `RUST_LOG`-aware `tracing_subscriber::fmt` setup for CLI `main.rs` |
-| `eval` *(feature `eval-harness`)* | Search-evaluation harness composed with `rurico` primitives — backs the `eval_harness` binary (ADR 0002). |
-| `testing::hybrid` *(feature `test-support`)* | FTS↔vec symmetry contract assertion for hybrid search. |
+| Module                                       | Contents                                                                                                                                                                                                |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `model`                                      | `DegradedReason`, `EmbedderDegraded`, `degrade_with_warn`, `record_degraded`, `ModelLoad<T>`, `ModelDownloadError`, `download_and_verify_model`                                                         |
+| `model::embedder`                            | `try_load_embedder_with`, `try_load_embedder_default_logging` — loads the embedding model                                                                                                               |
+| `model::reranker`                            | `try_load_reranker_with` — loads the reranking model                                                                                                                                                    |
+| `storage::filter`                            | `in_placeholders`, `anon_placeholders`, `as_sql_params`, `append_eq_filter`, … — SQL `WHERE` clause and parameter builders                                                                              |
+| `storage::query_helpers`                     | `collect_rows`, `fetch_by_in_clause` — `Connection`-bound row collectors and IN-clause bulk fetch (generic over collection and error type)                                                              |
+| `storage::fts`                               | `clean_for_trigram` — adapts `rurico::storage::MatchFtsQuery` for an FTS5 `trigram` tokenizer                                                                                                           |
+| `cli`                                        | `Spinner`, `with_spinner`, `embed_with_spinners`, `done`, `try_expand_shorthand`, `env_lookup`, `CliError`, `exit_code::codes`, `exit_error`, `hint_arrow`, `info`, `deprecation_warn`, `progress_step` |
+| `migration`                                  | `notify_schema_change` — unified `tracing::warn!` for schema-clear notices                                                                                                                              |
+| `logging`                                    | `init_subscriber` — `RUST_LOG`-aware `tracing_subscriber::fmt` setup for CLI `main.rs`                                                                                                                  |
+| `eval` _(feature `eval-harness`)_            | Search-evaluation harness composed with `rurico` primitives — backs the `eval_harness` binary (ADR 0002).                                                                                               |
+| `testing::hybrid` _(feature `test-support`)_ | FTS↔vec symmetry contract assertion for hybrid search.                                                                                                                                                  |
 
 ## Usage
 
@@ -27,9 +27,9 @@ amici = { git = "https://github.com/thkt/amici", rev = "<rev>" }
 
 ## Features
 
-| Feature | Effect |
-| ------- | ------ |
-| `eval-harness` | Compiles `amici::eval` and the `eval_harness` binary. Required by `just eval-*` recipes. |
+| Feature        | Effect                                                                                                           |
+| -------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `eval-harness` | Compiles `amici::eval` and the `eval_harness` binary. Required by `just eval-*` recipes.                         |
 | `test-support` | Exposes `amici::testing::hybrid` so downstream `[dev-dependencies]` can reuse the hybrid-search contract helper. |
 
 ## CLI conventions


### PR DESCRIPTION
## 概要

#122 (PR #136) で `degraded_reason_user_note` free fn が `EmbedderDegraded::user_note` メソッドへ移行したのに伴い、`README.md` / `README.ja.md` の `model` モジュール API 表に残っていた stale シンボルを `EmbedderDegraded` へ更新する。merge 後のドキュメント整合チェックで検出した follow-up。

## 変更点

- `README.md` / `README.ja.md` line 9: `model` 行の `degraded_reason_user_note` → `EmbedderDegraded`
- 副次的に markdown フォーマッタ (PostToolUse hook) が Modules / Features 表のカラム幅を整形。**空白のみの正規化で文言・コード変更なし**

## 検証

- `model` モジュールの実 top-level pub surface と表を照合: `DegradedReason` / `EmbedderDegraded` / `degrade_with_warn` / `record_degraded` / `ModelLoad<T>` / `ModelDownloadError` / `download_and_verify_model` で完全一致
- `degraded_reason_user_note` の repo 全域 grep: 残存ゼロ (本修正後)
- ADR (docs/decisions/) は `DegradedReason` (#122 で不変) のみ参照で整合、docs/audit/* は historical snapshot で対象外

issue なし (#136 マージ後に発見した doc follow-up)。