### PR TITLE
rurico を e330c22 に bump し rust-version を 1.96 へ引き上げ

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,7 +1906,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=c862123#c86212351cd297356abe4298c0688871d5808c4f"
+source = "git+https://github.com/thkt/rurico?rev=e330c22#e330c2258c890e41bc70fd388cabb057d69d1cbd"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -1924,7 +1924,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=c862123#c86212351cd297356abe4298c0688871d5808c4f"
+source = "git+https://github.com/thkt/rurico?rev=e330c22#e330c2258c890e41bc70fd388cabb057d69d1cbd"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "amici"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 description = "Shared model-loading, storage helpers, and CLI utilities for the sae/yomu/recall toolchain"
 license = "MIT"
 repository = "https://github.com/thkt/amici"
@@ -21,7 +21,7 @@ required-features = ["eval-harness"]
 bytemuck = "1"
 rand = "0.10"
 rand_chacha = "0.10"
-rurico = { git = "https://github.com/thkt/rurico", rev = "c862123" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "e330c22" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -30,7 +30,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "c862123", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "e330c22", features = ["test-support"] }
 temp-env = "0.3"
 tempfile = "3"
 


### PR DESCRIPTION
## 概要と目的

upstream rurico#207 が rust-version を 1.95 → 1.96 へ引き上げたことへの amici 側追従。rurico rev を PR #207 merge commit (`e330c22`) に上げ、amici の rust-version も 1.96 に揃える。

## 変更内容

- `Cargo.toml`: rurico rev (dep + dev-dep) `c862123` → `e330c22`、rust-version `1.95` → `1.96`
- `Cargo.lock`: rurico / rurico-ffi を `e330c2258c89` に更新

## 設計判断

- **MSRV 1.96 は依存フロアとして宣言**: amici は 1.96 機能を直接使わない (rurico の `assert_matches!` は `#[cfg(test)]` で lib artifact 不変)。(1) 依存 rurico の宣言 MSRV 1.96 以上に揃える依存フロア、(2) local / mise / CI stable すべて 1.96 稼働の実態と宣言 1.95 の乖離解消、の 2 点で 1.96 を宣言する。「一律最新追従」ではなく依存フロアという amici 固有の理由による。
- `c862123` → `e330c22` の span は PR #207 のみ。rurico lib は不変のため挙動は **no-op**。

## スコープ

- **コード変更なし (検証済み)**: `assert_matches!` 採用 (rurico#207 の fleet 変更) は amici では対象 0 件。amici の `assert!(matches!())` 全 18 箇所はすべてメッセージ付き (`"...got: {result:?}"`) で、rurico が Display 維持のため意図的に据え置いたカテゴリそのもの。メッセージなし候補は 0 件 → PR #207 の「amici は surface 0」を実地確認。
- **据え置き**: `src/cli/exit_code.rs:34` のコメント「not const (stable Rust 1.95)」は 1.96 でも `ExitCode::from` が非 const (E0015 で実検証) のため事実は真、バージョン表記のみ古く未変更。
- **除外**: Cargo.lock の unicode-segmentation `1.13.2` → `1.13.3` drift は別 concern として bump から除外。

## テスト方法

1. `cargo nextest run --all-features` → 255 passed, 0 failed
2. `cargo clippy --all-targets --all-features -- -D warnings` → 警告なし (pre-commit 通過)
3. `cargo fmt --check` → diff なし

## 関連

- upstream: thkt/rurico#207
- downstream 追従: thkt/sae#180, thkt/yomu#276, thkt/recall#129
