### PR TITLE
ADR-0008〜0011 の実装 follow-up (コードマーカー + 検証)

### DIFF
--- a/docs/audit/2026-06-24-015844-adr-gaps.md
+++ b/docs/audit/2026-06-24-015844-adr-gaps.md
@@ -1,0 +1,237 @@
+# ADR Gaps Audit: 2026-06-24-015844
+
+## Summary
+
+| Metric                   | Value                                            |
+| ------------------------ | ------------------------------------------------ |
+| Scope                    | repo (whole amici, production source + top docs) |
+| Source files scanned     | 29 (production `.rs`, tests excluded)            |
+| Documents scanned        | 3 (README.md, justfile, Cargo.toml `[lints.*]`)  |
+| Decision candidates      | 52 (substantive mined decisions)                 |
+| ADR-covered (excluded)   | 7 (cross-ref ADR-0002/0003/0004/0005/0006)       |
+| Net new candidates       | 45                                               |
+| ADR promotion candidates | 12 (4 keep → ADR, 8 downgrade → comment/absorb)  |
+
+Note: amici cross-references **scout ADR-0066** (Group 2 exit-code convention) which lives in the `scout` repo, not in `amici/docs/decisions/`. Local ADRs are 0001–0007. The dominant finding: amici's in-code module-docs already state the forward rule for most decisions, so the census resists promoting them; only decisions whose forward rule is **missing from code** or **un-enforceable by tools AND cross-subsystem** survive challenge as `keep`.
+
+## Source File Decisions
+
+### src/cli/exit_code.rs (115 lines)
+
+| #   | Line | Decision                                                                          | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ---- | --------------------------------------------------------------------------------- | ----------- | -------------------- | ------ | ------------- |
+| 1   | 11   | Project extension range 80–119, assigned per scout ADR-0066 (`UNKNOWN`=104)       | Yes         | No                   | H      | low           |
+| 2   | 17   | Exit codes are convention, not enforcement; only "distinct code per variant"      | Yes         | No                   | H      | medium        |
+| 3   | 32   | `u8` consts not `ExitCode` because `ExitCode::from()` is not `const` (rustc 1.95) | Yes         | No                   | L      | high          |
+| 4   | 84   | Only 6 sysexits codes exposed; 66-69/71/72/76-78 intentionally omitted            | No          | Yes                  | M      | medium        |
+| 5   | 107  | `INTERNAL` is an alias of `SOFTWARE`(70) to match ADR-0066 table naming           | Yes         | No                   | M      | high          |
+
+### src/cli/message.rs (144 lines)
+
+| #   | Line | Decision                                                                        | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ---- | ------------------------------------------------------------------------------- | ----------- | -------------------- | ------ | ------------- |
+| 1   | 1    | All helpers write to stderr with fixed greppable prefixes (uniform across CLIs) | Yes         | No                   | M      | medium        |
+| 2   | 72   | stdout reserved for pipeable program results; all guidance to stderr            | Yes         | No                   | M      | medium        |
+| 3   | 42   | `hint_arrow` formats for display only, NOT shell-escaped round-trip             | Yes         | No                   | L      | high          |
+
+### src/cli/spinner.rs (177 lines)
+
+| #   | Line | Decision                                                                     | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ---- | ---------------------------------------------------------------------------- | ----------- | -------------------- | ------ | ------------- |
+| 1   | 72   | `✓ {msg}` success marker emitted on both TTY and non-TTY for consistent logs | Yes         | No                   | M      | medium        |
+| 2   | 92   | `finish_with_detail` drops spinner before writing `✓` (Drop/done ordering)   | Yes         | No                   | L      | high          |
+| 3   | 9    | Braille frames + 80ms tick fixed as shared constants across downstream CLIs  | No          | Yes                  | L      | high          |
+| 4   | 110  | `✓` ANSI-green unconditional even on non-TTY, while frames are TTY-gated     | No          | Yes                  | L      | high          |
+
+### src/cli/shorthand.rs (69 lines)
+
+| #   | Line | Decision                                                                      | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ---- | ----------------------------------------------------------------------------- | ----------- | -------------------- | ------ | ------------- |
+| 1   | 3    | Bare `<bin> "query"` rewritten to implicit `search`; typo guard (OSA dist >1) | Yes         | No                   | M      | medium        |
+| 2   | 43   | Hand-rolled OSA distance (no Levenshtein dependency), threshold ≤1            | No          | Yes                  | M      | high          |
+
+### src/cli/config.rs (42 lines)
+
+| #   | Line | Decision                                                                         | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ---- | -------------------------------------------------------------------------------- | ----------- | -------------------- | ------ | ------------- |
+| 1   | 1    | env-reading ctors split into `from_env()` + `from_env_with(closure)` for testing | Yes         | No                   | M      | medium        |
+
+### src/cli.rs (11 lines)
+
+| #   | Line | Decision                                                                    | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ---- | --------------------------------------------------------------------------- | ----------- | -------------------- | ------ | ------------- |
+| 1   | 1    | Submodules private except `exit_code`; public surface via curated re-export | No          | Yes                  | M      | medium        |
+
+### src/storage/fts.rs (129 lines)
+
+| #   | Line | Decision                                                                           | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ---- | ---------------------------------------------------------------------------------- | ----------- | -------------------- | ------ | ------------- |
+| 1   | 1    | Adapter coupled to rurico `MatchFtsQuery` output shape (`" OR "` sep + `"..."`)    | Yes         | **Yes**              | H      | medium        |
+| 2   | 15   | Cap OR cross-product at 100 combos (memory bound; rurico eval: mrr/ndcg unchanged) | Yes         | No                   | M      | medium        |
+| 3   | 18   | Distribute OR-groups to flat alternatives (trigram tokenizer rejects nested OR)    | Yes         | No                   | M      | medium        |
+| 4   | 84   | Drop <3-char sub-trigram terms (tokenizer cannot index them)                       | Yes         | No                   | M      | medium        |
+| 5   | 25   | Return `None` ("no results") rather than empty MATCH string                        | Yes         | No                   | M      | medium        |
+
+### src/storage/filter.rs (369 lines)
+
+| #   | Line | Decision                                                                          | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ---- | --------------------------------------------------------------------------------- | ----------- | -------------------- | ------ | ------------- |
+| 1   | 9    | Tri-state empty-input convention (None=no-op / Some(empty)=match-nothing)         | Yes         | No                   | H      | medium        |
+| 2   | 23   | SQL-injection safety by `column: &'static str` (compiler rejects runtime strings) | Yes         | No                   | H      | medium        |
+| 3   | 85   | `escape_like` prepends `\`; must stay paired with `ESCAPE '\'` clause             | Yes         | **Yes**              | H      | medium        |
+| 4   | 96   | `like_prefix_match` ASCII-case-only to mirror SQLite default LIKE                 | Yes         | **Yes**              | M      | medium        |
+| 5   | 157  | `In`/`NotIn` closed enum (not `op: &str`) so SQL keywords bound at compile time   | Yes         | No                   | H      | medium        |
+| 6   | 290  | timestamp filter unit = ms since Unix epoch (recall's native format)              | Yes         | No                   | M      | medium        |
+
+### src/storage/query_helpers.rs (143 lines)
+
+| #   | Line | Decision                                                                             | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ---- | ------------------------------------------------------------------------------------ | ----------- | -------------------- | ------ | ------------- |
+| 1   | 1    | Execution side (Connection + stmt + row collection) split from filter.rs WHERE       | Yes         | No                   | M      | medium        |
+| 2   | 66   | `sql_template` must contain `{placeholders}` token; empty keys short-circuit `IN ()` | Yes         | **Yes**              | M      | medium        |
+| 3   | 118  | No internal chunking; caller owns splitting beyond `SQLITE_MAX_VARIABLE_NUMBER`      | Yes         | No                   | M      | medium        |
+| 4   | 8    | Generic over `E: From<rusqlite::Error>` (integrates thiserror/anyhow/bare)           | Yes         | No                   | M      | high          |
+
+### src/model.rs (294 lines)
+
+| #   | Line | Decision                                                                                    | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ---- | ------------------------------------------------------------------------------------------- | ----------- | -------------------- | ------ | ------------- |
+| 1   | 23   | `DegradedReason` coarse 4-bucket taxonomy; `Disabled` is caller-only                        | Yes         | No                   | H      | medium        |
+| 2   | 48   | `EmbedderDegraded` newtype gates `user_note` to embedder only (no reranker eqv)             | Yes         | No                   | H      | medium        |
+| 3   | 80   | Typed errors collapse to `DegradedReason` ONLY via `degrade_with_warn` (no bare `.map_err`) | Yes         | No                   | H      | medium        |
+| 4   | 162  | `ModelLoad::Failed` String erased; rendered verbatim downstream = user-visible API          | Yes         | No                   | H      | low           |
+| 5   | 219  | `ModelDownloadError::ProbeFailed(Option<String>)`; `None`=corruption-prevented-capture      | Yes         | No                   | M      | medium        |
+| 6   | 282  | `cache=Some` loader cannot emit NotInstalled/Disabled → `unreachable!` invariant            | Yes         | **Yes**              | M      | medium        |
+
+### src/model/embedder.rs (137 lines) / src/model/reranker.rs (89 lines)
+
+| #   | Line   | Decision                                                                                         | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ------ | ------------------------------------------------------------------------------------------------ | ----------- | -------------------- | ------ | ------------- |
+| 1   | emb:23 | On `ModelCorrupt`, loader auto-deletes artifacts; never calls tracing (inject `on_delete_error`) | Yes         | No                   | M      | medium        |
+| 2   | emb:91 | 3-tier split (preset / `_with` / `_with_fns`) for probe/new/delete injection testability         | Yes         | No                   | M      | medium        |
+| 3   | rer:43 | Reranker loader duplicates embedder state machine verbatim (intentional, may evolve apart)       | Partial     | **Yes**              | M      | medium        |
+
+### src/model/download.rs (65 lines)
+
+| #   | Line | Decision                                                                         | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ---- | -------------------------------------------------------------------------------- | ----------- | -------------------- | ------ | ------------- |
+| 1   | 1    | Sole I/O composition root; excluded from diff-coverage gate (like test scaffold) | Yes         | No                   | M      | medium        |
+| 2   | 30   | Downstream binary MUST call `rurico::handle_probe_if_needed()` first in `main()` | Yes         | No                   | H      | medium        |
+| 3   | 23   | "verify" = probe-load, NOT checksum (integrity delegated to rurico)              | Yes         | No                   | M      | medium        |
+
+### src/eval/pipeline.rs (645 lines)
+
+| #   | Line | Decision                                                                                | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ---- | --------------------------------------------------------------------------------------- | ----------- | -------------------- | ------ | ------------- |
+| 1   | 216  | `evaluate_first_search_replay` must NOT DRY-merge with `evaluate` (FR-008/FR-010 guard) | No          | No                   | H      | medium        |
+| 2   | 33   | FTS+vec fetch `k*3` candidates before RRF (copies recall's heuristic)                   | No          | Yes                  | M      | medium        |
+| 3   | 132  | `embedding_bytes` takes `[f32; EMBEDDING_DIMS]` so layout change = compile error        | No          | No                   | M      | medium        |
+| 4   | 333  | Query normalization applied to FTS body only (embedder does NFKC internally)            | No          | No                   | M      | medium        |
+| 5   | 575  | Reranker receives parent doc body, never chunk body ("parent-context posture")          | No          | No                   | M      | medium        |
+
+### src/eval/baseline.rs (391 lines)
+
+| #   | Line | Decision                                                                                  | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ---- | ----------------------------------------------------------------------------------------- | ----------- | -------------------- | ------ | ------------- |
+| 1   | 116  | `AggregationKind` closed wire enum (no `#[non_exhaustive]`); bare `topk-average` rejected | Partial     | No                   | M      | medium        |
+| 2   | 49   | `BASELINE_SCHEMA_VERSION` per-version log (1.1 fusion-key, 1.2 Oracle, 1.3 Replay)        | Partial     | No                   | M      | low           |
+| 3   | 210  | Timestamp stored as `epoch:N` (Unix sec) to avoid pulling in chrono                       | No          | No                   | L      | high          |
+| 4   | 297  | `atomic_write` (tmp sibling + fsync + rename) so SIGTERM/panic can't leave partial        | Yes         | No                   | M      | medium        |
+
+### src/eval/oracle_gap.rs (361 lines) / src/eval/oracle_pipeline.rs (226 lines)
+
+| #   | Line   | Decision                                                                                  | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ------ | ----------------------------------------------------------------------------------------- | ----------- | -------------------- | ------ | ------------- |
+| 1   | og:209 | `compute_gap` rejects snapshots with disagreeing pipeline knobs (config equality)         | No          | No                   | M      | medium        |
+| 2   | og:75  | Category/metric on baseline but absent on oracle = error, not skip (no vacuous PASS)      | No          | No                   | M      | medium        |
+| 3   | op:24  | OracleMerge synthetic scores anchored to `inner_max+(len-i)`, NOT `f64::MAX` (saturation) | No          | No                   | M      | medium        |
+| 4   | op:214 | `relevant_doc_ids` sorted by doc_id for bit-identical baselines (HashMap unstable)        | No          | No                   | M      | medium        |
+
+### src/eval/metrics.rs (160) / fixture.rs (275) / annotation.rs (167) / io.rs (38)
+
+| #   | Line    | Decision                                                                                | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ------- | --------------------------------------------------------------------------------------- | ----------- | -------------------- | ------ | ------------- |
+| 1   | met:154 | Bootstrap CI percentile index via integer truncation; empty/0-resamples = degenerate CI | No          | No                   | M      | medium        |
+| 2   | fix:32  | `relevance_map` grades constrained to {0,1,2,3}; `u8` type does not enforce it          | No          | **Yes**              | M      | medium        |
+| 3   | ann:65  | `Entry.relevance_map` uses BTreeMap (vs EvalQuery HashMap) for byte-stable output       | No          | No                   | L      | medium        |
+| 4   | io:31   | Shared `write_json` funnels serde errors into `io::ErrorKind::Other` (+ trailing \n)    | Yes         | No                   | M      | medium        |
+
+### src/bin/eval_harness.rs (2077 lines)
+
+| #   | Line | Decision                                                                              | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ---- | ------------------------------------------------------------------------------------- | ----------- | -------------------- | ------ | ------------- |
+| 1   | 156  | Harness exit codes 1/2/3 deliberately diverge from `codes::*` (internal tooling)      | Yes         | No                   | M      | medium        |
+| 2   | 171  | 3-way taxonomy: 1=regression, 2=usage, 3=infra (CI distinguishes without stderr)      | Yes         | No                   | M      | medium        |
+| 3   | 575  | MLX_DEPENDENT vs NON_MLX partition with compile-time assert forcing classification    | No          | No                   | M      | medium        |
+| 4   | 531  | Per-metric drift tolerances absorb MLX f32 non-determinism (≥2× observed, 1e-3 floor) | Yes         | **Yes**              | M      | medium        |
+| 5   | 1860 | FNV-1a fixture hash (sha2 avoided to keep dep graph small)                            | Yes         | No                   | L      | high          |
+| 6   | 179  | `RURI_V3_310M_MODEL_ID/_REVISION` amici-local mirrors of rurico crate-private values  | Yes         | **Yes**              | M      | medium        |
+| 7   | 1911 | `CATEGORY_ALLOWLIST` manual mirror of 8 fixture categories (no automated coupling)    | Yes         | **Yes**              | M      | medium        |
+
+### src/lib.rs (9) / logging.rs (68) / migration.rs (60) / testing.rs (7) / testing/hybrid.rs (100)
+
+| #   | Line   | Decision                                                                                             | Documented? | Incomplete-contract? | Impact | Reversibility |
+| --- | ------ | ---------------------------------------------------------------------------------------------------- | ----------- | -------------------- | ------ | ------------- |
+| 1   | lib:2  | `eval` gated `eval-harness`, `testing` gated `test-support`; no module-doc states the no-leak policy | No          | **Yes**              | H      | medium        |
+| 2   | log:26 | sae's implicit `sae=info` layering intentionally dropped (breaking unification)                      | No          | No                   | M      | low           |
+| 3   | log:33 | `RUST_LOG` overrides merged default ENTIRELY; upstream set rurico/amici hard-coded                   | No          | **Yes**              | M      | low           |
+| 4   | mig:8  | `notify_schema_change` single fixed signature; extras via span; `item` avoids `target` key           | Yes         | No                   | L      | high          |
+| 5   | hyb:1  | `assert_filter_symmetric` black-box outcome-property test API, strategy-independent                  | Yes         | No                   | H      | medium        |
+
+Files with no net-new ADR-gap decisions (covered by existing ADRs or purely mechanical): src/eval.rs, src/storage.rs, src/model/\* preset wrappers (ADR-0005), src/eval/metrics.rs nDCG/hit@k formulas (ADR-0002/0003), src/eval/fixture.rs ≥20-per-category floor (ADR-0002), src/eval/annotation.rs schema-version bump policy (ADR-0004).
+
+## Prose Document Decisions
+
+### README.md
+
+| #   | Line | Decision Verb | Decision                                                                         | ADR Coverage | Impact | Reversibility |
+| --- | ---- | ------------- | -------------------------------------------------------------------------------- | ------------ | ------ | ------------- |
+| 1   | 37   | must / split  | env-reading ctors split into `from_env()`+`from_env_with()` (DI for testability) | None         | M      | medium        |
+| 2   | 276  | exits         | `eval-oracle-gap` exits `1` when oracle recall@k < baseline recall@k             | ADR-0002     | M      | low           |
+
+### justfile
+
+No decision-bearing prose found (recipe wrappers only).
+
+### Cargo.toml `[lints.*]`
+
+| #   | Line | Decision Verb | Decision                                                                              | ADR Coverage | Impact | Reversibility |
+| --- | ---- | ------------- | ------------------------------------------------------------------------------------- | ------------ | ------ | ------------- |
+| 1   | 38   | forbid        | `unsafe_code = "forbid"` (statement-of-fact config; self-documenting)                 | None         | M      | high          |
+| 2   | 40   | deny          | clippy `absolute_paths`/`wildcard_imports`/`str_to_string`/etc. denied (style policy) | None         | L      | high          |
+
+Per the ADR-worth heuristic, `Cargo.toml [lints]` is its own source of truth; no ADR warranted (a 1-line policy comment in the block suffices if rationale is wanted).
+
+## ADR Promotion Candidates (post-challenge)
+
+| #   | Candidate                                                                          | Initial | Challenge | Final                               |
+| --- | ---------------------------------------------------------------------------------- | ------- | --------- | ----------------------------------- |
+| 1   | src/storage/fts.rs:1 — FTS5 trigram wire-format contract (amici↔rurico)            | promote | keep      | **ADR**                             |
+| 2   | src/model.rs:80 — Degraded-mode contract (taxonomy + user_note + mandated routing) | promote | keep      | **ADR**                             |
+| 3   | src/lib.rs:2 — feature-gating governs downstream production-build leakage          | promote | keep      | **ADR**                             |
+| 4   | src/cli/shorthand.rs:43 + eval_harness.rs:1860 — dependency-minimization policy    | promote | keep      | **ADR**                             |
+| 5   | src/storage/filter.rs:85 — SQL-escape `escape_like`↔`ESCAPE '\'` pairing           | promote | downgrade | strengthen comment (filter.rs:85)   |
+| 6   | src/storage/filter.rs:9 — tri-state empty-input + injection discipline             | promote | downgrade | comment suffices / absorb ADR-0001  |
+| 7   | src/model.rs:162 — `ModelLoad::Failed` String is user-visible cross-repo API       | promote | downgrade | absorb ADR-0001                     |
+| 8   | src/model/download.rs:30 — downstream `handle_probe_if_needed()`-first obligation  | promote | downgrade | absorb ADR-0005                     |
+| 9   | src/testing/hybrid.rs:1 — shared cross-repo black-box test contract                | promote | downgrade | hybrid.rs:1 doc suffices            |
+| 10  | src/eval/pipeline.rs:216 — `evaluate` vs replay no-DRY-merge structural guard      | promote | downgrade | absorb ADR-0003                     |
+| 11  | src/logging.rs:26 — unification breaking change + RUST_LOG override semantics      | promote | downgrade | strengthen comment (logging.rs:12)  |
+| 12  | src/bin/eval_harness.rs:156 — harness 1/2/3 exit-code divergence from codes::\*    | promote | downgrade | absorb ADR-0002                     |
+| 13  | src/bin/eval_harness.rs:575 — MLX/seatbelt subcommand partition                    | promote | drop      | skip (compile-time assert enforces) |
+
+Per-file summary: **keep 4 / downgrade 8 / drop 1**.
+
+### Bug-fix follow-ups (NOT ADRs — documenting would lock in the defect)
+
+| #   | Location                     | Issue                                                                                                                                                                                                                                                                                                                                                                                   |
+| --- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| B1  | src/bin/eval_harness.rs:179  | `RURI_V3_310M_REVISION` is literal `"pinned-via-rurico-embed-cache"`, not an HF commit hash. Both baseline and oracle derive it from the same const, so `oracle_gap` revision-compare is structurally blind to real upstream drift. Field doc promises "commit hash"; carries a non-hash. Fix: surface the real revision from rurico, or rename the field to admit it is a cache-label. |
+| B2  | src/bin/eval_harness.rs:1911 | `CATEGORY_ALLOWLIST` manually mirrors 8 fixture categories with no automated coupling to `queries.jsonl`; drift surfaces only when an annotation is rejected. Fix: add a test asserting `CATEGORY_ALLOWLIST == distinct categories parsed from the fixture`.                                                                                                                            |
+
+## ADR promotion candidates — rationale (the 4 `keep`)
+
+1. **FTS5 trigram wire-format contract (fts.rs)** — `parse_fts_segments` hard-splits on rurico `MatchFtsQuery`'s exact `" OR "` separator and `"..."` quoting; the coupling is a cross-repo invariant neither compiler enforces, and amici's tests pin only its own output shape, never referencing rurico as producer-of-truth. A silent rurico format change breaks parsing with no failing test. Reader: a rurico maintainer.
+2. **Degraded-mode contract (model.rs)** — the "never collapse a typed error via bare `.map_err`" routing rule is explicitly un-enforceable by the type system (the doc itself says "PR review will not flag the regression"), spans embedder+reranker, and carries the `EmbedderDegraded::user_note` downstream-facing API. Textbook invariant-not-enforceable-by-tools.
+3. **lib.rs feature-gating (lib.rs)** — the `cfg` gates encode OUTCOME's "library-only except eval harness" constraint, but lib.rs has zero module-doc; a contributor adding a `pub mod` has no in-file rule that new modules must not leak into downstream production builds. Forward rule is missing from code.
+4. **Dependency-minimization policy (shorthand.rs / eval_harness.rs / baseline.rs)** — "prefer hand-roll over a new dependency" recurs at 4+ sites (OSA distance, FNV-1a, epoch:N timestamps, avoid chrono/sha2), each with a local "X avoided" comment but no shared policy. Meets the ≥2-call-site / domain-obvious gate; a single forward rule prevents per-site re-litigation.

--- a/docs/decisions/0008-pin-the-fts5-trigram-wire-format-contract-with-rurico.md
+++ b/docs/decisions/0008-pin-the-fts5-trigram-wire-format-contract-with-rurico.md
@@ -1,0 +1,91 @@
+# Pin the FTS5 trigram wire-format contract with rurico
+
+- Status: accepted
+- Deciders: thkt
+- Date: 2026-06-24
+- Scope: [rust, storage, cross-repo]
+- Confidence: high — census (2026-06-24) で reviewer が incomplete-contract pattern として同定、critic-design が keep 判定。amici 側のみで強制できない cross-repo invariant であることをコード読解 + test 確認で裏付け。
+
+## Context and Problem Statement
+
+`src/storage/fts.rs` の `parse_fts_segments` は `rurico::storage::MatchFtsQuery` が emit する MATCH 文字列を、`" OR "` 区切りと `"..."` quoting という具体的な wire-format 前提でパースする。module-doc は「`MatchFtsQuery` output のアダプタ」と述べるが、producer (rurico) と consumer (amici) のどちらにも「この serialization 形式は両者で同期し続けねばならない」という forward-looking rule が無い。
+
+rurico 側が separator や quoting を変えても、rurico のコンパイラもテストも壊れない。amici 側の `fts/tests.rs` は amici 自身の出力形を pin するだけで、rurico を producer-of-truth として参照しない。結果として rurico の format 変更は amici のパースを silent に壊し、どちらの repo にも failing test が出ない。型でも lint でも守れない cross-repo invariant である。
+
+## Decision Drivers
+
+- silent breakage 阻止: rurico 側 format 変更が amici で no-failing-test のまま壊れる
+- mechanical 不可能性: 両 repo のコンパイラ・lint・単体テストいずれも producer/consumer 同期を保証できない
+- rev pin 運用: 配布は `git rev` pin のみ (OUTCOME Constraints) のため、format drift は rev bump 時にしか顕在化せず、検出点が一意でない
+- census 由来: 2026-06-24 census で reviewer が incomplete-contract として keep #1 同定
+
+## Considered Options
+
+- 本 ADR で wire-format 契約を明文化し、両側にコメントマーカーを置く
+- rurico に format を返す getter / typed API を生やし、amici が文字列パースをやめる
+- amici 側にラウンドトリップ test (rurico producer → amici parser) を追加するのみ
+- ADR 起票せず、fts.rs にコメント追記のみ
+
+## Decision Outcome
+
+Chosen option: 「本 ADR で wire-format 契約を明文化する」。
+
+1. **契約宣言**: `MatchFtsQuery` の MATCH 出力形式 (`" OR "` 区切り、fixed term は `"..."` quoting、OR-group は `( ... )`) を amici↔rurico 間の wire-format 契約と宣言する。rurico 側の serialization 変更は本契約の変更であり、amici の `parse_fts_segments` 追従を伴う coordinated change を必須とする。
+2. **コードマーカー** (実装 follow-up): `src/storage/fts.rs` の module-doc と `parse_fts_segments` に本 ADR を参照するコメントを追加し、rurico 側の該当 serialization 箇所にも相互参照を残す。
+3. **ラウンドトリップ test** (実装 follow-up): rurico の `MatchFtsQuery` を producer として通し、amici の `parse_fts_segments` が期待 segment を復元することを確認する統合テストを追加する。これにより rurico rev bump 時に format drift が test failure として顕在化する。
+
+### Consequences
+
+- Good: rurico の format 変更が amici の rev bump 時にレビュー gate / test failure として顕在化する
+- Good: producer/consumer の同期義務が文書化され、将来の contributor が片側だけ変えるのを防ぐ
+- Bad: amici と rurico の二 repo を跨ぐ契約のため、片側 repo のレビューだけでは閉じない
+- Bad: ラウンドトリップ test が land するまでは、契約はレビュー認知に依存する
+
+### Confirmation
+
+- `git grep "MatchFtsQuery" src/storage/fts.rs` で結合点が `fts.rs` に局在することを継続確認
+- 上記 3 のラウンドトリップ test が land 後は、rurico rev bump PR の CI が format drift を自動検出
+- rurico rev bump 時のレビューチェックリストに「`MatchFtsQuery` serialization 変更の有無確認」を組み込む
+
+## Pros and Cons of the Options
+
+### 本 ADR で wire-format 契約を明文化 (chosen)
+
+- Good: 両 repo に相互参照マーカーを置け、同期義務が一意の文書に集約される
+- Good: ラウンドトリップ test と組み合わせれば mechanical gate へ昇格できる
+- Bad: 契約自体は cross-repo で、片側コンパイラでは強制不能
+
+### rurico に typed API を生やし文字列パースをやめる
+
+- Good: wire-format 結合そのものを消せる (最も根本的)
+- Bad: rurico の公開 API 変更で、amici 以外の consumer 影響も評価が必要
+- Bad: amici は rurico の下流であり、上流 API 設計を amici 都合で駆動するのは責務逆転
+
+### ラウンドトリップ test 追加のみ
+
+- Good: 軽量で drift を test で捉えられる
+- Bad: なぜその形式なのかという契約の所在が文書化されず、test が消えると invariant も消える
+
+### コメント追記のみ
+
+- Good: 最軽量
+- Bad: 片側コメントは cross-repo 同期義務を相手 repo の contributor に強制できない
+
+## More Information
+
+### Trade-offs
+
+amici は rurico primitives の上に積む薄い composition 層 (ADR-0005) であり、rurico-internal な出力形式に依存する seam がいくつか存在する。本 ADR は fts wire-format をその代表として明文化するが、他 seam (probe sequencing 等) は別途各 ADR / コメントが扱う。代償として「fts.rs を読むだけでは契約が閉じず、rurico 側 serialization も併読が必要」な読みコストを許容する。
+
+### Reassessment Triggers
+
+- rurico が `MatchFtsQuery` に typed accessor を導入し、文字列パースが不要になった場合
+- FTS5 trigram tokenizer 以外の tokenizer を採用し、`parse_fts_segments` の前提が変わった場合
+- amici が rurico への依存をやめ、自前で MATCH 文字列を構築するようになった場合
+
+## References
+
+- ADR-0005: Place Model Wiring in rurico, Keep amici as Thin Composition Base (amici↔rurico 境界の先例)
+- census report `docs/audit/2026-06-24-015844-adr-gaps.md` § ADR Promotion Candidates C1
+- `src/storage/fts.rs` (`parse_fts_segments`, `MatchFtsQuery` アダプタ)
+- `rurico::storage::MatchFtsQuery` (producer 側 serialization)

--- a/docs/decisions/0009-route-model-degraded-transitions-through-a-typed-contract.md
+++ b/docs/decisions/0009-route-model-degraded-transitions-through-a-typed-contract.md
@@ -1,0 +1,96 @@
+# Route model-degraded transitions through a typed contract
+
+- Status: accepted
+- Deciders: thkt
+- Date: 2026-06-24
+- Scope: [rust, model, observability, cross-repo]
+- Confidence: high — census (2026-06-24) で reviewer が同定、critic-design が keep 判定。型システムで強制不可かつ embedder/reranker と下流 CLI を跨ぐ invariant であることをコード読解で裏付け。
+
+## Context and Problem Statement
+
+`src/model.rs` は model load の degraded path を 3 つの仕組みで統治する。`DegradedReason` (cache lookup / corruption / init / backend probe を 4 バケットに畳む coarse taxonomy)、`EmbedderDegraded::user_note` (embedder 専用の下流向け復旧メッセージ API)、そして typed error を `DegradedReason` に畳む際に必ず通すべき `degrade_with_warn` / `record_degraded` ヘルパである。
+
+中核は「typed error を bare `.map_err(|_| DegradedReason::X)` で潰してはならない」というルールだ。bare 潰しは元の cause を warn event から落とし、log consumer が `EmbedError::Backend` と cache-lookup permission error を区別できなくする。doc-comment 自身が「関数の戻り型が変わらないため PR review はこの regression を flag しない」と明記する通り、型でも lint でもレビューでも守れない。`user_note` が返す文字列は下流 (sae / yomu / recall) がユーザに見せる API surface でもあり、観測性と下流 UX の両面で load-bearing な invariant が、コメント以外に拠り所を持たない。
+
+## Decision Drivers
+
+- mechanical 不可能性: bare `.map_err` 潰しは戻り型不変のため型・lint・レビューで検出できない (doc-comment が明言)
+- 観測性の load-bearing 性: cause erasure は degraded path の根本原因を log から消し、UNKNOWN 排出率 (OUTCOME Indicator) の分析を不能にする
+- cross-subsystem: embedder と reranker の両 loader、および下流 CLI の notification 表示に跨る
+- census 由来: 2026-06-24 census で keep #2 同定
+
+## Considered Options
+
+- 本 ADR で degraded routing 契約を宣言し、`degrade_with_warn` / `record_degraded` を唯一の正規経路とする
+- `DegradedReason` のコンストラクタを private 化し、ヘルパ経由しか作れない型で強制する
+- clippy lint で `map_err(|_| DegradedReason` パターンを禁止する
+- ADR 起票せず、model.rs のコメントのみで運用する
+
+## Decision Outcome
+
+Chosen option: 「本 ADR で degraded routing 契約を宣言する」。
+
+1. **正規経路の宣言**: typed error から `DegradedReason` への変換は `degrade_with_warn` (元 error あり) または `record_degraded` (元 error なし) のみを正規経路とする。bare `.map_err(|_| DegradedReason::X)` は anti-pattern として禁止する。
+2. **taxonomy と note の契約**: `DegradedReason` の 4 バケット粒度と `EmbedderDegraded::user_note` の `Option<String>` 戻り (下流が verbatim 表示する API) を契約として pin する。reranker-degraded equivalent は consumer が必要とするまで追加しない (現状の意図的非対称を維持)。
+3. **下流の追従**: 下流 CLI (sae / yomu / recall) の degraded path も本契約に揃え、独自の cause-erasing 変換を持たない。
+
+### Consequences
+
+- Good: degraded path の cause が常に structured warn event に残り、log consumer が根本原因を追える
+- Good: `user_note` の API contract が pin され、下流の verbatim 表示が安定する
+- Bad: 型では強制できないため、最終防衛線はレビュー認知 + 下記 lint follow-up に依存する
+- Bad: reranker-degraded の非対称が将来 consumer 登場時に再評価コストを生む
+
+### Confirmation
+
+- `git grep "map_err(|_| DegradedReason"` および `git grep "map_err(|_| .*Degraded"` が 0 件であることを継続確認
+- clippy custom lint (実装 follow-up) で bare 潰しパターンを `deny` に昇格できれば mechanical gate へ移行
+- 下流 repo で `EmbedderDegraded::user_note` 以外の degraded notification 自前実装が grep 0 件 (OEM Indicator と接続)
+
+## Pros and Cons of the Options
+
+### 本 ADR で routing 契約を宣言 (chosen)
+
+- Good: cross-subsystem + cross-repo に跨る invariant を一意の文書に集約できる
+- Good: lint follow-up へ昇格する受け皿になる
+- Bad: 宣言時点では型強制が無く、レビュー認知依存
+
+### コンストラクタ private 化で型強制
+
+- Good: bare 潰しをコンパイルエラーにできる
+- Bad: `degrade_with_warn` は closure を返す設計で、private 化すると call site の人間工学が悪化
+- Bad: `Disabled` のような caller-only variant の生成経路と衝突する
+
+### clippy lint で禁止
+
+- Good: mechanical gate になりうる
+- Bad: `map_err(|_| EnumVariant)` 一般を狙うと false positive が多く、custom lint 実装コストが高い
+- Bad: lint だけでは「なぜ」が文書化されず、契約の所在が消える
+
+### コメントのみ
+
+- Good: 最軽量 (現状)
+- Bad: doc-comment 自身が「レビューで flag されない」と認める通り、コメント単独では gate にならない
+
+## More Information
+
+### Quality Attributes
+
+本契約は観測性 (observability) を quality attribute として優先する。degraded への fallback は許容するが、その cause を消すことは許容しない。`degrade_with_warn` の structured `error` / `reason` / `context` フィールドが、UNKNOWN 排出率を下げる (OUTCOME Indicator) ための一次データ源となる。
+
+### Trade-offs
+
+`EmbedderDegraded` newtype は embedder 専用 note を reranker に誤用させない greppable barrier として機能する。reranker 側に同等 note を持たせない非対称は、YAGNI に従い consumer 不在では追加しない判断であり、本 ADR はその非対称を意図的設計として記録する。
+
+### Reassessment Triggers
+
+- reranker-degraded notification を必要とする下流 consumer が登場した場合 (非対称の解消を再評価)
+- bare 潰し禁止を強制する clippy custom lint が land した場合 (本 ADR の役割をレビュー gate から code gate へ縮退再評価)
+- `DegradedReason` の 4 バケットでは区別が粗すぎる degraded 要因が出た場合 (taxonomy 拡張)
+
+## References
+
+- ADR-0005: Place Model Wiring in rurico, Keep amici as Thin Composition Base
+- census report `docs/audit/2026-06-24-015844-adr-gaps.md` § ADR Promotion Candidates C4
+- `src/model.rs` (`DegradedReason`, `EmbedderDegraded::user_note`, `degrade_with_warn`, `record_degraded`)
+- `src/model/embedder.rs` / `src/model/reranker.rs` (loader の degraded path)

--- a/docs/decisions/0010-gate-non-production-modules-behind-cargo-features.md
+++ b/docs/decisions/0010-gate-non-production-modules-behind-cargo-features.md
@@ -1,0 +1,86 @@
+# Gate non-production modules behind cargo features
+
+- Status: accepted
+- Deciders: thkt
+- Date: 2026-06-24
+- Scope: [rust, crate-boundary, build]
+- Confidence: high — census (2026-06-24) で reviewer が incomplete-contract として同定、critic-design が keep 判定。OUTCOME の library-only-except-eval 制約を cfg が encode するが forward rule がコードに無いことを lib.rs 読解で裏付け。
+
+## Context and Problem Statement
+
+`src/lib.rs` は amici の公開モジュール構成を決める crate root だが、module-doc が一切無い。`eval` は `#[cfg(feature = "eval-harness")]`、`testing` は `#[cfg(any(test, feature = "test-support"))]` で gate され、`cli` / `logging` / `migration` / `model` / `storage` は無条件公開という構造は、OUTCOME の「amici は `eval_harness` バイナリを除きライブラリクレートに留まる」「testing items は downstream production binary に入らない」制約を encode している。
+
+しかし lib.rs にはこの gating の理由も、新モジュール追加時のルールも書かれていない。cfg 属性は既存モジュールの statement-of-fact に留まり、「downstream production build に漏れてはならない非production モジュールは feature gate を必須とする」という forward-looking rule が無い。将来 contributor が `pub mod` を足す際、それを production に晒すか gate するかの判断基準がコードに存在しない。`testing.rs` は自モジュールの境界を述べるが、crate 全体の no-leak ポリシーは誰も持たない。
+
+## Decision Drivers
+
+- downstream 漏洩の防止: eval / testing 系コードが下流 production binary の依存・コンパイル対象に入ると、MLX (Apple Silicon 必須) や test-support 依存が下流ビルドを汚染する
+- forward rule の不在: 既存 cfg は statement-of-fact で、新モジュール追加時の判断基準を誰も持たない
+- OUTCOME 制約の encode: library-only-except-eval は OUTCOME Constraints に明記されるが、コード側に対応する gate ルールが無い
+- census 由来: 2026-06-24 census で keep #3 同定 (lib.rs の module-doc ゼロ = incomplete-contract)
+
+## Considered Options
+
+- 本 ADR で feature-gating ポリシーを宣言し、lib.rs に module-doc を追加する
+- 非production モジュールを別 crate (amici-eval / amici-testing) に物理分離する
+- ADR 起票せず、lib.rs にコメントのみ追加する
+
+## Decision Outcome
+
+Chosen option: 「本 ADR で feature-gating ポリシーを宣言する」。
+
+1. **gating ポリシー宣言**: downstream production build に入ってはならないモジュールは cargo feature で gate する。現状の割当を契約として pin する: `eval` → `eval-harness` (MLX 依存、Apple Silicon 専用)、`testing` → `test(any(test, feature = "test-support"))`。`cli` / `logging` / `migration` / `model` / `storage` は無条件公開の production API。
+2. **新モジュールの判断基準**: `pub mod` 追加時、それが (a) 下流 production が常時必要とするか、(b) eval / test / Apple-Silicon 専用かを判定し、後者は対応 feature で gate する。default feature には非production モジュールを入れない。
+3. **module-doc マーカー** (実装 follow-up): `src/lib.rs` に本 ADR を参照する module-doc を追加し、各 gate の理由 (MLX 依存 / test 専用) を 1 行ずつ記す。
+
+### Consequences
+
+- Good: 新モジュール追加時に gating 判断の基準が文書化され、漏洩を未然に防ぐ
+- Good: 下流 production build が MLX / test-support 依存を引かない状態を契約として保てる
+- Bad: 物理 crate 分離ほど強い境界ではなく、feature 設定ミスはコンパイルが通ってしまう
+- Bad: feature flag の組合せ (`--all-features` 等) でのビルド検証を CI で別途担保する必要がある
+
+### Confirmation
+
+- `cargo build` (default features) で `eval` / `testing` がコンパイル対象に入らないことを確認
+- 下流 repo が amici を引く際、`default-features = false` または production feature のみ指定で MLX 依存を引かないことを確認
+- CI が default / `--all-features` の両方でビルドを回し、feature gate の整合を担保 (Linux/Windows では eval-harness 非対象 = OUTCOME Constraints)
+
+## Pros and Cons of the Options
+
+### 本 ADR でポリシー宣言 + lib.rs module-doc (chosen)
+
+- Good: 既存構造を変えずに forward rule を追加でき、低コスト
+- Good: 新モジュール追加の判断基準を一意の文書に集約
+- Bad: feature 設定ミスはコンパイル成功してしまう (mechanical gate ではない)
+
+### 別 crate に物理分離
+
+- Good: 漏洩を crate 境界で機械的に不可能にする最強の境界
+- Bad: amici-eval / amici-testing への分割は workspace 再編コストが大きく、現状 1 crate の単純さを失う
+- Bad: testing helper の循環依存 (amici 本体を test するのに amici-testing が要る) を招きうる
+
+### コメントのみ
+
+- Good: 最軽量
+- Bad: lib.rs 単独のコメントは「新モジュールは gate せよ」という crate 全体ポリシーを encode する場として弱く、OUTCOME 制約との接続が消える
+
+## More Information
+
+### Trade-offs
+
+feature gate は物理 crate 分離より弱い境界だが、現状 amici は単一 crate の単純さ (Occam's Razor) を outcome 上の価値として持つ。本 ADR は crate を割らずに no-leak ポリシーを文書化する中間解を採り、漏洩リスクが顕在化した時点で物理分離を Reassessment Trigger に回す。
+
+### Reassessment Triggers
+
+- eval / testing の依存が肥大化し、feature gate ミスが実際に下流 build を壊した場合 (物理 crate 分離を再評価)
+- `cli` / `model` / `storage` のいずれかが Apple-Silicon 専用依存を持ち込み、無条件公開の前提が崩れた場合
+- 下流が amici の一部モジュールのみを欲し、より細かい feature 分割が必要になった場合
+
+## References
+
+- ADR-0001: Extract Shared Model-Loading and CLI Utilities into amici Crate (crate 境界の先例)
+- census report `docs/audit/2026-06-24-015844-adr-gaps.md` § ADR Promotion Candidates C7
+- `src/lib.rs` (モジュール構成 + cfg gate)
+- `src/testing.rs` (test-support 境界)
+- `.claude/OUTCOME.md` § Constraints (library-only-except-eval, MLX = Apple Silicon 専用)

--- a/docs/decisions/0011-prefer-hand-rolled-small-algorithms-over-new-dependencies.md
+++ b/docs/decisions/0011-prefer-hand-rolled-small-algorithms-over-new-dependencies.md
@@ -1,0 +1,90 @@
+# Prefer hand-rolled small algorithms over new dependencies
+
+- Status: accepted
+- Deciders: thkt
+- Date: 2026-06-24
+- Scope: [rust, dependencies, policy]
+- Confidence: medium-high — census (2026-06-24) で 4+ サイトに分散する暗黙ポリシーとして同定、critic-design が keep 判定 (coordinated call sites >= 2 / domain-obvious gate を満たす)。各サイトのコメントは「X を避けた」と述べるが共有ポリシーが不在。
+
+## Context and Problem Statement
+
+amici には「小さなアルゴリズムは依存追加せず自前実装する」という判断が複数箇所に独立して現れる。`src/cli/shorthand.rs` の `osa_distance` (typo 検出の OSA 距離、`strsim` 等を引かず手書き)、`src/bin/eval_harness.rs` の `fnv1a64` fixture hash (`sha2` を意図的に回避)、`src/bin/eval_harness.rs` と `src/eval/baseline.rs` の `epoch:N` timestamp ラベル (`chrono` を回避)。
+
+各サイトには「X を意図的に避けた」という局所コメントがあるが、これらを束ねる共有ポリシーが無い。結果として、将来 contributor が利便性のために `sha2` / `chrono` / Levenshtein crate を追加しようとした時、それが既存の判断と矛盾することに気付く拠り所が無い。4 箇所以上で coordinated に現れる domain-obvious な判断であり、毎回サイト単位で再議論されるのを防ぐ単一の forward rule が欠けている。
+
+## Decision Drivers
+
+- 依存ツリーの最小化: 小アルゴリズムのための重い依存 (`chrono` / `sha2`) はビルド時間・supply chain 面・rev pin 運用の負担を増やす
+- 4+ サイトの分散: 同じ判断が独立コメントで散在し、共有ポリシーが無い (coordinated call sites >= 2 gate を満たす)
+- re-litigation 防止: 共有 rule が無いと、依存追加の是非がサイトごとに毎回問い直される
+- census 由来: 2026-06-24 census で keep #4 同定 (recurring policy without a single owner)
+
+## Considered Options
+
+- 本 ADR で「小アルゴリズムは hand-roll 優先」ポリシーを宣言し、判断基準を明示する
+- ADR 起票せず、各サイトのコメントのみで運用を続ける
+- `deny.toml` / `Cargo.toml` の lint で特定 crate を banned-dependencies に登録する
+
+## Decision Outcome
+
+Chosen option: 「本 ADR で hand-roll 優先ポリシーを宣言する」。
+
+1. **ポリシー宣言**: 数十行で自前実装でき、正しさが自明な小アルゴリズム (string distance, 非暗号 hash, epoch timestamp 整形等) は、新規依存を追加せず hand-roll を優先する。
+2. **判断基準**: 依存追加が正当化されるのは次のいずれか。(a) 自前実装の正しさ検証コストが高い (暗号 hash、Unicode 正規化、TZ 計算等)、(b) 実装が数十行を大きく超える、(c) 既に同等依存が依存ツリーに存在する。これらに該当しない限り hand-roll。
+3. **既存サイトの記録**: 現存する hand-roll 判断 (`osa_distance` / `fnv1a64` / `epoch:N`) を本ポリシーの instance として記録し、各サイトのコメントから本 ADR を参照する (実装 follow-up)。
+
+### Consequences
+
+- Good: 依存追加の是非がサイト単位の毎回議論でなく、単一ポリシーで判断できる
+- Good: 依存ツリーが小さく保たれ、rev pin 運用と supply chain 面の負担が抑えられる
+- Bad: hand-roll はバグ混入リスクを自前で負う (テストで担保する必要がある)
+- Bad: 「数十行を大きく超える」「正しさ検証コストが高い」の境界は判断依存で、グレーゾーンが残る
+
+### Confirmation
+
+- 新規依存を追加する PR が本 ADR の判断基準 (a)/(b)/(c) のいずれに該当するかをレビューで確認
+- `osa_distance` / `fnv1a64` / `epoch_label` の各サイトに本ポリシーをカバーするユニットテストが存在することを確認 (hand-roll の正しさ担保)
+- `cargo tree` で依存数が census 時点 (2026-06-24) から不必要に増えていないことを継続観測
+
+## Pros and Cons of the Options
+
+### 本 ADR でポリシー宣言 (chosen)
+
+- Good: 分散する暗黙判断を single owner に集約し、re-litigation を防ぐ
+- Good: 判断基準 (a)/(b)/(c) でグレーゾーンを最小化
+- Bad: lint のような mechanical gate ではなく、レビュー認知に依存
+
+### 各サイトのコメントのみ
+
+- Good: 現状維持で最軽量
+- Bad: 共有ポリシーが無く、依存追加の是非がサイトごとに毎回問い直される (census が同定した問題そのもの)
+
+### banned-dependencies lint
+
+- Good: 特定 crate (`chrono` / `sha2`) の追加を機械的に拒否できる
+- Bad: ポリシーは「特定 crate 禁止」でなく「小アルゴリズムは hand-roll 優先」であり、crate 名の denylist では意図を表現できない
+- Bad: 正当な理由 (暗号 hash が真に必要等) で `sha2` を入れたい時に denylist が過剰阻止する
+
+## More Information
+
+### Before / After comparison
+
+- Before: `osa_distance` / `fnv1a64` / `epoch:N` が各々「X を避けた」コメントを持つが、判断の根拠が分散
+- After: 本 ADR が「小アルゴリズムは hand-roll 優先、依存追加は (a)/(b)/(c) のみ」という共有 rule を持ち、各サイトが参照
+
+### Trade-offs
+
+YAGNI と Occam's Razor に従い、利便性のための投機的依存を排除する。代償として hand-roll の正しさを自前テストで担保する義務を負う。暗号強度・Unicode 正確性・TZ 計算など「自前実装の正しさ検証が高コスト」な領域は明示的に本ポリシーの対象外とし、過剰な hand-roll への逆振れを防ぐ。
+
+### Reassessment Triggers
+
+- 同等の小アルゴリズムが標準ライブラリに入り、hand-roll が冗長になった場合
+- hand-roll した実装にバグが見つかり、検証コストが依存追加コストを上回ると判明した場合
+- 暗号 hash や正確な日時計算が真に必要になり、判断基準 (a) に該当する依存追加が正当化される場合
+
+## References
+
+- census report `docs/audit/2026-06-24-015844-adr-gaps.md` § ADR Promotion Candidates C11
+- `src/cli/shorthand.rs` (`osa_distance` — OSA 距離 hand-roll)
+- `src/bin/eval_harness.rs` (`fnv1a64` fixture hash, `epoch:N` timestamp label)
+- `src/eval/baseline.rs` (`epoch:N` capture-time label)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -4,15 +4,19 @@ This directory contains important decisions about the project's architecture.
 
 ## ADR List
 
-| Number | Title | Status | Date |
-|--------|-------|--------|------|
-| [0001](0001-extract-shared-model-loading-and-cli-utilities-into-amici-crate.md) | Extract Shared Model-Loading and CLI Utilities into amici Crate | accepted | 2026-04-13 |
-| [0002](0002-evaluation-methodology.md) | Search Quality Evaluation Methodology | accepted | 2026-04-27 |
-| [0003](0003-add-pgr-style-first-search-offline-retrieval-benchmark.md) | Add pgr-style First-Search Offline Retrieval Benchmark | accepted | 2026-05-08 |
-| [0004](0004-annotation-framework.md) | Annotation Framework Foundation | proposed | 2026-05-08 |
-| [0005](0005-model-wiring-belongs-to-rurico.md) | Place Model Wiring (lazy load, cache, probe) in rurico, Keep amici as Thin Composition Base | accepted | 2026-05-11 |
-| [0006](0006-pin-pipelinek10-as-part-of-baseline-schema-contract.md) | Pin PIPELINE_K=10 as part of baseline schema contract | proposed | 2026-05-14 |
-| [0007](0007-pin-baselinesnapshot-serde-defaults-to-pre-existing-behavior.md) | Pin BaselineSnapshot serde defaults to pre-existing behavior | proposed | 2026-05-14 |
+| Number                                                                          | Title                                                                                       | Status   | Date       |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | -------- | ---------- |
+| [0001](0001-extract-shared-model-loading-and-cli-utilities-into-amici-crate.md) | Extract Shared Model-Loading and CLI Utilities into amici Crate                             | accepted | 2026-04-13 |
+| [0002](0002-evaluation-methodology.md)                                          | Search Quality Evaluation Methodology                                                       | accepted | 2026-04-27 |
+| [0003](0003-add-pgr-style-first-search-offline-retrieval-benchmark.md)          | Add pgr-style First-Search Offline Retrieval Benchmark                                      | accepted | 2026-05-08 |
+| [0004](0004-annotation-framework.md)                                            | Annotation Framework Foundation                                                             | proposed | 2026-05-08 |
+| [0005](0005-model-wiring-belongs-to-rurico.md)                                  | Place Model Wiring (lazy load, cache, probe) in rurico, Keep amici as Thin Composition Base | accepted | 2026-05-11 |
+| [0006](0006-pin-pipelinek10-as-part-of-baseline-schema-contract.md)             | Pin PIPELINE_K=10 as part of baseline schema contract                                       | accepted | 2026-05-14 |
+| [0007](0007-pin-baselinesnapshot-serde-defaults-to-pre-existing-behavior.md)    | Pin BaselineSnapshot serde defaults to pre-existing behavior                                | accepted | 2026-05-14 |
+| [0008](0008-pin-the-fts5-trigram-wire-format-contract-with-rurico.md)           | Pin the FTS5 trigram wire-format contract with rurico                                       | accepted | 2026-06-24 |
+| [0009](0009-route-model-degraded-transitions-through-a-typed-contract.md)       | Route model-degraded transitions through a typed contract                                   | accepted | 2026-06-24 |
+| [0010](0010-gate-non-production-modules-behind-cargo-features.md)               | Gate non-production modules behind cargo features                                           | accepted | 2026-06-24 |
+| [0011](0011-prefer-hand-rolled-small-algorithms-over-new-dependencies.md)       | Prefer hand-rolled small algorithms over new dependencies                                   | accepted | 2026-06-24 |
 
 ## By Status
 
@@ -22,16 +26,20 @@ This directory contains important decisions about the project's architecture.
 - **0002**: Search Quality Evaluation Methodology
 - **0003**: Add pgr-style First-Search Offline Retrieval Benchmark
 - **0005**: Place Model Wiring (lazy load, cache, probe) in rurico, Keep amici as Thin Composition Base
+- **0006**: Pin PIPELINE_K=10 as part of baseline schema contract
+- **0007**: Pin BaselineSnapshot serde defaults to pre-existing behavior
+- **0008**: Pin the FTS5 trigram wire-format contract with rurico
+- **0009**: Route model-degraded transitions through a typed contract
+- **0010**: Gate non-production modules behind cargo features
+- **0011**: Prefer hand-rolled small algorithms over new dependencies
 
 ### Proposed
 
 - **0004**: Annotation Framework Foundation
-- **0006**: Pin PIPELINE_K=10 as part of baseline schema contract
-- **0007**: Pin BaselineSnapshot serde defaults to pre-existing behavior
 
 ## About MADR Format
 
-This project uses [MADR (Markdown Architecture Decision Records)](https://adr.github.io/madr/) format.
+This project uses [MADR (Markdown Any Decision Records)](https://adr.github.io/madr/) format, v4.
 
 ### How to Create an ADR
 
@@ -43,10 +51,11 @@ This project uses [MADR (Markdown Architecture Decision Records)](https://adr.gi
 
 - **Proposed**: Awaiting review
 - **Accepted**: Approved, implementing or completed
-- **Deprecated**: Better alternative found
-- **Superseded**: Replaced by another ADR
+- **Rejected**: Considered but not adopted
+- **Deprecated**: Retired without a replacement ADR
+- **Superseded**: Replaced by another ADR (e.g. `superseded by ADR-NNNN`)
 
 ---
 
-*Last updated: 2026-05-14*
-*Auto-generated by: update-index.sh*
+_Last updated: 2026-06-24_
+_Auto-generated by: update-index.py_

--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -1844,35 +1844,55 @@ fn compute_latency_percentiles(results: &[QueryResult]) -> (f64, f64) {
     (latencies[p50_idx] as f64, latencies[p95_idx] as f64)
 }
 
-/// Opaque capture-time label in `epoch:N` form (Unix seconds since UNIX_EPOCH).
+/// Format `secs` (Unix seconds since UNIX_EPOCH) as the `epoch:N` capture-time
+/// label.
 ///
-/// Avoids pulling `chrono` into the dependency tree just for a strict
-/// ISO-8601 timestamp; producer-doc and consumer schema both reflect the
-/// actual format.
+/// ADR-0011: avoids pulling `chrono` into the dependency tree just for a strict
+/// ISO-8601 timestamp; producer-doc and consumer schema both reflect the actual
+/// format.
+fn epoch_label(secs: u64) -> String {
+    format!("epoch:{secs}")
+}
+
+/// Current time as an [`epoch_label`]; thin `SystemTime::now()` wrapper.
 fn capture_timestamp_label() -> String {
     let secs = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
-    format!("epoch:{secs}")
+    epoch_label(secs)
+}
+
+// FNV-1a 64-bit offset basis and prime, per the FNV spec:
+// https://www.isthe.com/chongo/tech/comp/fnv/#FNV-param
+const FNV1A64_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV1A64_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+/// Fold `bytes` into a running FNV-1a 64-bit `hash`.
+///
+/// ADR-0011: hand-rolled to keep `sha2` out of the dependency graph — collision
+/// risk is acceptable for a fixture-changed signal, and the algorithm is a few
+/// lines. Accumulating so `hash_fixture_dir` can thread one hash across the
+/// three fixture files.
+fn fnv1a64_update(mut hash: u64, bytes: &[u8]) -> u64 {
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV1A64_PRIME);
+    }
+    hash
 }
 
 /// FNV-1a 64-bit hash over the three fixture JSONL files. Used as the
-/// `fixture_hash` field on [`BaselineSnapshot`]; sha2 is intentionally avoided
-/// to keep the dependency graph small (collision risk is acceptable for a
-/// fixture-changed signal). Returns a typed error rather than swallowing the
-/// `fs::read` failure so a missing fixture surfaces at capture time instead
-/// of silently producing a misleading hash.
+/// `fixture_hash` field on [`BaselineSnapshot`]. Returns a typed error rather
+/// than swallowing the `fs::read` failure so a missing fixture surfaces at
+/// capture time instead of silently producing a misleading hash.
 fn hash_fixture_dir(fixture_dir: &Path) -> Result<String, String> {
-    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    let mut hash = FNV1A64_OFFSET;
     for name in ["documents.jsonl", "queries.jsonl", "known_answers.jsonl"] {
         let path = fixture_dir.join(name);
         let content = fs::read(&path)
             .map_err(|e| format!("hash_fixture_dir: read {} failed: {e}", path.display()))?;
-        for byte in &content {
-            hash ^= u64::from(*byte);
-            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
-        }
+        hash = fnv1a64_update(hash, &content);
     }
     Ok(format!("fnv1a64:{hash:016x}"))
 }

--- a/src/bin/eval_harness/tests.rs
+++ b/src/bin/eval_harness/tests.rs
@@ -556,3 +556,33 @@ fn verify_baseline_rejects_kind_mismatch() {
         "FR-024/AC-7: kind mismatch (forward baseline + kind=replay) must EXIT_REGRESSION"
     );
 }
+
+#[test]
+fn fnv1a64_matches_known_answer_vectors() {
+    // ADR-0011: pin the hand-rolled FNV-1a 64 against canonical test vectors so
+    // a regression in the hand-roll is caught without depending on sha2.
+    assert_eq!(fnv1a64_update(FNV1A64_OFFSET, b""), 0xcbf2_9ce4_8422_2325);
+    assert_eq!(fnv1a64_update(FNV1A64_OFFSET, b"a"), 0xaf63_dc4c_8601_ec8c);
+    assert_eq!(
+        fnv1a64_update(FNV1A64_OFFSET, b"foobar"),
+        0x8594_4171_f739_67e8
+    );
+}
+
+#[test]
+fn fnv1a64_update_accumulates_across_chunks() {
+    // hash_fixture_dir threads one hash across successive file reads; chunked
+    // folding must equal hashing the concatenation (associativity).
+    let split = fnv1a64_update(fnv1a64_update(FNV1A64_OFFSET, b"foo"), b"bar");
+    let whole = fnv1a64_update(FNV1A64_OFFSET, b"foobar");
+    assert_eq!(split, whole);
+}
+
+#[test]
+fn epoch_label_formats_seconds_as_epoch_prefix() {
+    // ADR-0011: pin the `epoch:N` wire shape the consumer schema parses, so a
+    // drift away from the chrono-free format is caught without faking the clock.
+    assert_eq!(epoch_label(0), "epoch:0");
+    assert_eq!(epoch_label(42), "epoch:42");
+    assert_eq!(epoch_label(1_700_000_000), "epoch:1700000000");
+}

--- a/src/cli/shorthand.rs
+++ b/src/cli/shorthand.rs
@@ -40,6 +40,10 @@ pub fn try_expand_shorthand(
     }
 }
 
+/// Optimal String Alignment (restricted Damerau-Levenshtein) edit distance.
+///
+/// ADR-0011: hand-rolled to avoid a `strsim` dependency for a ~20-line DP;
+/// correctness is pinned by the unit tests in `shorthand/tests.rs`.
 fn osa_distance(a: &str, b: &str) -> usize {
     let a: Vec<char> = a.chars().collect();
     let b: Vec<char> = b.chars().collect();

--- a/src/cli/shorthand/tests.rs
+++ b/src/cli/shorthand/tests.rs
@@ -50,3 +50,17 @@ fn global_flag_hoisted_with_trailing_options() {
     let s: Vec<&str> = exp.iter().filter_map(|a| a.to_str()).collect();
     assert_eq!(s, ["sae", "--json", "search", "query", "--limit", "2"]);
 }
+
+#[test]
+fn osa_distance_measures_edits_including_transposition() {
+    // ADR-0011: pins the hand-rolled OSA distance correctness so a regression
+    // is caught without a strsim dependency.
+    assert_eq!(osa_distance("search", "search"), 0);
+    assert_eq!(osa_distance("serch", "search"), 1);
+    // Two transposition vectors so neither alone pins the OSA-specific arm
+    // (plain Levenshtein scores both as 2): removing the arm regresses both.
+    assert_eq!(osa_distance("seacrh", "search"), 1);
+    assert_eq!(osa_distance("ab", "ba"), 1);
+    assert_eq!(osa_distance("", "abc"), 3);
+    assert_eq!(osa_distance("kitten", "sitting"), 3);
+}

--- a/src/eval/baseline.rs
+++ b/src/eval/baseline.rs
@@ -208,7 +208,7 @@ pub struct BaselineSnapshot {
     /// symmetric provenance schema.
     pub captured_with: String,
     /// Capture-time label in `epoch:N` form (Unix seconds since UNIX_EPOCH).
-    /// Avoids pulling `chrono` in just for an ISO-8601 timestamp.
+    /// ADR-0011: avoids pulling `chrono` in just for an ISO-8601 timestamp.
     pub timestamp: String,
     /// Hugging Face repo id of the embed model used.
     pub model_id: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,18 @@
+//! amici crate root.
+//!
+//! ADR-0010: a module that must not leak into a downstream production build is
+//! gated behind a cargo feature. `cli` / `logging` / `migration` / `model` /
+//! `storage` are unconditional production API. The gated modules and their
+//! reasons:
+//!
+//! - `eval` → `eval-harness`: pulls MLX (Apple Silicon only); used by the
+//!   `eval_harness` binary, never by a downstream production CLI.
+//! - `testing` → `any(test, feature = "test-support")`: test helpers that must
+//!   stay out of a downstream production binary.
+//!
+//! When adding a `pub mod`, gate it when it is eval / test / Apple-Silicon
+//! only; leave it unconditional only when downstream production always needs it.
+
 pub mod cli;
 #[cfg(feature = "eval-harness")]
 pub mod eval;

--- a/src/model.rs
+++ b/src/model.rs
@@ -20,6 +20,12 @@ use crate::cli::{hint, warning};
 ///
 /// `Disabled` is reserved for caller-level opt-out (e.g. an environment variable);
 /// the loader functions never produce it.
+///
+/// ADR-0009: a typed error is converted into this enum only through
+/// [`degrade_with_warn`] (cause present) or [`record_degraded`] (no cause) —
+/// never a bare `.map_err(|_| DegradedReason::X)`, which erases the cause from
+/// the warn event. The source scan in `tests/adr_0009_degraded_routing_gate.rs`
+/// denies the bare pattern, making this the mechanical gate the ADR specifies.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DegradedReason {
     /// Caller explicitly disabled the model (e.g. via an environment variable or config flag).

--- a/src/storage/fts.rs
+++ b/src/storage/fts.rs
@@ -1,4 +1,12 @@
 //! FTS5 trigram tokenizer adapters for `rurico::storage::MatchFtsQuery` output.
+//!
+//! ADR-0008: the MATCH wire format parsed here is a cross-repo contract with
+//! rurico, the producer. `parse_fts_segments` depends on `"..."`-quoted fixed
+//! terms and the `" OR "` separator inside `( ... )` OR-groups emitted by
+//! `rurico::storage::prepare_match_query`. rurico's compiler and tests do not
+//! catch a serialization change, so a rev bump that drifts the format is caught
+//! only by the round-trip test in `fts/tests.rs`. Keep this parser in sync with
+//! the producer.
 
 use rurico::storage::MatchFtsQuery;
 
@@ -67,6 +75,13 @@ fn clean_impl(match_query: &str) -> Option<String> {
     )
 }
 
+/// Split a cleaned MATCH string into `(fixed_terms, or_groups)`.
+///
+/// ADR-0008: parses rurico's wire format directly. `"..."` quoting and the
+/// `" OR "` separator inside `( ... )` groups are the pinned contract; the
+/// top-level `" AND "` rurico emits between terms is ignored (any non-quote,
+/// non-paren run is skipped). A producer-side change to quoting or the OR
+/// separator silently breaks this recovery — see the module-doc.
 fn parse_fts_segments(cleaned: &str) -> (Vec<String>, Vec<Vec<String>>) {
     let mut fixed: Vec<String> = Vec::new();
     let mut or_groups: Vec<Vec<String>> = Vec::new();

--- a/src/storage/fts/tests.rs
+++ b/src/storage/fts/tests.rs
@@ -104,3 +104,54 @@ fn accepts_live_prepare_match_query_output() {
         Some("\"hello\" \"world\"")
     );
 }
+
+#[test]
+fn parse_fts_segments_recovers_rurico_or_group_wire_format() {
+    // ADR-0008 round-trip: rurico is the producer-of-truth for the MATCH wire
+    // format. A vocab-expanded short term ("au") makes rurico emit a
+    // `( "audit" OR "authentication" OR "authorization" )` OR-group joined by
+    // `" AND "` to the fixed `"login"`. amici's parse_fts_segments must recover
+    // that group and the fixed term. If rurico drifts the `" OR "` separator,
+    // the `( )` wrapping, or the `"..."` quoting, the recovered segments diverge
+    // and this test fails on the next rev bump.
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE VIRTUAL TABLE fts_chunks USING fts5(content);
+         INSERT INTO fts_chunks(content) VALUES ('authentication login session');
+         INSERT INTO fts_chunks(content) VALUES ('authorization permission role');
+         INSERT INTO fts_chunks(content) VALUES ('audit logging trace');
+         CREATE VIRTUAL TABLE fts_chunks_vocab USING fts5vocab(fts_chunks, row);",
+    )
+    .unwrap();
+
+    let matched = prepare_match_query(
+        &conn,
+        "au login",
+        "fts_chunks_vocab",
+        &QueryNormalizationConfig::default(),
+    )
+    .unwrap();
+
+    // Precondition: rurico actually emitted the OR-group wire format.
+    let wire = matched.as_str();
+    assert!(wire.contains(" OR "), "expected OR-group separator: {wire}");
+    assert!(wire.contains('('), "expected OR-group parens: {wire}");
+
+    let (fixed, or_groups) = parse_fts_segments(wire);
+
+    assert_eq!(fixed, vec!["\"login\"".to_owned()]);
+    assert_eq!(or_groups.len(), 1, "one expanded OR-group: {wire}");
+    // Term order within the group is unspecified — vocab expansion orders by
+    // `cnt DESC` then sqlite row order, so the consumer treats it as a set.
+    // Sort before comparing membership.
+    let mut group = or_groups[0].clone();
+    group.sort();
+    assert_eq!(
+        group,
+        vec![
+            "\"audit\"".to_owned(),
+            "\"authentication\"".to_owned(),
+            "\"authorization\"".to_owned(),
+        ]
+    );
+}

--- a/tests/adr_0009_degraded_routing_gate.rs
+++ b/tests/adr_0009_degraded_routing_gate.rs
@@ -1,0 +1,116 @@
+//! ADR-0009 mechanical gate: deny bare cause-erasing `map_err` into a degraded
+//! reason. A typed error must route through `degrade_with_warn` /
+//! `record_degraded` so the cause stays in the structured warn event. This
+//! source scan is the continuous check the ADR's Confirmation specifies, kept
+//! hermetic (no `git` dependency) so it runs in the normal test suite. It stands
+//! in for the aspirational dylint custom lint: adding dylint to enforce ADR-0009
+//! would itself violate ADR-0011 (dependency minimization).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.is_dir() {
+            collect_rs_files(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Return the 1-based line numbers of every cause-discarding `map_err(|_…|)`
+/// whose closure body reaches a degraded reason.
+///
+/// Matches the `map_err(|_` prefix so an underscore-named-but-unused binding
+/// (`map_err(|_err| DegradedReason::X)`) is caught alongside the plain
+/// `map_err(|_|` form — both discard the cause. A binding that actually threads
+/// the cause (`map_err(|e| …e…)`) has no leading underscore and is not flagged.
+///
+/// `//` comments are stripped first so the anti-pattern quoted verbatim in
+/// model.rs docs cannot trip the scan; the surviving code is rejoined into one
+/// string and scanned as a whole, so a multi-line `map_err(|_| {
+/// DegradedReason::X })` closure — the form a real regression takes — is caught
+/// where a line-by-line scan would miss it. A 160-char window spans the closure
+/// body; the sanctioned routes (`degrade_with_warn` / `record_degraded`) never
+/// pair a `map_err` closure with a `Degraded` reason, so no false positive arises.
+///
+/// Known limit: `//` inside a string literal is treated as a comment start, so a
+/// line mixing such a literal with a bare `map_err` could slip past. No source
+/// line does this today; avoid the combination rather than parse Rust here.
+fn scan_bare_map_err_into_degraded(content: &str) -> Vec<usize> {
+    const NEEDLE: &str = "map_err(|_";
+    let code = content
+        .lines()
+        .map(|line| match line.find("//") {
+            Some(i) => &line[..i],
+            None => line,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let mut hits = Vec::new();
+    for (start, _) in code.match_indices(NEEDLE) {
+        let window: String = code[start..].chars().take(160).collect();
+        if window.contains("Degraded") {
+            let line_no = code[..start].bytes().filter(|&b| b == b'\n').count() + 1;
+            hits.push(line_no);
+        }
+    }
+    hits
+}
+
+#[test]
+fn no_bare_cause_erasing_map_err_into_degraded() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    collect_rs_files(&src, &mut files);
+    assert!(!files.is_empty(), "no source files scanned under {src:?}");
+
+    let mut offenders = Vec::new();
+    for file in &files {
+        let content = fs::read_to_string(file).unwrap();
+        for line_no in scan_bare_map_err_into_degraded(&content) {
+            offenders.push(format!("{}:{}", file.display(), line_no));
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "bare cause-erasing map_err into a degraded reason (ADR-0009 forbids \
+         this; route through degrade_with_warn / record_degraded):\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn scan_flags_single_and_multi_line_closures_but_not_comments_or_other_errors() {
+    // Positive: single-line and multi-line closures both reach a degraded reason.
+    let single = "let e = x.map_err(|_| DegradedReason::ProbeFailed(None))?;";
+    assert_eq!(scan_bare_map_err_into_degraded(single), vec![1]);
+
+    let multi = "fn f() {\n    x.map_err(|_| {\n        DegradedReason::Disabled\n    })\n}";
+    assert_eq!(
+        scan_bare_map_err_into_degraded(multi),
+        vec![2],
+        "multi-line closure into a degraded reason must be flagged"
+    );
+
+    // Positive: an underscore-named-but-unused binding still discards the cause.
+    let named = "x.map_err(|_err| DegradedReason::ProbeFailed(None))?;";
+    assert_eq!(
+        scan_bare_map_err_into_degraded(named),
+        vec![1],
+        "named-but-ignored binding into a degraded reason must be flagged"
+    );
+
+    // Negative: a doc line quoting the pattern is stripped at `//`.
+    let doc = "/// never `.map_err(|_| DegradedReason::X)`, which erases the cause";
+    assert!(scan_bare_map_err_into_degraded(doc).is_empty());
+
+    // Negative: a bare closure into a non-degraded error is allowed (mirrors the
+    // real `map_err(|_| PipelineError::ChunkDimensionMismatch { .. })` sites).
+    let other = "x.map_err(|_| PipelineError::ChunkDimensionMismatch { expected: 0 })?;";
+    assert!(scan_bare_map_err_into_degraded(other).is_empty());
+}


### PR DESCRIPTION
## 概要

census/adrift workflow が生成した ADR-0008〜0011 を、コード側の参照マーカーと各決定を pin する test として codebase に接続する (#159)。amici 単独で完結する範囲のみ実装し、rurico 側マーカーと下流 CLI 整合は別 PR に defer。

## 変更内容

| ADR | マーカー / 検証 |
| --- | --- |
| 0008 FTS5 trigram wire-format | 実 `prepare_match_query` producer を通す round-trip test が、`parse_fts_segments` の消費する `"..."` + `" OR "` OR-group 形状を復元 |
| 0009 typed model-degraded routing | hermetic な source-scan gate (`tests/adr_0009_degraded_routing_gate.rs`) が cause を捨てる `map_err(|_…| Degraded…)` を拒否。negative-control unit test で multi-line / named-but-ignored closure に発火しコメント・非 degraded error は無視することを保証 |
| 0010 non-production feature gating | eval / testing module gate への参照コメント |
| 0011 hand-rolled small algorithms | `osa_distance` / `fnv1a64` / 抽出した純粋 `epoch_label` の known-value test で strsim / sha2 / chrono 回避を guard |

`docs/decisions/README.md`: working-tree の index が全 row を proposed / Not-set に regress させていたため、0001〜0007 の status / date を ADR header から復元し 0008〜0011 を追加。`docs/audit/...-adr-gaps.md` は ADR-0009 が引用する census provenance。

## Design Decisions

- ADR-0009 検証は dylint custom lint ではなく hermetic な grep gate を採用 (dylint を依存に加えること自体が ADR-0011 の依存最小化に反するため)
- `epoch_label` を純粋関数に抽出し、clock を fake せず format を test 可能にした

## 検証

- `cargo fmt --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` rc=0
- `cargo nextest run --all-features` 262 passed / 9 skipped

## Follow-up (別 PR / session に defer)

- [ ] rurico 側 cross-ref マーカー (producer 側 wire-format 契約の明示)
- [ ] 下流 CLI (sae / yomu / recall) の degraded-path 整合
- [ ] ADR-0009 の dylint custom lint 化 (依存判断を要するため保留、現状は grep gate で代替)

Refs #159

https://claude.ai/code/session_01WmemPmMviEasd7DSZeUka3