### PR TITLE
chore(deps): rurico の rusqlite を 0.39 → 0.40 に追従

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "a76001fb4daed01e5f2b518aac0b4dc592e7c734da63dbffcf0c64fa612a8d0c"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1906,7 +1906,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=e330c22#e330c2258c890e41bc70fd388cabb057d69d1cbd"
+source = "git+https://github.com/thkt/rurico?rev=adbe3a8#adbe3a8b7457dc8f174160b629b604479c6019cf"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -1924,7 +1924,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=e330c22#e330c2258c890e41bc70fd388cabb057d69d1cbd"
+source = "git+https://github.com/thkt/rurico?rev=adbe3a8#adbe3a8b7457dc8f174160b629b604479c6019cf"
 dependencies = [
  "mlx-sys",
  "rusqlite",
@@ -1933,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "1b3492ea85308705c3a5cc24fb9b9cf77273d30590349070db42991202b214c4"
 dependencies = [
  "bitflags",
  "fallible-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ required-features = ["eval-harness"]
 bytemuck = "1"
 rand = "0.10"
 rand_chacha = "0.10"
-rurico = { git = "https://github.com/thkt/rurico", rev = "e330c22" }
-rusqlite = { version = "0.39", features = ["bundled"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "adbe3a8" }
+rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
@@ -30,7 +30,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "e330c22", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "adbe3a8", features = ["test-support"] }
 temp-env = "0.3"
 tempfile = "3"
 


### PR DESCRIPTION
## 概要
rurico が rusqlite 0.39 → 0.40 に更新（PR #208, rev `adbe3a8`）。amici は rusqlite を自前 dep と rurico 経由の2経路で引き、libsqlite3-sys の `links = "sqlite3"` が 0.37/0.38 共存を禁止するため、自前 rusqlite を**同一変更で** 0.40 に追従（分割不可）。

## 変更
- `rusqlite` 0.39 → 0.40
- `rurico` `e330c22` → `adbe3a8`（dependencies + dev-dependencies）

## 検証
- `libsqlite3-sys` 0.38.0 単一に収斂、0.37 消滅（`cargo tree -i libsqlite3-sys`）
- rusqlite 0.40.0 が 自前 / rurico / rurico-ffi の3経路を統一
- MSRV 1.96-compatible（resolver 明示）、rust-version 警告なし
- VTab API（0.40 唯一の破壊的変更）は amici で未使用（`create_module` 0 hit）
- `cargo clippy --all-targets --all-features` clean
- `cargo nextest run --all-features`: 255 passed, 9 skipped（vec0/FTS5 境界テスト green）

Closes #140