### PR TITLE
chore(deps): rurico を 2b011b0 へ bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,7 +2346,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=dd423c6892784d72bb314064a403be350bdd0b59#dd423c6892784d72bb314064a403be350bdd0b59"
+source = "git+https://github.com/thkt/rurico?rev=2b011b0ae46d2af9bc5d31c840d7ab0fd8923c07#2b011b0ae46d2af9bc5d31c840d7ab0fd8923c07"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -2364,7 +2364,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=dd423c6892784d72bb314064a403be350bdd0b59#dd423c6892784d72bb314064a403be350bdd0b59"
+source = "git+https://github.com/thkt/rurico?rev=2b011b0ae46d2af9bc5d31c840d7ab0fd8923c07#2b011b0ae46d2af9bc5d31c840d7ab0fd8923c07"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["eval-harness"]
 bytemuck = "1"
 rand = "0.10"
 rand_chacha = "0.10"
-rurico = { git = "https://github.com/thkt/rurico", rev = "dd423c6892784d72bb314064a403be350bdd0b59" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "2b011b0ae46d2af9bc5d31c840d7ab0fd8923c07" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -30,7 +30,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "dd423c6892784d72bb314064a403be350bdd0b59", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "2b011b0ae46d2af9bc5d31c840d7ab0fd8923c07", features = ["test-support"] }
 temp-env = "0.3"
 tempfile = "3"
 


### PR DESCRIPTION
## 概要

PR #173 の merge に含まれ損ねた rurico rev bump (`dd423c6` → `2b011b0`)。上流差分は CI 設定のみ (trybuild pre-warm spike の追加と revert / visibility timeout fix) で API 変更なし。

## テスト

- `cargo nextest run --all-features`: 260 passed / 0 failed
- pre-commit (fmt / clippy --all-features): green

https://claude.ai/code/session_016xeoBZk9J7MEWRriohXxJd