### PR TITLE
test: 構造なぞりの機械的テストを精査・削減し ModelLoad の Debug 契約を固定 (#166)

### DIFF
--- a/src/cli/spinner/tests.rs
+++ b/src/cli/spinner/tests.rs
@@ -12,16 +12,6 @@ fn cancel_signals_done() {
     );
 }
 
-// T-031: set_message_updates_message
-#[test]
-fn set_message_updates_message() {
-    let spinner = Spinner::new("initial");
-    spinner.set_message("updated");
-    let msg = spinner.message.lock().unwrap().clone();
-    assert_eq!(msg, "updated");
-    spinner.cancel();
-}
-
 // T-032: finish_non_tty_does_not_panic
 #[test]
 fn finish_non_tty_does_not_panic() {

--- a/src/eval/annotation/tests.rs
+++ b/src/eval/annotation/tests.rs
@@ -5,13 +5,11 @@
 //! Spec's Skip rationale (FR-V002 Serialise wrapper) explicitly defers
 //! that case to the implicit serde path coverage from T-002.
 //!
-//! Sub-PR-B: T-002 (this file's `session_write_json_round_trips_through_tempdir`
-//! and `annotation_error_io_variant_is_reachable_via_from`) in
-//! `.claude/workspace/planning/2026-05-09-issue-53-annotate-subcommand/spec.md`.
+//! Sub-PR-B: T-002 (this file's `session_write_json_round_trips_through_tempdir`)
+//! in `.claude/workspace/planning/2026-05-09-issue-53-annotate-subcommand/spec.md`.
 
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
-use std::io;
 
 use tempfile::tempdir;
 
@@ -155,20 +153,5 @@ fn session_write_json_round_trips_through_tempdir() {
     assert_eq!(
         parsed, original,
         "round-trip via Session::write_json must preserve PartialEq equality"
-    );
-}
-
-// T-002 (sub-PR-B): annotation_error_io_variant_is_reachable_via_from
-// FR-003: AnnotationError gains an Io variant carrying std::io::Error
-//         with #[from] for `?`-propagation. Confirms the variant is
-//         reachable via From conversion.
-#[test]
-fn annotation_error_io_variant_is_reachable_via_from() {
-    let io_err = io::Error::other("stub io error");
-    let err: AnnotationError = io_err.into();
-    assert!(
-        matches!(err, AnnotationError::Io(_)),
-        "FR-003: AnnotationError::Io must be reachable via From<io::Error>; \
-         got: {err:?}"
     );
 }

--- a/src/model/tests.rs
+++ b/src/model/tests.rs
@@ -58,20 +58,22 @@ fn as_ref_returns_inner_only_for_ready() {
     assert_eq!(ModelLoad::<i32>::Failed("e".into()).as_ref(), None);
 }
 
-// T-020: debug_output_contains_variant_name
+// T-020: Debug is hand-written (no `T: Debug` bound), so `ModelLoad<T>` is
+// Debug for any `T` and `Ready` hides its inner value. Using a non-Debug `T`
+// throughout pins the unconditional impl: a `#[derive(Debug)]` would reintroduce
+// the `T: Debug` bound (this test would stop compiling) and print the inner
+// value (the `Ready(...)` assertion would fail). The previous assertion only
+// matched variant-name substrings, which a derive also satisfies, so it pinned
+// neither property.
 #[test]
-fn debug_output_contains_variant_name() {
-    let ready = format!("{:?}", ModelLoad::Ready(1));
-    assert!(ready.contains("Ready"), "expected 'Ready', got: {ready}");
-    let absent = format!("{:?}", ModelLoad::<i32>::Absent);
-    assert!(
-        absent.contains("Absent"),
-        "expected 'Absent', got: {absent}"
-    );
-    let failed = format!("{:?}", ModelLoad::<i32>::Failed("msg".into()));
-    assert!(
-        failed.contains("Failed"),
-        "expected 'Failed', got: {failed}"
+fn debug_is_unconditional_and_hides_ready_inner() {
+    struct NoDebug;
+
+    assert_eq!(format!("{:?}", ModelLoad::Ready(NoDebug)), "Ready(...)");
+    assert_eq!(format!("{:?}", ModelLoad::<NoDebug>::Absent), "Absent");
+    assert_eq!(
+        format!("{:?}", ModelLoad::<NoDebug>::Failed("msg".into())),
+        "Failed(\"msg\")"
     );
 }
 


### PR DESCRIPTION
## 背景

Closes #166。issue は「内部構造をなぞる / derive 挙動を確認するだけ」で refactor しても壊れない機械的 unit テスト5件を挙げ、壊れないものの削減を提案した。「削除前に1件ずつ確認する」という指示どおり、5件を **delete-test レンズ**(意味ある挙動変更でそのテストは壊れるか?)で個別に監査し、一括削除ではなくテストごとに判断した。

## 判定 (削除2 / 書換1 / 維持2)

| テスト | 対応 | 根拠 |
| --- | --- | --- |
| `set_message_updates_message` (spinner) | **削除** | `spinner.message.lock()` に直接到達する white-box テスト。`Mutex<String>` の round-trip(std 挙動)を検証するだけで、amici のロジックも表示契約も固定しない。 |
| `annotation_error_io_variant_is_reachable_via_from` | **削除** | thiserror `#[from]` は compile 時に解決され、`Io` / `Serialise` は源型が異なるため `io::Error::other(..).into()` は `Io` 以外に到達不能。`matches!` は型システムが既に保証する事柄を assert しているだけ。 |
| `debug_output_contains_variant_name` → `debug_is_unconditional_and_hides_ready_inner` | **書換** | 下記参照。 |
| `as_ref_returns_inner_only_for_ready` | **維持** | public アクセサの black-box 契約。下流 (yomu) が `as_ref()` を消費。手書き match で derive 不可。 |
| `in_placeholders_numbered` | **維持** | `?N` 採番 SQL 生成 + 空境界を固定。統合テストは `anon_placeholders` を通り本関数を**カバーしない**ため、sae/yomu が消費する `?N` 契約の唯一のガード。 |

## Debug の書換

`ModelLoad` の `impl<T> Debug` は **`T: Debug` 境界なしの手書き** = 意図的な public 契約で、任意の `T` で Debug 可能かつ `Ready` の内部値を隠蔽する。旧アサーションは variant 名の部分文字列を見るだけで、これは `#[derive(Debug)]` でも満たされる = どちらの性質も固定していなかった(delete-test レンズ上 worthless)。書換版は非 Debug な `T` を一貫して format する — derive 化すると compile 不能になり、かつ内部値を漏らすため、両性質が観測可能になった。

補足: adversarial check により初期の論拠を訂正した — derive 化単独では下流コンパイルは**壊れない**(`#[derive(Debug)]` は条件付き `impl<T: Debug>` を生み、現在どの下流も `ModelLoad<Box<dyn Rerank>>: Debug` を要求しない)。ここで固定するのは shared lib の**無条件** `impl<T> Debug` を public API として pin する契約であって、現行の下流ビルド依存ではない。

## 検証

- `cargo nextest run --all-features`: 260 passed, 0 failed
- `just check`: clippy `-D warnings` clean / fmt clean / doctests pass

https://claude.ai/code/session_017EnV51LhhpV3QxajjiELnu