### PR TITLE
chore(deps): rurico を b78aae2 に更新し transitive crate も揃える

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "castaway"
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex 2.0.1",
@@ -1199,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "mach-sys"
@@ -1643,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1868,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=e2977ab#e2977ab41b78d20c5cd7dde56b339cedee35f2b3"
+source = "git+https://github.com/thkt/rurico?rev=b78aae2#b78aae2e0b56aed698f78526ce2d28d2b2caa496"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -1886,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=e2977ab#e2977ab41b78d20c5cd7dde56b339cedee35f2b3"
+source = "git+https://github.com/thkt/rurico?rev=b78aae2#b78aae2e0b56aed698f78526ce2d28d2b2caa496"
 dependencies = [
  "mlx-sys",
  "rusqlite",
@@ -1929,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "log",
  "once_cell",
@@ -2310,9 +2310,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2330,9 +2330,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["eval-harness"]
 bytemuck = "1"
 rand = "0.10"
 rand_chacha = "0.10"
-rurico = { git = "https://github.com/thkt/rurico", rev = "e2977ab" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "b78aae2" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -30,7 +30,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "e2977ab", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "b78aae2", features = ["test-support"] }
 temp-env = "0.3"
 tempfile = "3"
 


### PR DESCRIPTION
## 概要

rurico の rev を `e2977ab` → `b78aae2` に更新し、transitive crate も `cargo update` で揃える。

## rurico 差分 (#247-#251)

docs/ADR 追記・CI action 更新・transitive cargo update のみで API 変更なし。amici 側の consumer 修正は不要。

## crate 更新

| crate | from | to |
| --- | --- | --- |
| bytes | 1.11.1 | 1.12.0 |
| cc | 1.2.64 | 1.2.65 |
| log | 0.4.32 | 0.4.33 |
| quote | 1.0.45 | 1.0.46 |
| rustls | 0.23.40 | 0.23.41 |
| time | 0.3.49 | 0.3.51 |
| time-macros | 0.2.29 | 0.2.30 |

## 検証

`cargo nextest run --all-features`: 262 passed, 0 failed。pre-commit (fmt / clippy --all-targets --all-features -D warnings) green。

https://claude.ai/code/session_01MK35sPPN7YoGMFUYjZVFB9